### PR TITLE
fix(examples): add missing newline

### DIFF
--- a/examples/scopesorted.toml
+++ b/examples/scopesorted.toml
@@ -25,6 +25,7 @@ body = """
         {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
         {%- endif -%}
     {%- endfor -%}
+    {% raw %}\n{% endraw %}\
     {%- for commit in commits %}
         {%- if commit.scope -%}
         {% else -%}


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

Add a missing newline to the [`Scoped (Sorted)`](https://git-cliff.org/docs/templating/examples#scoped-sorted) example.

## Motivation and Context

I use `git-cliff` for generating the changelog of [`bulloak`](https://github.com/alexfertel/bulloak). Before the change in this PR, I would get the following:

```markdown
- *(README)* Fix typo
- *(tests)* Remove ticks from identifiers- Support the ~/code/rust character in identifiers
- Support ticks in identifiers
```

You can see that when the block for commits that have no scope starts, there is a missing newline.

After the change in this PR, we get:

```markdown
- *(README)* Fix typo
- *(tests)* Remove ticks from identifiers
- Support the ~/code/rust character in identifiers
- Support ticks in identifiers
```

Which is what we expect.

## How Has This Been Tested?

Manually, but the change is quite trivial.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
