### PR TITLE
fix(commit): trim the trailing newline from message

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -39,7 +39,7 @@ impl<'a> Release<'a> {
 			.next(
 				self.commits
 					.iter()
-					.map(|commit| commit.message.to_string())
+					.map(|commit| commit.message.trim_end().to_string())
 					.collect::<Vec<String>>(),
 			)
 			.to_string();
@@ -70,6 +70,7 @@ mod test {
 			("1.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
 			("1.0.1", vec!["fix: add xyz", "fix: aaaaaa"]),
 			("2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+			("2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
 		] {
 			let release = Release {
 				version:   None,


### PR DESCRIPTION
When the commit message ends with a '\n', then it is not considered a valid conventional commit. That's why the message must be cleaned up.

<!--- Thank you for contributing to git-cliff! ⛰️  -->

## Description and Motivation and Context
Wrong next version when using the bumped-version parameter. The 'git commit' command creates a '\n' at the end of the line.
In this case, commit is considered as a patch. 
[https://github.com/MarcoIeni/release-plz/blob/4b0684ff8d9048032167a43fd70b70af4940239d/crates/next_version/src/next_version.rs#L27](https://github.com/MarcoIeni/release-plz/blob/4b0684ff8d9048032167a43fd70b70af4940239d/crates/next_version/src/next_version.rs#L27)
```
    /// - If some commits are present, but none of them match conventional commits specification,
    ///   the version is incremented as a Patch.
```

## How Has This Been Tested?

git cli command on linux/macos

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
