### PR TITLE
feat(github): support overriding the GitHub API URL

### DIFF
--- a/git-cliff-core/src/github.rs
+++ b/git-cliff-core/src/github.rs
@@ -27,6 +27,7 @@ use serde::{
 	Deserialize,
 	Serialize,
 };
+use std::env;
 use std::hash::{
 	Hash,
 	Hasher,
@@ -35,6 +36,9 @@ use std::time::Duration;
 
 /// GitHub REST API url.
 const GITHUB_API_URL: &str = "https://api.github.com";
+
+/// Environment variable for overriding the GitHub REST API url.
+const GITHUB_API_URL_ENV: &str = "GITHUB_API_URL";
 
 /// User agent for interacting with the GitHub API.
 ///
@@ -56,6 +60,13 @@ pub const START_FETCHING_MSG: &str = "Retrieving data from GitHub...";
 /// Log message to show when done fetching from GitHub.
 pub const FINISHED_FETCHING_MSG: &str = "Done fetching GitHub data.";
 
+/// Returns the GitHub API url either from environment or from default value.
+fn get_github_api_url() -> String {
+	env::var(GITHUB_API_URL_ENV)
+		.ok()
+		.unwrap_or_else(|| GITHUB_API_URL.to_string())
+}
+
 /// Trait for handling the different entries returned from the GitHub API.
 trait GitHubEntry {
 	/// Returns the API URL for fetching the entries at the specified page.
@@ -76,9 +87,10 @@ pub struct GitHubCommit {
 impl GitHubEntry for GitHubCommit {
 	fn url(owner: &str, repo: &str, page: i32) -> String {
 		format!(
-			"{GITHUB_API_URL}/repos/{}/{}/commits?per_page={MAX_PAGE_SIZE}&\
-			 page={page}",
-			owner, repo
+			"{}/repos/{}/{}/commits?per_page={MAX_PAGE_SIZE}&page={page}",
+			get_github_api_url(),
+			owner,
+			repo
 		)
 	}
 	fn buffer_size() -> usize {
@@ -117,9 +129,10 @@ pub struct GitHubPullRequest {
 impl GitHubEntry for GitHubPullRequest {
 	fn url(owner: &str, repo: &str, page: i32) -> String {
 		format!(
-			"{GITHUB_API_URL}/repos/{}/{}/pulls?per_page={MAX_PAGE_SIZE}&\
-			 page={page}&state=closed",
-			owner, repo
+			"{}/repos/{}/{}/pulls?per_page={MAX_PAGE_SIZE}&page={page}&state=closed",
+			get_github_api_url(),
+			owner,
+			repo
 		)
 	}
 

--- a/website/docs/integration/github.md
+++ b/website/docs/integration/github.md
@@ -63,6 +63,12 @@ For example:
 GITHUB_TOKEN="***" git cliff --github-repo "orhun/git-cliff"
 ```
 
+:::tip
+
+You can use the [`GITHUB_API_URL`](https://docs.github.com/en/actions/learn-github-actions/variables) environment variable want to override the API URL. This is useful if you are using GitHub enterprise.
+
+:::
+
 ## Templating
 
 :::tip


### PR DESCRIPTION
## Description

You can now use `GITHUB_API_URL` if you want to override the GitHub API URL.

## Motivation and Context

closes #508

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
