### PR TITLE
fix(args): allow -o and -p together if they point to different files

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -386,6 +386,11 @@ pub fn run(mut args: Opt) -> Result<()> {
 			)));
 		}
 	}
+	if args.output.is_some() && args.prepend.is_some() {
+		return Err(Error::ArgumentError(String::from(
+			"'-o' and '-p' cannot be used together",
+		)));
+	}
 	if args.body.is_some() {
 		config.changelog.body.clone_from(&args.body);
 	}

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -386,9 +386,13 @@ pub fn run(mut args: Opt) -> Result<()> {
 			)));
 		}
 	}
-	if args.output.is_some() && args.prepend.is_some() {
+	if args.output.is_some() &&
+		args.prepend.is_some() &&
+		args.output.as_ref() == args.prepend.as_ref()
+	{
 		return Err(Error::ArgumentError(String::from(
-			"'-o' and '-p' cannot be used together",
+			"'-o' and '-p' can only be used together if they point to different \
+			 files",
 		)));
 	}
 	if args.body.is_some() {

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -72,6 +72,7 @@ Prepend new changes to an existing changelog file:
 ```bash
 # 1- changelog header is removed from CHANGELOG.md
 # 2- new entries are prepended to CHANGELOG.md without footer part
+# the --prepend option is incompatible with -o (output)
 git cliff --unreleased --tag 1.0.0 --prepend CHANGELOG.md
 ```
 

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -72,7 +72,7 @@ Prepend new changes to an existing changelog file:
 ```bash
 # 1- changelog header is removed from CHANGELOG.md
 # 2- new entries are prepended to CHANGELOG.md without footer part
-# the --prepend option is incompatible with -o (output)
+# the --prepend option is incompatible with -o (output) if the file paths are equal
 git cliff --unreleased --tag 1.0.0 --prepend CHANGELOG.md
 ```
 


### PR DESCRIPTION
setting prepend and output together will ignore the prepend flag

## Description

- preprend and output flags are conflicting and should only be used together if they point to different paths

## Motivation and Context

https://github.com/orhun/git-cliff-action/issues/21#issuecomment-2130022787

## How Has This Been Tested?

I build it locally and tested it with one of my rust projects

## Screenshots / Logs (if applicable)

![Screenshot-Visual Studio Code-007271](https://github.com/orhun/git-cliff/assets/106314688/0f445800-fadc-4c6d-bc88-c13f2b94e5c9)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

not sure

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
