### PR TITLE
refactor(changelog): support `--bump` for processed releases

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -65,14 +65,6 @@ fn check_new_version() {
 	}
 }
 
-/// Output of the `process_repository` call.
-enum ProcessOutput<'a> {
-	/// List of releases.
-	Releases(Vec<Release<'a>>),
-	/// Semantic version.
-	Version(String),
-}
-
 /// Processes the tags and commits for creating release entries for the
 /// changelog.
 ///
@@ -82,7 +74,7 @@ fn process_repository<'a>(
 	repository: &'static Repository,
 	config: Config,
 	args: &Opt,
-) -> Result<ProcessOutput<'a>> {
+) -> Result<Vec<Release<'a>>> {
 	let mut tags = repository.tags(&config.git.tag_pattern, args.topo_order)?;
 	let skip_regex = config.git.skip_tags.as_ref();
 	let ignore_regex = config.git.ignore_tags.as_ref();
@@ -269,24 +261,7 @@ fn process_repository<'a>(
 		}
 	}
 
-	// Bump the version.
-	if (args.bump || args.bumped_version) &&
-		releases[release_index].version.is_none()
-	{
-		let next_version = releases[release_index].calculate_next_version()?;
-		if args.bumped_version {
-			return Ok(ProcessOutput::Version(next_version));
-		}
-
-		debug!("Bumping the version to {next_version}");
-		releases[release_index].version = Some(next_version.to_string());
-		releases[release_index].timestamp = SystemTime::now()
-			.duration_since(UNIX_EPOCH)?
-			.as_secs()
-			.try_into()?;
-	}
-
-	Ok(ProcessOutput::Releases(releases))
+	Ok(releases)
 }
 
 /// Runs `git-cliff`.
@@ -401,34 +376,32 @@ pub fn run(mut args: Opt) -> Result<()> {
 	// Process the repository.
 	let repositories = args.repository.clone().unwrap_or(vec![env::current_dir()?]);
 	let mut releases = Vec::<Release>::new();
-	let mut versions = Vec::<String>::new();
 	for repository in repositories {
 		let repository = Repository::init(repository)?;
-		let process_output = process_repository(
+		releases.extend(process_repository(
 			Box::leak(Box::new(repository)),
 			config.clone(),
 			&args,
-		)?;
+		)?);
+	}
 
-		match process_output {
-			ProcessOutput::Releases(release) => releases.extend(release),
-			ProcessOutput::Version(version) => versions.push(version),
+	// Process commits and releases for the changelog.
+	let mut changelog = Changelog::new(releases, &config)?;
+
+	// Print the result.
+	if args.bump || args.bumped_version {
+		if let Some(next_version) = changelog.bump_version()? {
+			if args.bumped_version {
+				if let Some(path) = args.output {
+					let mut output = File::create(path)?;
+					output.write_all(next_version.as_bytes())?;
+				} else {
+					println!("{next_version}");
+				}
+				return Ok(());
+			}
 		}
 	}
-
-	// Generate output.
-	if !versions.is_empty() {
-		let buf = versions.join("\n");
-		if let Some(path) = args.output {
-			let mut output = File::create(path)?;
-			output.write_all(buf.as_bytes())?;
-		} else {
-			println!("{buf}");
-		};
-		return Ok(());
-	}
-
-	let changelog = Changelog::new(releases, &config)?;
 	if args.context {
 		return if let Some(path) = args.output {
 			let mut output = File::create(path)?;


### PR DESCRIPTION
## Description

This is a behavior change to improve the `--bump` functionality.

`--bump` flag now takes the processed commits into account which means e.g. if you have used `commit_preprocessors` to modify the commit message, the bumped version will be calculated based on these modified commit messages.

There is also another behavioral change in the `--bumped-version`. For multiple repositories, it used to return the each calculated version separated by newline. However, this functionality is not documented anywhere and I'm not sure if it is really useful. This feature is not released yet which means it was safe to remove. I might consider adding it again if there will be desire in the future.

## Motivation and Context

See #405

## How Has This Been Tested?

Unit tests.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
