### PR TITLE
fix(project): use the correct branch for codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,6 @@ coverage:
         target: auto
         threshold: 5%
         branches:
-          - master
+          - main
         if_ci_failed: error
     patch: off


### PR DESCRIPTION
I updated this file because the default branch is `main`, not `master`.