### PR TITLE
feat(github): make less GitHub API calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,9 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -725,6 +727,7 @@ dependencies = [
 name = "git-cliff-core"
 version = "1.4.0"
 dependencies = [
+ "chrono",
  "config",
  "dirs",
  "document-features",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -25,6 +25,7 @@ github = [
   "dep:reqwest-middleware",
   "dep:tokio",
   "dep:futures",
+  "dep:chrono",
 ]
 
 [dependencies]
@@ -56,6 +57,7 @@ tokio = { version = "1.35.1", features = [
 ], optional = true }
 futures = { version = "0.3.30", optional = true }
 url = "2.5.0"
+chrono = { version = "0.4.31", optional = true }
 
 [dependencies.git2]
 version = "0.18.1"

--- a/git-cliff-core/src/error.rs
+++ b/git-cliff-core/src/error.rs
@@ -88,7 +88,12 @@ pub enum Error {
 	HttpHeaderError(#[from] reqwest::header::InvalidHeaderValue),
 	/// Error that may occur during handling pages.
 	#[error("Pagination error: `{0}`")]
+	#[cfg(feature = "github")]
 	PaginationError(String),
+	/// Error that may occur during chrono calls.
+	#[error("Chrono error: `{0}`")]
+	#[cfg(feature = "github")]
+	ChronoError(String),
 	/// The errors that may occur while parsing URLs.
 	#[error("URL parse error: `{0}`")]
 	UrlParseError(#[from] url::ParseError),


### PR DESCRIPTION
## Description

This PR aims to improve the GitHub integration by sending less requests to the REST API. For that, I used the additional date parameters `since` and `until` to scope the request to a specific time frame.

However, this means that you won't be able to use the `is_first_time` field on the contributor since it requires the _whole_ history to find out if the user has contributed before.

## Motivation and Context

See #422

## How Has This Been Tested?

Not tested yet.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
