### PR TITLE
fix(command): add missing environment variables for Windows

### DIFF
--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -25,6 +25,7 @@ pub fn run(
 ) -> Result<String> {
 	let mut child = if cfg!(target_os = "windows") {
 		Command::new("cmd")
+			.envs(envs)
 			.args(["/C", command])
 			.stdin(Stdio::piped())
 			.stdout(Stdio::piped())


### PR DESCRIPTION
## Description

This PR fixes #531 where the environment variables were not being passed to cmd on Windows. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It breaks some of the functionality of being able to run custom shell commands in the preprocessor.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I've tested to verify that when using the COMMIT_SHA environment variable in the traditional cmd fashion ```%COMMIT_SHA%``` that it is now properly available to shell commands.

<!--- Include details of your testing environment, and the tests you ran to -->
Tested on Windows 11.

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
