### PR TITLE
fix(deps): make `completions` and `mangen` optional feature

### DIFF
--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -16,10 +16,12 @@ rust-version = "1.60.0"
 [[bin]]
 name = "git-cliff-completions"
 path = "src/bin/completions.rs"
+required-features = []
 
 [[bin]]
 name = "git-cliff-mangen"
 path = "src/bin/mangen.rs"
+required-features = []
 
 [features]
 # check for new versions


### PR DESCRIPTION
## Description
Makes git-cliff-completions and git-cliff-mangen optional feature
See #115

## Motivation and Context


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [X] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
