### PR TITLE
fix(config): drop extra '(' in first commit URL in github-keepachangelog

### DIFF
--- a/examples/github-keepachangelog.toml
+++ b/examples/github-keepachangelog.toml
@@ -43,7 +43,7 @@ body = """
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
   * @{{ contributor.username }} made their first contribution
     {%- if contributor.pr_number %} in \
-      [#{{ contributor.pr_number }}](({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
+      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
     {%- endif %}
 {%- endfor %}\n
 """


### PR DESCRIPTION
## Description

Remove an extra open parenthesis from the PR URL for a new committer.

## Motivation and Context

The extra open parenthesis breaks the URL so that it is not properly rendered.

## How Has This Been Tested?

After modifying this in my copy of the example configuration, it generates valid URLs
for new contributors.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other [example configuration]

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
