### PR TITLE
chore(core): make git2 optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           command: check
           args: --locked --verbose
+      - name: Check without default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --locked --no-default-features --verbose
 
   test:
     name: Test suite

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["changelog", "generator", "conventional", "commit"]
 edition = "2021"
 rust-version = "1.64.0"
 
+[features]
+default = ["repo"]
+repo = ["dep:git2"]
+
 [dependencies]
 glob.workspace = true
 regex.workspace = true
@@ -26,6 +30,7 @@ lazy-regex = "2.5.0"
 [dependencies.git2]
 version = "0.17.1"
 default-features = false
+optional = true
 
 [dependencies.config]
 version = "0.13.3"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -12,10 +12,10 @@ rust-version = "1.64.0"
 
 [features]
 default = ["repo"]
-repo = ["dep:git2"]
+repo = ["dep:git2", "dep:glob", "dep:indexmap"]
 
 [dependencies]
-glob.workspace = true
+glob = { workspace = true, optional = true }
 regex.workspace = true
 log.workspace = true
 thiserror = "1.0.40"
@@ -23,7 +23,7 @@ serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 serde_regex = "1.1.0"
 tera = "1.18.1"
-indexmap = "1.9.3"
+indexmap = { version = "1.9.3", optional = true }
 toml = "0.7.3"
 lazy-regex = "2.5.0"
 

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -9,6 +9,7 @@ use crate::error::{
 	Error as AppError,
 	Result,
 };
+#[cfg(feature = "repo")]
 use git2::{
 	Commit as GitCommit,
 	Signature as CommitSignature,
@@ -84,6 +85,7 @@ pub struct Signature {
 	pub timestamp: i64,
 }
 
+#[cfg(feature = "repo")]
 impl<'a> From<CommitSignature<'a>> for Signature {
 	fn from(signature: CommitSignature<'a>) -> Self {
 		Self {
@@ -142,6 +144,7 @@ impl<'a> From<String> for Commit<'a> {
 	}
 }
 
+#[cfg(feature = "repo")]
 impl<'a> From<&GitCommit<'a>> for Commit<'a> {
 	fn from(commit: &GitCommit<'a>) -> Self {
 		Commit {

--- a/git-cliff-core/src/error.rs
+++ b/git-cliff-core/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
 	#[error("UTF-8 error: `{0}`")]
 	Utf8Error(#[from] std::str::Utf8Error),
 	/// Error variant that represents errors coming out of libgit2.
+	#[cfg(feature = "repo")]
 	#[error("Git error: `{0}`")]
 	GitError(#[from] git2::Error),
 	/// Error that may occur while parsing the config file.

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -1,6 +1,9 @@
 //! A highly customizable changelog generator
 //!
 //! ## Features
+//!
+//! The [cargo features](https://doc.rust-lang.org/cargo/reference/features.html)
+//! of the libraries are:
 //! - `repo`: Enable parsing commits from a git repository. Enabled by default.
 //!   You can turn this off if you already have the commits to put in the
 //!   changelog and you don't need `git-cliff` to parse them.

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -1,4 +1,9 @@
 //! A highly customizable changelog generator
+//!
+//! ## Features
+//! - `repo`: Enable parsing commits from a git repository. Enabled by default.
+//!   You can turn this off if you already have the commits to put in the
+//!   changelog and you don't need `git-cliff` to parse them.
 #![warn(missing_docs, clippy::unwrap_used)]
 
 /// Changelog generator.

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -3,7 +3,7 @@
 //! ## Features
 //!
 //! The [cargo features](https://doc.rust-lang.org/cargo/reference/features.html)
-//! of the libraries are:
+//! of the library are:
 //! - `repo`: Enable parsing commits from a git repository. Enabled by default.
 //!   You can turn this off if you already have the commits to put in the
 //!   changelog and you don't need `git-cliff` to parse them.

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod embed;
 pub mod error;
 /// Common release type.
 pub mod release;
+#[cfg(feature = "repo")]
 /// Git repository.
 pub mod repo;
 /// Template engine.


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

<!--- Describe your changes in detail -->
Make git2 optional in git-cliff-core crate.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In release-plz I use git-cliff-core.
However, I don't need git-cliff to read the git history, so I don't need it to include git2.
I depend on both cargo and git-cliff, and often they have conflicting git2 versions.
For example, right now I can't update to the latest git-cliff, because git2 of git-cliff isn't compatible with cargo.

However with this change, by using:
`git-cliff-core =  { path = "../git-cliff/git-cliff-core", default-features = false }`
in release-plz I'm able to update!

Some questions for you:
- are you ok with this additional complexity?
- do you want to find a better name for the feature?

Probably there are other dependencies that can be made optional, but for now git2 is the biggest pain-point for me.
If you are interested, I can find more dependencies.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

release-plz is compiling.
Maybe we can add a CI check to test that git-cliff-core compiles even without default features enabled.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## alternative

Extract the code that doesn't depend on git2 in a third crate.
In particular, in my use case I already have the commits I want to write in the changelog, so it would be great if there was a crate that is only focused on generating the changelog, not in determining the commits to write into it.
It would be great if it could expose a subset of the configuration. For example, in release-plz not all git-cliff configuration option will have effect.