### PR TITLE
Put newest commit on top in CHANGELOG.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ git-cliff [FLAGS] [OPTIONS] [RANGE]
 -t, --tag <TAG>            Sets the tag for the latest version [env: TAG=]
 -b, --body <TEMPLATE>      Sets the template for the changelog body [env: TEMPLATE=]
 -s, --strip <PART>         Strips the given parts from the changelog [possible values: header, footer, all]
+    --sort <sort>          Sets sorting of the commits inside sections [default: oldest] [possible values: oldest, newest]
 ```
 
 **Args:**
@@ -183,6 +184,17 @@ Generate a changelog scoped to a specific directory (useful for monorepos):
 
 ```sh
 git cliff --commit-path project1/
+```
+
+Sort the commits inside sections:
+
+```sh
+# The oldest commit will be on top.
+# (default)
+git cliff --sort oldest
+
+# The newest commit will be on top.
+git cliff --sort newest
 ```
 
 Save the changelog file to the specified file:

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -77,4 +77,20 @@ pub struct Opt {
 	/// Sets the commit range to process.
 	#[structopt(value_name = "RANGE")]
 	pub range:       Option<String>,
+
+	/// Sets sorting of the commits inside the sections
+	///
+	/// If sort is `oldest`, the oldest commit will be on top. {n}
+	/// - PR #1 {n}
+	/// - PR #2
+	///
+	/// If sort is `newest`, the newest commit will be on top. {n}
+	/// - PR #2 {n}
+	/// - PR #1 {n}
+	#[structopt(
+		long,
+		possible_values = &["oldest", "newest"],
+		default_value = "oldest"
+	)]
+	pub sort: String,
 }

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -78,15 +78,7 @@ pub struct Opt {
 	#[structopt(value_name = "RANGE")]
 	pub range:       Option<String>,
 
-	/// Sets sorting of the commits inside the sections
-	///
-	/// If sort is `oldest`, the oldest commit will be on top. {n}
-	/// - PR #1 {n}
-	/// - PR #2
-	///
-	/// If sort is `newest`, the newest commit will be on top. {n}
-	/// - PR #2 {n}
-	/// - PR #1 {n}
+	/// Sets sorting of the commits inside sections.
 	#[structopt(
 		long,
 		possible_values = &["oldest", "newest"],

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -145,7 +145,11 @@ pub fn run(mut args: Opt) -> Result<()> {
 	for git_commit in commits.into_iter().rev() {
 		let commit = Commit::from(&git_commit);
 		let commit_id = commit.id.to_string();
-		releases[release_index].commits.insert(0, commit);
+		if args.sort == "newest" {
+			releases[release_index].commits.insert(0, commit);
+		} else {
+			releases[release_index].commits.push(commit);
+		}
 		if let Some(tag) = tags.get(&commit_id) {
 			releases[release_index].version = Some(tag.to_string());
 			releases[release_index].commit_id = Some(commit_id);

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -145,7 +145,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 	for git_commit in commits.into_iter().rev() {
 		let commit = Commit::from(&git_commit);
 		let commit_id = commit.id.to_string();
-		releases[release_index].commits.push(commit);
+		releases[release_index].commits.insert(0, commit);
 		if let Some(tag) = tags.get(&commit_id) {
 			releases[release_index].version = Some(tag.to_string());
 			releases[release_index].commit_id = Some(commit_id);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the way `git-cliff` sorts commit messages on CHANGELOG.md.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Normally, I would expect the latest change on the top in CHANGELOG. However, currently, `git-cliff` puts the oldest commit on the top of the sections(#Features, Fixes and such). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this using both a mock repo and `git-cliff`'s own repo. 

## Screenshots / Output (if appropriate):
```
- Support parsing the missing scopes with `default_scope` (#8)
- Support generating a changelog scoped to a directory (#11)
 ```

With this update, it will look like this:

 ```
 - Support generating a changelog scoped to a directory (#11)
 - Support parsing the missing scopes with `default_scope` (#8)
 ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
