### PR TITLE
feat(github): allow overriding API URL

### DIFF
--- a/git-cliff-core/src/github.rs
+++ b/git-cliff-core/src/github.rs
@@ -34,7 +34,7 @@ use std::hash::{
 use std::time::Duration;
 
 /// GitHub REST API url.
-const GITHUB_API_URL: &str = "https://api.github.com";
+const GITHUB_API_URL: &str = env!("GITHUB_API_URL", "https://api.github.com");
 
 /// User agent for interacting with the GitHub API.
 ///


### PR DESCRIPTION
## Description

Allow overriding GITHUB_API_URL via environment variable 

## Motivation and Context

Supports using other github instances besides github.com, like github enterprise

Closes #508 

## How Has This Been Tested?

TBD

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
