### PR TITLE
feat(template): support using PR labels in the GitHub template

### DIFF
--- a/git-cliff-core/src/github.rs
+++ b/git-cliff-core/src/github.rs
@@ -93,6 +93,14 @@ pub struct GitHubCommitAuthor {
 	pub login: Option<String>,
 }
 
+/// Label of the pull request.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestLabel {
+	/// Name of the label.
+	pub name: String,
+}
+
 /// Representation of a single pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubPullRequest {
@@ -102,6 +110,8 @@ pub struct GitHubPullRequest {
 	pub title:            Option<String>,
 	/// SHA of the merge commit.
 	pub merge_commit_sha: Option<String>,
+	/// Labels of the pull request.
+	pub labels:           Vec<PullRequestLabel>,
 }
 
 impl GitHubEntry for GitHubPullRequest {
@@ -126,7 +136,7 @@ pub struct GitHubReleaseMetadata {
 }
 
 /// Representation of a GitHub contributor.
-#[derive(Debug, Default, Clone, Eq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct GitHubContributor {
 	/// Username.
 	pub username:      Option<String>,
@@ -134,14 +144,10 @@ pub struct GitHubContributor {
 	pub pr_title:      Option<String>,
 	/// The pull request that the user created.
 	pub pr_number:     Option<i64>,
+	/// Labels of the pull request.
+	pub pr_labels:     Vec<String>,
 	/// Whether if the user contributed for the first time.
 	pub is_first_time: bool,
-}
-
-impl PartialEq for GitHubContributor {
-	fn eq(&self, other: &Self) -> bool {
-		self.username == other.username
-	}
 }
 
 impl Hash for GitHubContributor {

--- a/website/docs/integration/github.md
+++ b/website/docs/integration/github.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 ---
+
 # GitHub Integration 🆕
 
 :::warning
@@ -105,6 +106,7 @@ For each commit, GitHub related values are added as a nested object (named `gith
     "username": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
+    "pr_labels": ["rust"],
     "is_first_time": false
   }
 }
@@ -144,12 +146,14 @@ For each release, following contributors data is added to the [template context]
         "username": "orhun",
         "pr_title": "some things have changed",
         "pr_number": 420,
+        "pr_labels": ["rust"],
         "is_first_time": true
       },
       {
         "username": "cliffjumper",
         "pr_title": "I love jumping",
         "pr_number": 999,
+        "pr_labels": ["rust"],
         "is_first_time": true
       }
     ]


### PR DESCRIPTION
## Description

This PR makes it possible to use the pull request labels with the [GitHub integration](https://git-cliff.org/docs/integration/github):

```jinja2
* {{ commit.github.pr_labels }}
```

The final context is the following:

```json
"github": {
    "username": "orhun",
    "pr_title": "some things have changed",
    "pr_number": 420,
    "pr_labels": ["test"],
    "is_first_time": false
}
```

## Motivation and Context

See #461

## How Has This Been Tested?

Unit tests.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
