### PR TITLE
feat: add tera filter for ordered commit groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +628,7 @@ dependencies = [
  "git2",
  "glob",
  "indexmap 2.1.0",
+ "itertools",
  "lazy-regex",
  "log",
  "next_version",
@@ -890,6 +897,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
+ "serde",
 ]
 
 [[package]]
@@ -907,6 +915,15 @@ dependencies = [
  "hermit-abi",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1576,6 +1593,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -15,7 +15,7 @@ default = ["repo"]
 ## Enable parsing commits from a git repository.
 ## You can turn this off if you already have the commits to put in the
 ## changelog and you don't need `git-cliff` to parse them.
-repo = ["dep:git2", "dep:glob", "dep:indexmap"]
+repo = ["dep:git2", "dep:glob"]
 
 [dependencies]
 glob = { workspace = true, optional = true }
@@ -23,10 +23,11 @@ regex.workspace = true
 log.workspace = true
 thiserror = "1.0.50"
 serde = { version = "1.0.190", features = ["derive"] }
-serde_json = "1.0.108"
+serde_json = { version = "1.0.108", features = ["preserve_order"] }
 serde_regex = "1.1.0"
 tera = "1.19.1"
-indexmap = { version = "2.1.0", optional = true }
+indexmap = { version = "2.1.0", features = ["serde"] }
+itertools = "0.11"
 toml = "0.8.6"
 lazy-regex = "3.0.2"
 next_version = "0.2.9"


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

<!--- Describe your changes in detail -->

Add a Tera filter that produces commit groups, with order determined by `commit_parsers` config.

At least, that is the end goal, the PR does not yet achieve this. It's definitely a mess but  I'd like some feedback on the overall goal before progressing further.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using `group_by(attribute="group")` may not produce desired behavior if order of changelog section matters, eg. "Features" before  "Bug Fixes".

As far as I can tell, the most sensible place to source the ordering details is the `commit_parsers` config (it's what I initially tried to force sections to be ordered differently). It's not wired up like that yet, but hopefully this half of the task shows that it _can_ be done.

## How Has This Been Tested?

A new integration test has been added showing that ordering of sections is definable and not accidentally determined by the hash in a regular map.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
