### PR TITLE
feat(output): support using stdout via dash (`-o -`)

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -48,6 +48,7 @@ use std::io::{
 	self,
 	Write,
 };
+use std::path::PathBuf;
 use std::time::{
 	SystemTime,
 	UNIX_EPOCH,
@@ -498,7 +499,11 @@ pub fn run(mut args: Opt) -> Result<()> {
 		changelog.prepend(fs::read_to_string(path)?, &mut File::create(path)?)?;
 	}
 	if let Some(path) = args.output {
-		let mut output = File::create(path)?;
+		let mut output: Box<dyn Write> = if path == PathBuf::from("-") {
+			Box::new(io::stdout())
+		} else {
+			Box::new(File::create(path)?)
+		};
 		if args.context {
 			changelog.write_context(&mut output)
 		} else {


### PR DESCRIPTION
## Description

Using `-` for `stdout` is a common convention between CLI tools and this PR simply adds this support to `git-cliff`.

## Motivation and Context

This makes it possible to use `git-cliff` as follows:

```
$ git-cliff -o -
```

(instead of `git-cliff -o /dev/stdout` or `git-cliff -o`)

Also you can combine it with `-p` as mentioned in #643

## How Has This Been Tested?

Locally

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
