### PR TITLE
docs: update Tera links to the new URL

### DIFF
--- a/.github/fixtures/test-commit-footers/cliff.toml
+++ b/.github/fixtures/test-commit-footers/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-commit-preprocessors/cliff.toml
+++ b/.github/fixtures/test-commit-preprocessors/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-custom-scope/cliff.toml
+++ b/.github/fixtures/test-custom-scope/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-date-order/cliff.toml
+++ b/.github/fixtures/test-date-order/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-ignore-tags/cliff.toml
+++ b/.github/fixtures/test-ignore-tags/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-keep-a-changelog-links/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links/cliff.toml
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     {% if previous %}\
@@ -77,4 +77,3 @@ ignore_tags = ""
 topo_order = false
 # sort the commits inside sections by oldest/newest order
 sort_commits = "oldest"
-

--- a/.github/fixtures/test-latest-with-one-tag/cliff.toml
+++ b/.github/fixtures/test-latest-with-one-tag/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-limit-commits/cliff.toml
+++ b/.github/fixtures/test-limit-commits/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-skip-breaking-changes/cliff.toml
+++ b/.github/fixtures/test-skip-breaking-changes/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-split-commits/cliff.toml
+++ b/.github/fixtures/test-split-commits/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-topo-order-arg/cliff.toml
+++ b/.github/fixtures/test-topo-order-arg/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/.github/fixtures/test-topo-order/cliff.toml
+++ b/.github/fixtures/test-topo-order/cliff.toml
@@ -5,7 +5,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -12,7 +12,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     {% if previous.version %}\

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -12,7 +12,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/examples/cocogitto.toml
+++ b/examples/cocogitto.toml
@@ -8,7 +8,7 @@ header = """
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs
+# https://keats.github.io/tera/docs/#introduction
 body = """
 ---
 {% if version %}\

--- a/examples/detailed.toml
+++ b/examples/detailed.toml
@@ -8,7 +8,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/examples/keepachangelog.toml
+++ b/examples/keepachangelog.toml
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/examples/limitedcommits.toml
+++ b/examples/limitedcommits.toml
@@ -3,7 +3,7 @@
 
 [changelog]
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}\

--- a/examples/minimal.toml
+++ b/examples/minimal.toml
@@ -3,7 +3,7 @@
 
 [changelog]
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}\

--- a/examples/scoped.toml
+++ b/examples/scoped.toml
@@ -8,7 +8,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/examples/scopesorted.toml
+++ b/examples/scopesorted.toml
@@ -8,7 +8,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/examples/unconventional.toml
+++ b/examples/unconventional.toml
@@ -8,7 +8,7 @@ header = """
 All notable changes to this project will be documented in this file.\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}

--- a/website/docs/templating/syntax.md
+++ b/website/docs/templating/syntax.md
@@ -15,7 +15,7 @@ There are 3 kinds of delimiters and those cannot be changed:
 
 <!-- {% endraw %} -->
 
-See the [Tera Documentation](https://tera.netlify.app/docs/#templates) for more information about [control structures](https://tera.netlify.app/docs/#control-structures), [built-ins filters](https://tera.netlify.app/docs/#built-ins), etc.
+See the [Tera Documentation](https://keats.github.io/tera/docs/#templates) for more information about [control structures](https://keats.github.io/tera/docs/#control-structures), [built-ins filters](https://keats.github.io/tera/docs/#built-ins), etc.
 
 Custom built-in filters that **git-cliff** uses:
 


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

<!--- Describe your changes in detail -->

The Tera website changed from Netlify to GitHub Pages, with the old Netlify deployment gone. Therefore, all links to Tera should point to the new URL.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Clicked each link, especially the ones with anchors, and verified the anchors are still correct.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
