### PR TITLE
docs(website): fix the documentation for `--include-path`

### DIFF
--- a/website/docs/usage/monorepos.md
+++ b/website/docs/usage/monorepos.md
@@ -4,9 +4,14 @@ sidebar_position: 5
 
 # Monorepos
 
-You can generate a changelog scoped to a specific directory:
+You can generate a changelog scoped to a specific directory via `--include-path` and `exclude-path`. This requires changing the current working directory to the target folder. The included/excluded paths must be relative to the repository's root. 
 
 ```bash
-git cliff --include-path "**/*.toml" --include-path "*.md"
-git cliff --exclude-path ".github/*"
+cd packages/some_library
+git cliff --include-path "packages/some_library/**/*" --repository "../../"
+```
+
+```bash
+cd packages/some_library
+git cliff --include-path "packages/some_library/**/*" --repository "../../" --exclude-path ".github/*"
 ```

--- a/website/docs/usage/monorepos.md
+++ b/website/docs/usage/monorepos.md
@@ -4,7 +4,9 @@ sidebar_position: 5
 
 # Monorepos
 
-You can generate a changelog scoped to a specific directory via `--include-path` and `exclude-path`. This requires changing the current working directory to the target folder. The included/excluded paths must be relative to the repository's root. 
+You can generate a changelog scoped to a specific directory via `--include-path` and `--exclude-path`.
+
+This requires changing the current working directory to the target folder. The included/excluded paths must be relative to the repository's root.
 
 ```bash
 cd packages/some_library


### PR DESCRIPTION

## Description

Related to #48


## Motivation and Context

`--include-path` with the previous documentation always gave no result. This fixes it by properly documenting the excepted inputs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On a real project by running the commands

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
