### PR TITLE
docs(core): document timestamp format of `Release` struct

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -11,7 +11,7 @@ pub struct Release<'a> {
 	/// Commit ID of the tag.
 	#[serde(rename = "commit_id")]
 	pub commit_id: Option<String>,
-	/// Timestamp of the release.
+	/// Timestamp of the release in seconds, from epoch.
 	pub timestamp: i64,
 	/// Previous release.
 	pub previous:  Option<Box<Release<'a>>>,


### PR DESCRIPTION
I copied this from [here](https://github.com/rust-lang/git2-rs/blob/0443adb5388b2a529c042256e7716c36dc567220/src/time.rs#L32), which is the function `git-cliff` calls to populate that field.