### PR TITLE
test(changelog): add cases for `docs:` prefix

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -250,6 +250,14 @@ mod test {
 						skip:          None,
 					},
 					CommitParser {
+						message:       Regex::new("docs:").ok(),
+						body:          None,
+						group:         Some(String::from("Documentation")),
+						default_scope: None,
+						scope:         Some(String::from("documentation")),
+						skip:          None,
+					},
+					CommitParser {
 						message:       Regex::new(r#"match\((.*)\):.*"#).ok(),
 						body:          None,
 						group:         Some(String::from("Matched ($1)")),
@@ -303,6 +311,10 @@ mod test {
 				Commit::new(
 					String::from("qw3rty"),
 					String::from("doc: update docs"),
+				),
+				Commit::new(
+					String::from("0bc123"),
+					String::from("docs: add some documentation"),
 				),
 				Commit::new(
 					String::from("0jkl12"),
@@ -404,6 +416,7 @@ mod test {
 			### Documentation
 			#### documentation
 			- update docs
+			- add some documentation
 
 			### Matched (group)
 			#### group
@@ -513,6 +526,7 @@ chore(deps): fix broken deps
 			### Documentation
 			#### documentation
 			- update docs
+			- add some documentation
 
 			### Matched (group)
 			#### group


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

This PR adds test cases for the `docs:` prefix.

## Motivation and Context

The current test suite doesn't test the  `docs:` prefix which is the recommended value for documentation commits for conventional commits. This change adds the relevant test cases.

Closes https://github.com/orhun/git-cliff/issues/164

## How Has This Been Tested?

Test cases that were referring `doc:` were duplicated with `docs:` instead.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
