### PR TITLE
feat(changelog): make `changelog.header` a template

### DIFF
--- a/.github/fixtures/new-fixture-template/cliff.toml
+++ b/.github/fixtures/new-fixture-template/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bump-initial-tag-cli-arg/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag-cli-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bump-initial-tag-default/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag-default/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bump-initial-tag/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bump-version-keep-zerover/cliff.toml
+++ b/.github/fixtures/test-bump-version-keep-zerover/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bump-version/cliff.toml
+++ b/.github/fixtures/test-bump-version/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-bumped-version/cliff.toml
+++ b/.github/fixtures/test-bumped-version/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-commit-footers/cliff.toml
+++ b/.github/fixtures/test-commit-footers/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-commit-preprocessors/cliff.toml
+++ b/.github/fixtures/test-commit-preprocessors/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-configure-from-cargo-toml/Cargo.toml
+++ b/.github/fixtures/test-configure-from-cargo-toml/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [package.metadata.git-cliff.changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-custom-scope/cliff.toml
+++ b/.github/fixtures/test-custom-scope/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-custom-tag-pattern/cliff.toml
+++ b/.github/fixtures/test-custom-tag-pattern/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-date-order/cliff.toml
+++ b/.github/fixtures/test-date-order/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-footer-template/cliff.toml
+++ b/.github/fixtures/test-footer-template/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-header-template/cliff.toml
+++ b/.github/fixtures/test-header-template/cliff.toml
@@ -1,0 +1,31 @@
+[changelog]
+# changelog header
+header = """
+# Changelog
+{% for release in releases %}\
+    {% if release.version %}\
+        {% if release.previous.version %}\
+            <!--{{ release.previous.version }}..{{ release.version }}-->
+        {% endif %}\
+    {% else %}\
+        <!--{{ release.previous.version }}..HEAD-->
+    {% endif %}\
+{% endfor %}\
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespace from the templates
+trim = true

--- a/.github/fixtures/test-header-template/cliff.toml
+++ b/.github/fixtures/test-header-template/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog
 {% for release in releases %}\

--- a/.github/fixtures/test-header-template/commit.sh
+++ b/.github/fixtures/test-header-template/commit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_COMMITTER_DATE="2021-01-23 01:23:45" git commit --allow-empty -m "feat: add feature 1"
+GIT_COMMITTER_DATE="2021-01-23 01:23:45" git commit --allow-empty -m "feat: add feature 2"
+git tag v0.1.0
+
+GIT_COMMITTER_DATE="2021-01-23 01:23:46" git commit --allow-empty -m "fix: fix feature 1"
+GIT_COMMITTER_DATE="2021-01-23 01:23:46" git commit --allow-empty -m "fix: fix feature 2"
+git tag v0.2.0
+
+GIT_COMMITTER_DATE="2021-01-23 01:23:47" git commit --allow-empty -m "feat: add footer"
+git tag v3.0.0
+
+GIT_COMMITTER_DATE="2021-01-23 01:23:47" git commit --allow-empty -m "test: footer"
+GIT_COMMITTER_DATE="2021-01-23 01:23:47" git commit --allow-empty -m "perf: footer"

--- a/.github/fixtures/test-header-template/expected.md
+++ b/.github/fixtures/test-header-template/expected.md
@@ -1,0 +1,33 @@
+# Changelog
+<!--v3.0.0..HEAD-->
+<!--v0.2.0..v3.0.0-->
+<!--v0.1.0..v0.2.0-->
+## [unreleased]
+
+### Perf
+
+- Footer
+
+### Test
+
+- Footer
+
+## [3.0.0]
+
+### Feat
+
+- Add footer
+
+## [0.2.0]
+
+### Fix
+
+- Fix feature 1
+- Fix feature 2
+
+## [0.1.0]
+
+### Feat
+
+- Add feature 1
+- Add feature 2

--- a/.github/fixtures/test-ignore-tags/cliff.toml
+++ b/.github/fixtures/test-ignore-tags/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-keep-a-changelog-links-current-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-current-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-latest-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-latest-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-no-tags/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-no-tags/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-one-tag-bump-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-one-tag-bump-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-one-tag/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-one-tag/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-tag-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-tag-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links-unreleased-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-unreleased-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-keep-a-changelog-links/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/.github/fixtures/test-latest-with-one-tag/cliff.toml
+++ b/.github/fixtures/test-latest-with-one-tag/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-limit-commits/cliff.toml
+++ b/.github/fixtures/test-limit-commits/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-no-exec/cliff.toml
+++ b/.github/fixtures/test-no-exec/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-regex-replace-parser/cliff.toml
+++ b/.github/fixtures/test-regex-replace-parser/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-skip-breaking-changes/cliff.toml
+++ b/.github/fixtures/test-skip-breaking-changes/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-skip-commits/cliff.toml
+++ b/.github/fixtures/test-skip-commits/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-split-commits/cliff.toml
+++ b/.github/fixtures/test-split-commits/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-topo-order-arg/cliff.toml
+++ b/.github/fixtures/test-topo-order-arg/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/.github/fixtures/test-topo-order/cliff.toml
+++ b/.github/fixtures/test-topo-order/cliff.toml
@@ -1,5 +1,5 @@
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/cliff.toml
+++ b/cliff.toml
@@ -6,7 +6,7 @@
 # See documentation for more information on available options.
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 [![animation](https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff-anim.gif)](https://git-cliff.org)\n
 """

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -6,7 +6,7 @@
 # See documentation for more information on available options.
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/examples/cocogitto.toml
+++ b/examples/cocogitto.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.\n

--- a/examples/detailed.toml
+++ b/examples/detailed.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/examples/github-keepachangelog.toml
+++ b/examples/github-keepachangelog.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/examples/keepachangelog.toml
+++ b/examples/keepachangelog.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.

--- a/examples/scoped.toml
+++ b/examples/scoped.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/examples/scopesorted.toml
+++ b/examples/scopesorted.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/examples/unconventional.toml
+++ b/examples/unconventional.toml
@@ -2,7 +2,7 @@
 # https://git-cliff.org/docs/configuration
 
 [changelog]
-# changelog header
+# template for the changelog footer
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -425,14 +425,16 @@ impl<'a> Changelog<'a> {
 			serde_json::to_value(self.config.remote.clone())?,
 		);
 		#[cfg(feature = "github")]
-		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set() {
+		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set()
+		{
 			self.get_github_metadata()
 				.expect("Could not get github metadata")
 		} else {
 			(vec![], vec![])
 		};
 		#[cfg(feature = "gitlab")]
-		let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set() {
+		let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set()
+		{
 			self.get_gitlab_metadata()
 				.expect("Could not get gitlab metadata")
 		} else {
@@ -506,16 +508,13 @@ impl<'a> Changelog<'a> {
 			.clone()
 			.unwrap_or_default();
 
-		let mut releases = self.releases.clone();
-
-		// render the header template
 		if let Some(header_template) = &self.header_template {
 			let write_result = writeln!(
 				out,
 				"{}",
 				header_template.render(
 					&Releases {
-						releases: &releases,
+						releases: &self.releases,
 					},
 					Some(&self.additional_context),
 					&postprocessors,
@@ -528,8 +527,7 @@ impl<'a> Changelog<'a> {
 			}
 		}
 
-		// render the body template
-		for release in releases.iter_mut() {
+		for release in &self.releases {
 			let write_result = write!(
 				out,
 				"{}",
@@ -546,14 +544,13 @@ impl<'a> Changelog<'a> {
 			}
 		}
 
-		// render the footer template
 		if let Some(footer_template) = &self.footer_template {
 			let write_result = writeln!(
 				out,
 				"{}",
 				footer_template.render(
 					&Releases {
-						releases: &releases,
+						releases: &self.releases,
 					},
 					Some(&self.additional_context),
 					&postprocessors,

--- a/website/docs/configuration/changelog.md
+++ b/website/docs/configuration/changelog.md
@@ -22,23 +22,26 @@ postprocessors = [{ pattern = "foo", replace = "bar"}]
 
 <!-- {% endraw %} -->
 
+See [templating](/docs/category/templating) for more detail.
+
+
 ### header
 
-Header text that will be added to the beginning of the changelog.
+Footer template that will be rendered and added to the beginning of the changelog.
+
+The template context contains the full list of releases in the variable `releases`. See [templating](/docs/category/templating) for more details.
 
 ### body
 
-Body template that represents a single release in the changelog.
+Body template that will be rendered for each release in the changelog. For example, if the changelog contains 3 releases, it will be rendered 3 times, once for each release.
 
-See [templating](/docs/category/templating) for more detail.
+The template context contains one release in the variable `release`. See [templating](/docs/category/templating) for more detail.
 
 ### footer
 
 Footer template that will be rendered and added to the end of the changelog.
 
-The template context is the same as [`body`](#body) and contains all the releases instead of a single release.
-
-For example, to get the list of releases, use the `{{ releases }}` variable in the template. To get information about a single release, iterate over this array and access the fields similar to [`body`](#body).
+The template context contains the full list of releases in the variable `releases`. See [templating](/docs/category/templating) for more details.
 
 See [Keep a Changelog configuration](/docs/templating/examples#keep-a-changelog) for seeing the example of adding links to the end of the changelog.
 

--- a/website/docs/configuration/changelog.md
+++ b/website/docs/configuration/changelog.md
@@ -26,7 +26,7 @@ See [templating](/docs/category/templating) for more detail.
 
 ### header
 
-Footer template that will be rendered and added to the beginning of the changelog.
+Header template that will be rendered and added to the beginning of the changelog.
 
 The template context contains the full list of releases in the variable `releases`. See [templating](/docs/category/templating) for more details.
 

--- a/website/docs/configuration/changelog.md
+++ b/website/docs/configuration/changelog.md
@@ -24,7 +24,6 @@ postprocessors = [{ pattern = "foo", replace = "bar"}]
 
 See [templating](/docs/category/templating) for more detail.
 
-
 ### header
 
 Footer template that will be rendered and added to the beginning of the changelog.


### PR DESCRIPTION
Made changelog.header into a template like changelog.body and changelog.footer. Added test test-header-template.

## Description

Implement #697.

## Motivation and Context

Create parity between `changelog.header`, `changelog.body` and `changelog.footer`.

## How Has This Been Tested?

- Added new test fixture "test-header-template".

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [X] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
