### PR TITLE
chore(tests): don't check last commit

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -210,7 +210,6 @@ impl Repository {
 mod test {
 	use super::*;
 	use crate::commit::Commit as AppCommit;
-	use git_conventional::ErrorKind;
 	use std::env;
 	use std::process::Command;
 	use std::str;


### PR DESCRIPTION
## Description

Don't check if last commit is conventional.

## Motivation and Context

Having the PR checks failing because one of the commits is not conventional is annoying for contributors. Original feedback: https://github.com/orhun/git-cliff/pull/613#issuecomment-2059908791

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I pushed [fc58c87](https://github.com/orhun/git-cliff/pull/619/commits/fc58c87bf2e6592a31d7f3f60e19d99fa7aabfe8) to this PR. It's not a conventional commit and the tests still work.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
