### PR TITLE
docs(website): improve matching gitmoji tip

### DIFF
--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -49,6 +49,6 @@ Then strip the tags in the template with the series of filters:
 [git]
 commit_preprocessors = [
   # Remove gitmoji, both actual UTF emoji and :emoji:
-  { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}\u{200D}]) *', replace = "" },
+  { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}](?:\u{FE0F})?\u{200D}?) *', replace = "" },
 ]
 ```


### PR DESCRIPTION
## Description

Emojis are hard. The pattern was not matching the certain emojis.

The new pattern fixes the issue by adding the variation selector`u{FE0F}`.

Further, this makes the zero-width joiner (`u{200D}`) optional, matching emojis both with and without the ZWJ.

## How Has This Been Tested?

I tested the new pattern on my repo and found out many commits had been skipped: https://github.com/welpo/tabi/commit/1bb3c91b91585bb6317ed0d82e6d0c0fbc36e0b6

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->