### PR TITLE
feat(ci): add 'typos' check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check typos
+        uses: crate-ci/typos@master
       - name: Check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check typos
-        uses: crate-ci/typos@master
       - name: Check
         uses: actions-rs/cargo@v1
         with:
@@ -31,6 +29,15 @@ jobs:
         with:
           command: check
           args: --locked --no-default-features --verbose
+
+  typos:
+    name: Typos
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check typos
+        uses: crate-ci/typos@master
 
   test:
     name: Test suite

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR app
 
 # Even if the repository as marked as safe, GitHub Actions and some other
 # environments insist on running the entrypoint as root inside the container
-# even when being run by a non priviledged user on their own files. Here we
+# even when being run by a non privileged user on their own files. Here we
 # check the ownership of the workdir (which may or may not be /app) and change
 # our effective user/group ID to match.
 RUN cat <<'EOF' > /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Learn how to use **git-cliff** from the [documentation](https://git-cliff.org/do
 
 ## Editor Support
 
-- [git-cliff.el](https://github.com/liuyinz/git-cliff.el) - Genarate, update and release changelog in Emacs
+- [git-cliff.el](https://github.com/liuyinz/git-cliff.el) - Generate, update and release changelog in Emacs
 
 ## Similar/Related Projects
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,5 @@
+[type.md]
+extend-ignore-re = [
+  "\\[[[:xdigit:]]{7}\\]\\(https://github.com/orhun/git-cliff/commit/[[:xdigit:]]{40}\\)",
+  "\\[halp\\]\\(https://github.com/orhun/halp\\)",
+]

--- a/website/docs/templating/context.md
+++ b/website/docs/templating/context.md
@@ -27,7 +27,7 @@ following context is generated to use for templating:
   "commits": [
     {
       "id": "e795460c9bb7275294d1fa53a9d73258fb51eb10",
-      "group": "<type> (overrided by commit_parsers)",
+      "group": "<type> (overridden by commit_parsers)",
       "scope": "[scope]",
       "message": "<description>",
       "body": "[body]",
@@ -124,8 +124,8 @@ If [`conventional_commits`](/docs/configuration#conventional_commits) is set to 
   "commits": [
     {
       "id": "e795460c9bb7275294d1fa53a9d73258fb51eb10",
-      "group": "(overrided by commit_parsers)",
-      "scope": "(overrided by commit_parsers)",
+      "group": "(overridden by commit_parsers)",
+      "scope": "(overridden by commit_parsers)",
       "message": "(full commit message including description, footers, etc.)",
       "conventional": false,
       "links": [


### PR DESCRIPTION
resolves #311

## Description

Will catch most of the typos in the documentation and markdown files automatically in CI (see #311 for details). Note that I chose to not create a new job and make it part of the `check` job (but I can go either way).

Also, I configured `typos` to ignore a bunch of 7-chars commit hash and one of your other project `halp` (which obviously is a typo of `help` :upside_down_face:).

## Motivation and Context

See #311.

## How Has This Been Tested?

CI will tell.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other - CI improvement

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Needs #316 to be merged first
