### PR TITLE
fix(config): set max of `limit_commits` to the number of commits

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -148,7 +148,9 @@ fn process_repository<'a>(
 		args.exclude_path.clone(),
 	)?;
 	if let Some(commit_limit_value) = config.git.limit_commits {
-		commits = commits.drain(..commit_limit_value).collect();
+		commits = commits
+			.drain(..commits.len().min(commit_limit_value))
+			.collect();
 	}
 
 	// Update tags.


### PR DESCRIPTION
## Description

Fixes a panic which occurs when the commit limit set in the config is greater than the number of commits.

## Motivation and Context

## How Has This Been Tested?

## Screenshots / Output (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
