### PR TITLE
chore(website): fix URLs in navigation bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -87,11 +87,11 @@ const config = {
           { to: "/blog", label: "Blog", position: "left" },
           {
             label: "💖 Sponsor",
-            href: "https://github.com/sponsors/MarcoIeni",
+            href: "https://github.com/sponsors/orhun",
             position: "right",
           },
           {
-            href: "https://github.com/MarcoIeni/release-plz",
+            href: "https://github.com/orhun/git-cliff",
             "aria-label": "GitHub",
             className: "header-github-link",
             position: "right",


### PR DESCRIPTION
## Description

Commit 1da7cac7ce5df4de0a49ddbb9a52621ffa849124 added Sponsor and GitHub links to the navigation bar. However, the links are not for this project.

This PR fixes these two links.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
