### PR TITLE
fix: allow version bump with a single previous release

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -204,7 +204,7 @@ fn process_repository<'a>(
 		}
 	}
 
-	if release_index > 1 {
+	if release_index > 0 {
 		previous_release.previous = None;
 		releases[release_index].previous = Some(Box::new(previous_release));
 	}


### PR DESCRIPTION
<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description

<!--- Describe your changes in detail -->

If I try to run `git cliff --bump` on a repo that has a single tag, I'll get an error telling me "Previous version is not found for calculating the next release."

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The code checked that `release_index > 1`, that means it would work with 2 existing releases.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The change is trivial, I've tested that `git cliff --bump` now works also on a repo with a single tag.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
