### PR TITLE
feat(template): support using PR title in the GitHub template

### DIFF
--- a/examples/github-keepachangelog.toml
+++ b/examples/github-keepachangelog.toml
@@ -64,7 +64,11 @@ conventional_commits = true
 filter_unconventional = true
 # process each line of a commit as an individual commit
 split_commits = false
-commit_preprocessors = [{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" }]
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+    # remove issue numbers from commits
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
 # regex for parsing and grouping commits
 commit_parsers = [
     { message = "^.*: add", group = "Added" },

--- a/examples/github.toml
+++ b/examples/github.toml
@@ -14,7 +14,12 @@ body = """
 
 {%- if version %} in {{ version }}{%- endif -%}
 {% for commit in commits %}
-  * {{ commit.message | split(pat="\n") | first | trim }}\
+  {% if commit.github.pr_title -%}
+    {%- set commit_message = commit.github.pr_title -%}
+  {%- else -%}
+    {%- set commit_message = commit.message -%}
+  {%- endif -%}
+  * {{ commit_message | split(pat="\n") | first | trim }}\
     {% if commit.github.username %} by @{{ commit.github.username }}{%- endif -%}
     {% if commit.github.pr_number %} in #{{ commit.github.pr_number }}{%- endif %}
 {%- endfor -%}
@@ -52,7 +57,10 @@ filter_unconventional = true
 # process each line of a commit as an individual commit
 split_commits = false
 # regex for preprocessing the commit messages
-commit_preprocessors = [{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" }]
+commit_preprocessors = [
+  # remove issue numbers from commits
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false
 # filter out the commits that are not matched by commit parsers

--- a/git-cliff-core/src/github.rs
+++ b/git-cliff-core/src/github.rs
@@ -98,6 +98,8 @@ pub struct GitHubCommitAuthor {
 pub struct GitHubPullRequest {
 	/// Pull request number.
 	pub number:           i64,
+	/// Pull request title.
+	pub title:            Option<String>,
 	/// SHA of the merge commit.
 	pub merge_commit_sha: Option<String>,
 }
@@ -128,6 +130,8 @@ pub struct GitHubReleaseMetadata {
 pub struct GitHubContributor {
 	/// Username.
 	pub username:      Option<String>,
+	/// Title of the pull request.
+	pub pr_title:      Option<String>,
 	/// The pull request that the user created.
 	pub pr_number:     Option<i64>,
 	/// Whether if the user contributed for the first time.

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -56,13 +56,16 @@ impl<'a> Release<'a> {
 			if let Some(commit) =
 				self.commits.iter_mut().find(|commit| commit.id == v.sha)
 			{
-				commit.github.username = v.author.clone().and_then(|v| v.login);
-				commit.github.pr_number = github_pull_requests
+				let pull_request = github_pull_requests
 					.iter()
-					.find(|pr| pr.merge_commit_sha == Some(v.sha.clone()))
-					.map(|v| v.number);
+					.find(|pr| pr.merge_commit_sha == Some(v.sha.clone()));
+
+				commit.github.username = v.author.clone().and_then(|v| v.login);
+				commit.github.pr_number = pull_request.map(|v| v.number);
+				commit.github.pr_title = pull_request.and_then(|v| v.title.clone());
 				contributors.insert(GitHubContributor {
 					username:      v.author.clone().and_then(|v| v.login),
+					pr_title:      commit.github.pr_title.clone(),
 					pr_number:     commit.github.pr_number,
 					is_first_time: false,
 				});

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -317,30 +317,35 @@ mod test {
 			],
 			vec![
 				GitHubPullRequest {
+					title:            Some(String::from("1")),
 					number:           42,
 					merge_commit_sha: Some(String::from(
 						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
 					)),
 				},
 				GitHubPullRequest {
+					title:            Some(String::from("2")),
 					number:           66,
 					merge_commit_sha: Some(String::from(
 						"21f6aa587fcb772de13f2fde0e92697c51f84162",
 					)),
 				},
 				GitHubPullRequest {
+					title:            Some(String::from("3")),
 					number:           53,
 					merge_commit_sha: Some(String::from(
 						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
 					)),
 				},
 				GitHubPullRequest {
+					title:            Some(String::from("4")),
 					number:           1000,
 					merge_commit_sha: Some(String::from(
 						"4d3ffe4753b923f4d7807c490e650e6624a12074",
 					)),
 				},
 				GitHubPullRequest {
+					title:            Some(String::from("5")),
 					number:           999999,
 					merge_commit_sha: Some(String::from(
 						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
@@ -356,6 +361,7 @@ mod test {
 					message: String::from("add github integration"),
 					github: GitHubContributor {
 						username:      Some(String::from("orhun")),
+						pr_title:      Some(String::from("1")),
 						pr_number:     Some(42),
 						is_first_time: false,
 					},
@@ -366,6 +372,7 @@ mod test {
 					message: String::from("fix github integration"),
 					github: GitHubContributor {
 						username:      Some(String::from("orhun")),
+						pr_title:      Some(String::from("2")),
 						pr_number:     Some(66),
 						is_first_time: false,
 					},
@@ -376,6 +383,7 @@ mod test {
 					message: String::from("update metadata"),
 					github: GitHubContributor {
 						username:      Some(String::from("nuhro")),
+						pr_title:      Some(String::from("3")),
 						pr_number:     Some(53),
 						is_first_time: false,
 					},
@@ -386,6 +394,7 @@ mod test {
 					message: String::from("do some stuff"),
 					github: GitHubContributor {
 						username:      Some(String::from("awesome_contributor")),
+						pr_title:      Some(String::from("4")),
 						pr_number:     Some(1000),
 						is_first_time: false,
 					},
@@ -396,6 +405,7 @@ mod test {
 					message: String::from("alright"),
 					github: GitHubContributor {
 						username:      Some(String::from("orhun")),
+						pr_title:      Some(String::from("5")),
 						pr_number:     Some(999999),
 						is_first_time: false,
 					},
@@ -406,6 +416,7 @@ mod test {
 					message: String::from("should be fine"),
 					github: GitHubContributor {
 						username:      Some(String::from("someone")),
+						pr_title:      Some(String::from("6")),
 						pr_number:     None,
 						is_first_time: false,
 					},
@@ -425,21 +436,25 @@ mod test {
 				contributors: vec![
 					GitHubContributor {
 						username:      Some(String::from("someone")),
+						pr_title:      Some(String::from("6")),
 						pr_number:     None,
 						is_first_time: true,
 					},
 					GitHubContributor {
 						username:      Some(String::from("orhun")),
+						pr_title:      Some(String::from("5")),
 						pr_number:     Some(42),
 						is_first_time: true,
 					},
 					GitHubContributor {
 						username:      Some(String::from("nuhro")),
+						pr_title:      Some(String::from("3")),
 						pr_number:     Some(53),
 						is_first_time: true,
 					},
 					GitHubContributor {
 						username:      Some(String::from("awesome_contributor")),
+						pr_title:      Some(String::from("4")),
 						pr_number:     Some(1000),
 						is_first_time: true,
 					},

--- a/website/docs/integration/github.md
+++ b/website/docs/integration/github.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 1
 ---
-
 # GitHub 🆕
 
 :::warning
@@ -104,6 +103,7 @@ For each commit, GitHub related values are added as a nested object (named `gith
 
   "github": {
     "username": "orhun",
+    "pr_title": "some things have changed",
     "pr_number": 420,
     "is_first_time": false
   }
@@ -142,11 +142,13 @@ For each release, following contributors data is added to the [template context]
     "contributors": [
       {
         "username": "orhun",
+        "pr_title": "some things have changed",
         "pr_number": 420,
         "is_first_time": true
       },
       {
         "username": "cliffjumper",
+        "pr_title": "I love jumping",
         "pr_number": 999,
         "is_first_time": true
       }


### PR DESCRIPTION
## Description

This PR makes it possible to use the pull request title with the [GitHub integration](https://git-cliff.org/docs/integration/github):

```jinja2
* {{ commit.github.pr_title }}
```

The final context is the following:

```json
"github": {
    "username": "orhun",
    "pr_title": "some things have changed",
    "pr_number": 420,
    "is_first_time": false
}
```

## Motivation and Context

#148

## How Has This Been Tested?

Locally / Fixture tests

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
