### PR TITLE
feat(commit): add merge_commit flag to the context

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -120,6 +120,8 @@ pub struct Commit<'a> {
 	pub author:        Signature,
 	/// Committer.
 	pub committer:     Signature,
+	/// Whether if the commit has two or more parents.
+	pub merge_commit:  bool,
 }
 
 impl<'a> From<String> for Commit<'a> {
@@ -152,6 +154,7 @@ impl<'a> From<&GitCommit<'a>> for Commit<'a> {
 			message: commit.message().unwrap_or_default().to_string(),
 			author: commit.author().into(),
 			committer: commit.committer().into(),
+			merge_commit: commit.parent_count() > 1,
 			..Default::default()
 		}
 	}
@@ -414,6 +417,7 @@ impl Serialize for Commit<'_> {
 		commit.serialize_field("author", &self.author)?;
 		commit.serialize_field("committer", &self.committer)?;
 		commit.serialize_field("conventional", &self.conv.is_some())?;
+		commit.serialize_field("merge_commit", &self.merge_commit)?;
 		commit.end()
 	}
 }

--- a/website/docs/templating/context.md
+++ b/website/docs/templating/context.md
@@ -43,6 +43,7 @@ following context is generated to use for templating:
       "breaking_description": "<description>",
       "breaking": false,
       "conventional": true,
+      "merge_commit": false,
       "links": [
         { "text": "(set by link_parsers)", "href": "(set by link_parsers)" }
       ],
@@ -129,6 +130,7 @@ If [`conventional_commits`](/docs/configuration#conventional_commits) is set to 
       "scope": "(overridden by commit_parsers)",
       "message": "(full commit message including description, footers, etc.)",
       "conventional": false,
+      "merge_commit": false,
       "links": [
         { "text": "(set by link_parsers)", "href": "(set by link_parsers)" }
       ],


### PR DESCRIPTION
## Description

This PR adds `merge_commit` flag to the context as follows:

```json
  {
    "id": "ac01f822dd982513433f21b7611c6ef03cc978b0",
    "message": "Merge branch 'other'",
    "body": null,
    "footers": [],
    "group": "<!-- 7 -->⚙️ Miscellaneous Tasks",
    "breaking_description": null,
    "breaking": false,
    "scope": null,
    "links": [],
    "author": {
      "name": "Orhun Parmaksız",
      "email": "orhunparmaksiz@gmail.com",
      "timestamp": 1702757837
    },
    "committer": {
      "name": "Orhun Parmaksız",
      "email": "orhunparmaksiz@gmail.com",
      "timestamp": 1702760672
    },
    "conventional": true,
    "merge_commit": true // <--
  },
```

This can be used to filter out merge commits as follows:

```jinja2
{% for group, commits in commits |
  filter(attribute="merge_commit", value=false) |
  group_by(attribute="group") %}
    ### {{ group | upper_first }}
    {% for commit in commits %}
        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
    {% endfor %}
{% endfor %}\n
```

P.S. I decided to use `merge_commit` instead of `is_merge_commit` to keep it consistent with the other fields.

## Motivation and Context

See #85 #321 #143

## How Has This Been Tested?

Tested locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
