### PR TITLE
docs: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Learn how to use **git-cliff** from the [documentation](https://git-cliff.org/do
 
 ## Editor Support
 
-- [git-cliff.el](https://github.com/liuyinz/git-cliff.el) - Genarate, update and release changelog in Emacs
+- [git-cliff.el](https://github.com/liuyinz/git-cliff.el) - Generate, update and release changelog in Emacs
 
 ## Similar/Related Projects
 


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description
This pull request fixes typo `Genarate -> Generate` in README.md
<!--- Describe your changes in detail -->

