### PR TITLE
fix(changelog): ignore empty lines when using `split_commits`

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -94,10 +94,14 @@ impl<'a> Changelog<'a> {
 						commit
 							.message
 							.lines()
-							.flat_map(|line| {
+							.filter_map(|line| {
 								let mut c = commit.clone();
 								c.message = line.to_string();
-								Self::process_commit(c, &self.config.git)
+								if !c.message.is_empty() {
+									Self::process_commit(c, &self.config.git)
+								} else {
+									None
+								}
 							})
 							.collect()
 					} else {
@@ -722,6 +726,7 @@ style: make awesome stuff look better
 			String::from("123abc"),
 			String::from(
 				"chore(deps): bump some deps
+
 chore(deps): bump some more deps
 chore(deps): fix broken deps
 ",


### PR DESCRIPTION
## Description

Prevent duplication of changelog when using `split_commit` and the commits have empty lines.

## Motivation and Context

When using split commits, if there is a an empty line between commits, it will duplicate the commit prior to the empty line, and I noticed that it will sometimes assign it to a different scope, though I have not investigated the why at this point.
One of the reasons this is a problem is that in certain GUIs (like GitHub Desktop) if you enter the first line in the header and the second line in the body, it will automatically add a new line.
fixes #606 

## How Has This Been Tested?
Using the existing test (changelog_generator_split_commits) by adding a new line in one of the commits.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
