### PR TITLE
fix(config)!: nested environment config overrides

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -144,7 +144,9 @@ impl Config {
 			config::Config::builder().add_source(config::File::from(path))
 		};
 		Ok(config_builder
-			.add_source(config::Environment::with_prefix("CLIFF").separator("_"))
+			.add_source(
+				config::Environment::with_prefix("CLIFF_GIT").separator("__"),
+			)
 			.build()?
 			.try_deserialize()?)
 	}
@@ -164,7 +166,7 @@ mod test {
 			.to_path_buf()
 			.join("config")
 			.join(crate::DEFAULT_CONFIG);
-		env::set_var("CLIFF_CHANGELOG_FOOTER", "test");
+		env::set_var("CLIFF_GIT__CHANGELOG__FOOTER", "test");
 		let config = Config::parse(&path)?;
 		assert_eq!(Some(String::from("test")), config.changelog.footer);
 		Ok(())

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -145,7 +145,7 @@ impl Config {
 		};
 		Ok(config_builder
 			.add_source(
-				config::Environment::with_prefix("CLIFF_GIT").separator("__"),
+				config::Environment::with_prefix("GIT_CLIFF").separator("__"),
 			)
 			.build()?
 			.try_deserialize()?)
@@ -171,9 +171,9 @@ mod test {
 		const TAG_PATTERN_VALUE: &str = "*[0-9]*";
 		const IGNORE_TAGS_VALUE: &str = "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+";
 
-		env::set_var("CLIFF_GIT__CHANGELOG__FOOTER", FOOTER_VALUE);
-		env::set_var("CLIFF_GIT__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
-		env::set_var("CLIFF_GIT__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
+		env::set_var("GIT_CLIFF__CHANGELOG__FOOTER", FOOTER_VALUE);
+		env::set_var("GIT_CLIFF__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
+		env::set_var("GIT_CLIFF__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
 
 		let config = Config::parse(&path)?;
 

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -166,9 +166,29 @@ mod test {
 			.to_path_buf()
 			.join("config")
 			.join(crate::DEFAULT_CONFIG);
-		env::set_var("CLIFF_GIT__CHANGELOG__FOOTER", "test");
+
+		const FOOTER_VALUE: &str = "test";
+		const TAG_PATTERN_VALUE: &str = "*[0-9]*";
+		const IGNORE_TAGS_VALUE: &str = "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+";
+
+		env::set_var("CLIFF_GIT__CHANGELOG__FOOTER", FOOTER_VALUE);
+		env::set_var("CLIFF_GIT__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
+		env::set_var("CLIFF_GIT__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
+
 		let config = Config::parse(&path)?;
-		assert_eq!(Some(String::from("test")), config.changelog.footer);
+
+		assert_eq!(Some(String::from(FOOTER_VALUE)), config.changelog.footer);
+		assert_eq!(
+			Some(String::from(TAG_PATTERN_VALUE)),
+			config.git.tag_pattern
+		);
+		assert_eq!(
+			Some(String::from(IGNORE_TAGS_VALUE)),
+			config
+				.git
+				.ignore_tags
+				.map(|ignore_tags| ignore_tags.to_string())
+		);
 		Ok(())
 	}
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -281,6 +281,11 @@ Examples:
 
 It's possible to use environment variables to override configuration elements. If an environment variable matches a configuration element the variable's value will be used instead of the element's.
 
+Format:
+```
+[PREFIX]__[CONFIG SECTION]__[FIELD NAME]
+```
+
 Examples:
 
 To override the `footer` element:
@@ -293,10 +298,4 @@ To override the `ignore_tags` element:
 
 ```bash
 export GIT_CLIFF__GIT__IGNORE_TAGS="v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
-```
-
-If it's not clear from the examples the format of the variable name is:
-
-```
-[PREFIX]__[CONFIG SECTION]__[FIELD NAME]
 ```

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -279,7 +279,7 @@ Examples:
 
 ### Environment Configuration Overrides
 
-It's possible to use environment variable to override configuration elements. If an environment variable matches a configuration element the variable's value will be used instead of the element's.
+It's possible to use environment variables to override configuration elements. If an environment variable matches a configuration element the variable's value will be used instead of the element's.
 
 Examples:
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -286,13 +286,13 @@ Examples:
 To override the `footer` element:
 
 ```bash
-export CLIFF_GIT__CHANGELOG__FOOTER="<!-- footer from env -->"
+export GIT_CLIFF__CHANGELOG__FOOTER="<!-- footer from env -->"
 ```
 
 To override the `ignore_tags` element:
 
 ```bash
-export CLIFF_GIT__GIT__IGNORE_TAGS="v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+export GIT_CLIFF__GIT__IGNORE_TAGS="v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 ```
 
 If it's not clear from the examples the format of the variable name is:

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -279,7 +279,7 @@ Examples:
 
 ### Environment Configuration Overrides
 
-It's possible to override configuration elements environment variables. If an environment variable matches a configuration element the variable's value will be used instead of the value from the config file.
+It's possible to use environment variable to override configuration elements. If an environment variable matches a configuration element the variable's value will be used instead of the element's.
 
 Examples:
 

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -276,3 +276,27 @@ Examples:
 `limit_commits` is a **optional** positive integer number that limits the number of included commits in the generated changelog.
 
 `limit_commits` is not part of the default configuration.
+
+### Environment Configuration Overrides
+
+It's possible to override configuration elements environment variables. If an environment variable matches a configuration element the variable's value will be used instead of the value from the config file.
+
+Examples:
+
+To override the `footer` element:
+
+```bash
+export CLIFF_GIT__CHANGELOG__FOOTER="<!-- footer from env -->"
+```
+
+To override the `ignore_tags` element:
+
+```bash
+export CLIFF_GIT__GIT__IGNORE_TAGS="v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+```
+
+If it's not clear from the examples the format of the variable name is:
+
+```
+[PREFIX]__[CONFIG SECTION]__[FIELD NAME]
+```


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description
Behavior related to overriding configuration for nested elements via environment variables changed in config-rs@v0.9. We need to use `__` instead of `_` separator to match nested fields. For details see https://github.com/mehcode/config-rs/issues/73. 

Also added some documentation that mentions it's possible to use environment variables to override configuration.

## How Has This Been Tested?

All tests are passing locally, I updated `config::test::parse_config` and added a couple more env override assertions. I also tested in a small sandbox project and observed the following:

history
```
commit 9d5ce9759e2fbedc48fbb23e22cdad74214c809a (HEAD -> main, tag: v1.0.3-rc1)
Author: Mack Solomon <macksol@gmail.com>
Date:   Tue Apr 18 22:14:30 2023 -0700

    feat(all): a feature

commit f5b5135793de7bacfdec9750ef9d535320aaa614 (tag: v1.0.2)
Author: Mack Solomon <macksol@gmail.com>
Date:   Tue Apr 18 22:13:35 2023 -0700

    fix(all): a fix
```

result (with fix)
```
➜  release-playground git:(main) ✗ export CLIFF_GIT__GIT__IGNORE_TAGS="v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"    
➜  release-playground git:(main) ✗ ~/dev/git-cliff/target/release/git-cliff --latest                  
# Changelog

All notable changes to this project will be documented in this file.

## [1.0.2] - 2023-04-19

### Bug Fixes

- A fix

<!-- generated by git-cliff -->
```

We can see that the first RC tag in history is being ignored as expected so the env override worked! 🎊 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
