### PR TITLE
fix(parser): allow matching empty commit body

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -262,11 +262,13 @@ impl Commit<'_> {
 			if let Some(message_regex) = parser.message.as_ref() {
 				regex_checks.push((message_regex, self.message.to_string()))
 			}
-			if let (Some(body_regex), Some(body)) = (
-				parser.body.as_ref(),
-				self.conv.as_ref().and_then(|v| v.body()),
-			) {
-				regex_checks.push((body_regex, body.to_string()))
+			let body = self
+				.conv
+				.as_ref()
+				.and_then(|v| v.body())
+				.map(|v| v.to_string());
+			if let Some(body_regex) = parser.body.as_ref() {
+				regex_checks.push((body_regex, body.clone().unwrap_or_default()))
 			}
 			if let (Some(field_name), Some(pattern_regex)) =
 				(parser.field.as_ref(), parser.pattern.as_ref())
@@ -276,11 +278,7 @@ impl Commit<'_> {
 					match field_name.as_str() {
 						"id" => Some(self.id.clone()),
 						"message" => Some(self.message.clone()),
-						"body" => self
-							.conv
-							.as_ref()
-							.and_then(|v| v.body())
-							.map(|v| v.to_string()),
+						"body" => body,
 						"author.name" => self.author.name.clone(),
 						"author.email" => self.author.email.clone(),
 						"committer.name" => self.committer.name.clone(),

--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -61,7 +61,7 @@ commit_preprocessors = [
 ]
 ```
 
-## Skip empty body
+## Skip commits with an empty body
 
 ```toml
 [git]

--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -60,3 +60,12 @@ commit_preprocessors = [
   { pattern = ' *(:\w+:|[\p{Emoji_Presentation}\p{Extended_Pictographic}](?:\u{FE0F})?\u{200D}?) *', replace = "" },
 ]
 ```
+
+## Skip empty body
+
+```toml
+[git]
+commit_parsers = [
+  { body = "$^", skip = true },
+]
+```


### PR DESCRIPTION
## Description

This PR updates the commit parsing to matching empty commit body.

Makes it possible to skip commits with empty body:

```toml
[git]
commit_parsers = [
  { body = "$^", skip = true },
]
```

## Motivation and Context

closes #604

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
