### PR TITLE
fix(git): sort commits in topological order

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -49,7 +49,7 @@ impl Repository {
 		exclude_path: Option<Vec<Pattern>>,
 	) -> Result<Vec<Commit>> {
 		let mut revwalk = self.inner.revwalk()?;
-		revwalk.set_sorting(Sort::TIME | Sort::TOPOLOGICAL)?;
+		revwalk.set_sorting(Sort::TOPOLOGICAL)?;
 		if let Some(range) = range {
 			revwalk.push_range(&range)?;
 		} else {


### PR DESCRIPTION
closes #188
closes #38

## Description

Commit a1b4b5b ("fix(git): sort the commits in topological order"), changed the order from `TIME` to `TIME | TOPOLOGICAL`. According to the docs, this is equivalent to `git log --date-sort`:

* https://github.com/libgit2/libgit2/blob/v1.7.1/include/git2/revwalk.h#L33-L38

This breaks down in the following scenario:

1. A PR is open.
2. A release v1 is made.
3. A PR is merged.
4. A relase v2 is made.

The git history for this would be:

```
- v2 release
- pr merge commit
- v1 release
- actual pr commit
```

This directly spills into the changelog produced by `git-cliff`, misattributing commits that were merged in v2 to v1 retroactively when v2 is made.

You can see this with `git log`. If you pass `--topo-order` there:

```
- v2 relase
- pr merge commit
- actual pr commit
- v1 relase
```

With this change we only pass `Sort::TOPOLOGICAL` in `git-cliff`, which produces the very same results as `git log --topo-order`.


## How Has This Been Tested?

Tested on a repo with the scenario described above.

## Screenshots / Logs (if applicable)

Here's the `git log` output that is causing commit `ZTC-886` to be misattributed to v2.0.6 when it was only merged after the release happened.

```
commit d3fcb284e764a90d3bfecbaac60c51ba93d3e44e (HEAD, tag: v2.0.7)
Date:   Mon Oct 9 15:27:35 2023 +0100

    Release 2.0.7

commit 508ac156deeef509938128b5bce62ab5b956f565
Merge: a778700 adf03ec
Date:   Tue Oct 3 15:43:16 2023 +0000

    Pull request #89: ZTC-1201

    Merge to main

    * commit 'adf03ec4246bf94e8fd534986f314dda6a9a996c':
      ZTC-1201

commit adf03ec4246bf94e8fd534986f314dda6a9a996c
Date:   Mon Oct 2 14:06:47 2023 +0100

    ZTC-1201

commit a778700021276d2c6f59756687011629b88f7e36
Merge: a1ef654 989e7cf
Date:   Mon Oct 2 12:22:38 2023 +0000

    Pull request #86: ZTC-886

    Merge to main

    * commit '989e7cfe4ec199f56a5b05f6b5d66d6acd6c761b':
      ZTC-886

commit a1ef654fd337d12464394152b5d86467680e28ae (tag: v2.0.6, origin/release/2.0.6, release/2.0.6)
Date:   Fri Sep 29 17:51:49 2023 +0100

    Release 2.0.6

commit f2046939b0b0e178f9f2c0c170a14368d53e2e15 (origin/jpaiva/OXY-1224)
Date:   Fri Sep 29 16:58:29 2023 +0100

    OXY-1224

commit 989e7cfe4ec199f56a5b05f6b5d66d6acd6c761b
Date:   Fri Sep 29 15:54:54 2023 +0100

    ZTC-886
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
