### PR TITLE
fix(commit): trim the text before matching with commit parser

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -309,7 +309,7 @@ impl Commit<'_> {
 				}
 			}
 			for (regex, text) in regex_checks {
-				if regex.is_match(&text) {
+				if regex.is_match(text.trim()) {
 					if self.skip_commit(parser, protect_breaking) {
 						return Err(AppError::GroupError(String::from(
 							"Skipping commit",


### PR DESCRIPTION
## Description

This PR changes the commit parser behavior to always trim the text (commit message, body, etc.) before matching it with a regex.

This means that you will be able to use `$` in the regex for matching until the end.

## Motivation and Context

closes #554

## How Has This Been Tested?

Locally / tests / fixtures.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
