### PR TITLE
chore(pypi): update maturin version

### DIFF
--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -57,9 +57,6 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target
 bin-dir = "{ name }-{ version }/{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
 
-[package.metadata.maturin]
-name = "git-cliff"
-
 [package.metadata.generate-rpm]
 assets = [
   { source = "target/release/git-cliff", dest = "/usr/bin/git-cliff", mode = "755" },

--- a/pypi/.gitignore
+++ b/pypi/.gitignore
@@ -1,0 +1,5 @@
+# venv dir which might be present during testing
+.venv
+
+# where the build artifacts go
+wheels

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.5,<2"]
 build-backend = "maturin"
 
 [project]

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -16,3 +16,4 @@ classifiers = [
 [tool.maturin]
 bindings = "bin"
 manifest-path = "../git-cliff/Cargo.toml"
+module-name = "git-cliff"


### PR DESCRIPTION
## Description

I've updated the maturin version, addressed a deprecation warning, and added a .gitignore file to the pypi folder to ignore files that are generated during build and local testing.

## Motivation and Context

I discovered that the version of maturin specified in `pyproject.toml` was too narrowly constrained in the process of investigating https://github.com/orhun/git-cliff/issues/534.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I ran the `maturin build` command that is normally run in GHA locally, and confirmed that it builds an installable wheel on my platform (Windows).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!-- ## Screenshots / Logs (if applicable) -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
