### PR TITLE
feat(ci): test that python wheels can be built and installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,9 +256,7 @@ jobs:
           # https://github.com/PyO3/maturin-action/issues/245
           manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || 'auto' }}
       - name: Build Python wheels (macos & windows)
-        if: |
-          matrix.build.PYPI_PUBLISH == true &&
-          (startsWith(matrix.build.OS, 'macos') || startsWith(matrix.build.OS, 'windows'))
+        if: (startsWith(matrix.build.OS, 'macos') || startsWith(matrix.build.OS, 'windows'))
         uses: PyO3/maturin-action@v1
         with:
           working-directory: pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,121 @@ jobs:
             printf "Checking MSRV for $package..."
             cargo msrv --output-format json --path "$package" verify | tail -n 1 | jq --exit-status '.success'
           done
+
+  wheels:
+    name: Test that python wheels build and install
+    runs-on: ${{ matrix.build.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - {
+              NAME: linux-x64-glibc,
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-unknown-linux-gnu,
+            }
+          - {
+              NAME: linux-x64-musl,
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-unknown-linux-musl,
+            }
+          - {
+              NAME: linux-x86-musl,
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: i686-unknown-linux-musl,
+            }
+          - {
+              NAME: linux-arm64-glibc,
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-gnu,
+            }
+          - {
+              NAME: linux-arm64-musl,
+              OS: ubuntu-22.04,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-unknown-linux-musl,
+            }
+          - {
+              NAME: win32-x64-mingw,
+              OS: windows-2022,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-pc-windows-gnu,
+            }
+          - {
+              NAME: win32-x64-msvc,
+              OS: windows-2022,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-pc-windows-msvc,
+            }
+          - {
+              NAME: win32-x86-msvc,
+              OS: windows-2022,
+              TOOLCHAIN: stable,
+              TARGET: i686-pc-windows-msvc,
+            }
+          - {
+              NAME: darwin-x64,
+              OS: macos-12,
+              TOOLCHAIN: stable,
+              TARGET: x86_64-apple-darwin,
+            }
+          - {
+              NAME: darwin-arm64,
+              OS: macos-12,
+              TOOLCHAIN: stable,
+              TARGET: aarch64-apple-darwin,
+            }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        shell: bash
+        run: |
+          if [[ "${{ matrix.build.NAME }}" = *"-musl" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              --allow-unauthenticated musl-tools
+          fi
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.build.TOOLCHAIN }}
+          target: ${{ matrix.build.TARGET }}
+          override: true
+      - name: Build Python wheels (linux)
+        if: startsWith(matrix.build.NAME, 'linux')
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: pypi
+          target: ${{ matrix.build.TARGET }}
+          args: --release --sdist --out wheels
+          sccache: "true"
+          # https://github.com/PyO3/maturin-action/issues/245
+          manylinux: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-gnu' && '2_28' || 'auto' }}
+      - name: Build Python wheels (macos & windows)
+        if: |
+          matrix.build.PYPI_PUBLISH == true &&
+          (startsWith(matrix.build.OS, 'macos') || startsWith(matrix.build.OS, 'windows'))
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: pypi
+          target: ${{ matrix.build.TARGET }}
+          args: --release --sdist --out wheels
+          sccache: "true"
+      - name: Build Python wheels (musl)
+        if: endsWith(matrix.build.OS, 'musl')
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: pypi
+          target: ${{ matrix.build.TARGET }}
+          args: --release --sdist --out wheels
+          sccache: "true"
+          manylinux: musllinux_1_2
+      - name: Test wheel installation
+        run: |
+          pip install --no-index --find-links=pypi/wheels git-cliff
+          git-cliff --version

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["maturin>=1.5,<2"]
+build-backend = "maturin"
+
 [project]
 name = "git-cliff"
 requires-python = ">=3.7"

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["maturin>=1.5,<2"]
-build-backend = "maturin"
-
 [project]
 name = "git-cliff"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Description

This adds a CI job that builds and installs python wheels for every platform that wheels are published to PyPI.

## Motivation and Context

This should warn against issues such as #534.

## How Has This Been Tested?

Please refer to GHA runs of this workflow in my fork: https://github.com/radusuciu/git-cliff/actions/workflows/ci.yml

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
