### PR TITLE
chore(npm): add minimum supported Node versions

### DIFF
--- a/npm/git-cliff/package.json
+++ b/npm/git-cliff/package.json
@@ -112,5 +112,8 @@
   "packageManager": "yarn@4.1.0",
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": ">=18.19 || >=20.6 || >=21"
   }
 }

--- a/website/docs/installation/npm.md
+++ b/website/docs/installation/npm.md
@@ -33,3 +33,9 @@ runGitCliff(options);
 ```
 
 Under the hood this will parse the options, set up the environment and call the **git-cliff** binary for you.
+
+## Supported Node.js Versions
+The following minimum versions of Node are currently supported:
+- 18.19.0
+- 20.6.0
+- 21.0.0

--- a/website/docs/installation/npm.md
+++ b/website/docs/installation/npm.md
@@ -23,7 +23,7 @@ Afterwards, you can run **git-cliff** via `npm exec git-cliff` or `npx git-cliff
 **git-cliff** also provides a fully typed programmatic API. You can use it to integrate **git-cliff** into your own tooling.
 
 ```typescript
-import { runGitCliff, type Options } from 'git-cliff';
+import { runGitCliff, type Options } from "git-cliff";
 
 const options: Options = {
   // ...
@@ -35,7 +35,9 @@ runGitCliff(options);
 Under the hood this will parse the options, set up the environment and call the **git-cliff** binary for you.
 
 ## Supported Node.js Versions
+
 The following minimum versions of Node are currently supported:
-- 18.19.0
-- 20.6.0
-- 21.0.0
+
+- `>=18.19`
+- `>=20.6`
+- `>=21`


### PR DESCRIPTION
## chore(config): Add minimum supported Node versions

Resolves #602 by adding `engines` to `npm` package for the minimum supported versions of Node and adds those to the website page about `npm`

## Motivation and Context

Makes system dependencies clearer.

## How Has This Been Tested?

Followed the process I documented on [this comment](https://github.com/orhun/git-cliff/issues/602#issuecomment-2068283185) to find the versions that worked

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
