### PR TITLE
feat(changelog): make remote data available in context

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -57,6 +57,7 @@ impl<'a> Changelog<'a> {
 		};
 		changelog.process_commits();
 		changelog.process_releases();
+		changelog.add_remote_data()?;
 		Ok(changelog)
 	}
 
@@ -355,6 +356,55 @@ impl<'a> Changelog<'a> {
 		}
 	}
 
+	/// Adds remote data (e.g. GitHub commits) to the releases.
+	pub fn add_remote_data(&mut self) -> Result<()> {
+		debug!("Adding remote data...");
+		self.additional_context.insert(
+			"remote".to_string(),
+			serde_json::to_value(self.config.remote.clone())?,
+		);
+		#[cfg(feature = "github")]
+		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set() {
+			self.get_github_metadata()
+				.expect("Could not get github metadata")
+		} else {
+			(vec![], vec![])
+		};
+		#[cfg(feature = "gitlab")]
+		let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set() {
+			self.get_gitlab_metadata()
+				.expect("Could not get gitlab metadata")
+		} else {
+			(vec![], vec![])
+		};
+		#[cfg(feature = "bitbucket")]
+		let (bitbucket_commits, bitbucket_pull_request) =
+			if self.config.remote.bitbucket.is_set() {
+				self.get_bitbucket_metadata()
+					.expect("Could not get bitbucket metadata")
+			} else {
+				(vec![], vec![])
+			};
+		for release in self.releases.iter_mut() {
+			#[cfg(feature = "github")]
+			release.update_github_metadata(
+				github_commits.clone(),
+				github_pull_requests.clone(),
+			)?;
+			#[cfg(feature = "gitlab")]
+			release.update_gitlab_metadata(
+				gitlab_commits.clone(),
+				gitlab_merge_request.clone(),
+			)?;
+			#[cfg(feature = "bitbucket")]
+			release.update_bitbucket_metadata(
+				bitbucket_commits.clone(),
+				bitbucket_pull_request.clone(),
+			)?;
+		}
+		Ok(())
+	}
+
 	/// Increments the version for the unreleased changes based on semver.
 	pub fn bump_version(&mut self) -> Result<Option<String>> {
 		if let Some(ref mut last_release) = self.releases.iter_mut().next() {
@@ -376,35 +426,6 @@ impl<'a> Changelog<'a> {
 	/// Generates the changelog and writes it to the given output.
 	pub fn generate<W: Write>(&self, out: &mut W) -> Result<()> {
 		debug!("Generating changelog...");
-		let mut additional_context = self.additional_context.clone();
-		additional_context.insert(
-			"remote".to_string(),
-			serde_json::to_value(self.config.remote.clone())?,
-		);
-		#[cfg(feature = "github")]
-		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set()
-		{
-			self.get_github_metadata()
-				.expect("Could not get github metadata")
-		} else {
-			(vec![], vec![])
-		};
-		#[cfg(feature = "gitlab")]
-		let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set()
-		{
-			self.get_gitlab_metadata()
-				.expect("Could not get gitlab metadata")
-		} else {
-			(vec![], vec![])
-		};
-		#[cfg(feature = "bitbucket")]
-		let (bitbucket_commits, bitbucket_pull_request) =
-			if self.config.remote.bitbucket.is_set() {
-				self.get_bitbucket_metadata()
-					.expect("Could not get bitbucket metadata")
-			} else {
-				(vec![], vec![])
-			};
 		let postprocessors = self
 			.config
 			.changelog
@@ -421,27 +442,12 @@ impl<'a> Changelog<'a> {
 		}
 		let mut releases = self.releases.clone();
 		for release in releases.iter_mut() {
-			#[cfg(feature = "github")]
-			release.update_github_metadata(
-				github_commits.clone(),
-				github_pull_requests.clone(),
-			)?;
-			#[cfg(feature = "gitlab")]
-			release.update_gitlab_metadata(
-				gitlab_commits.clone(),
-				gitlab_merge_request.clone(),
-			)?;
-			#[cfg(feature = "bitbucket")]
-			release.update_bitbucket_metadata(
-				bitbucket_commits.clone(),
-				bitbucket_pull_request.clone(),
-			)?;
 			let write_result = write!(
 				out,
 				"{}",
 				self.body_template.render(
 					&release,
-					Some(&additional_context),
+					Some(&self.additional_context),
 					&postprocessors
 				)?
 			);
@@ -459,7 +465,7 @@ impl<'a> Changelog<'a> {
 					&Releases {
 						releases: &releases,
 					},
-					Some(&additional_context),
+					Some(&self.additional_context),
 					&postprocessors,
 				)?
 			);


### PR DESCRIPTION
## Description

This PR updates the changelog processing order to make remote data (e.g. GitHub commits, pull requests, etc.) available in the context.

## Motivation and Context

```
git cliff --github-repo orhun/git-cliff -c examples/github.toml -x --no-exec -u
```

This command will now contain the GitHub data such as:

```json
 "github": {
      "contributors": [
        {
          "username": "bukowa",
          "pr_title": "style(lint): fix formatting",
          "pr_number": 702,
          "pr_labels": [],
          "is_first_time": true
        },
    ],
}
```

Might fix #687 

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
