### PR TITLE
feat: add ignore_commits regex

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -40,6 +40,7 @@ pub struct ChangelogConfig {
 
 /// Git configuration
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GitConfig {
 	/// Whether to enable parsing conventional commits.
 	pub conventional_commits:  Option<bool>,
@@ -62,6 +63,9 @@ pub struct GitConfig {
 	pub filter_commits:           Option<bool>,
 	/// Blob pattern for git tags.
 	pub tag_pattern:              Option<String>,
+	/// Regex to ignore commits.
+	#[serde(with = "serde_regex", default)]
+	pub ignore_commits:           Option<Regex>,
 	/// Regex to skip matched tags.
 	#[serde(with = "serde_regex", default)]
 	pub skip_tags:                Option<Regex>,

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -243,6 +243,10 @@ A regex for ignore processing the matched tags.
 
 While `skip_tags` drop commits from the changelog, `ignore_tags` include ignored commits into the next tag.
 
+### ignore_commits
+
+A regex for ignore processing the matched commits.
+
 ### topo_order
 
 If set to `true`, tags are processed in topological order instead of chronological.


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

Not sure about the naming `ignore_commits`, filter_commits is already taken. 

This also adds `#[serde(deny_unknown_fields)]` to protect users for typos.

## Motivation and Context

I'm using the tool with the other group. There are many irrelevant commits
```
    { message = ".*", group = "Other", default_scope = "other"},
```

## How Has This Been Tested?

tested locally

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
