### PR TITLE
fix(release): fix typo in the installation of typos-cli

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if ! command -v typos &>/dev/null; then
-  echo "typos is not installed. Run 'cargo install typos' to install it, otherwise the typos won't be fixed"
+  echo "typos is not installed. Run 'cargo install typos-cli' to install it, otherwise the typos won't be fixed"
 fi
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
While creating releases locally I followed the directions from `release.sh` to run `cargo install typos` but I'm pretty sure that the correct command is `cargo install typos-cli`.