### PR TITLE
fix(gitlab): URL-encode the owner in remote requests for GitLab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -2880,6 +2881,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -74,6 +74,7 @@ tokio = { version = "1.38.0", features = [
 futures = { version = "0.3.30", optional = true }
 url = "2.5.2"
 dyn-clone = "1.0.17"
+urlencoding = "2.1.3"
 
 [dependencies.git2]
 version = "0.19.0"

--- a/website/docs/integration/gitlab.md
+++ b/website/docs/integration/gitlab.md
@@ -63,6 +63,8 @@ GITLAB_TOKEN="***" git cliff --gitlab-repo "orhun/git-cliff"
 
 You can use the `GITLAB_API_URL` environment variable want to override the API URL. This is useful if you are using your own GitLab instance.
 
+When your project on your own Gitlab has one or many subgroups (e.g my.gitlab.com/myGroup/mySubgroup/myProject) set owner in the toml to "myGroup/mySubgroup" and repo to the repo name.
+
 :::
 
 ## Templating


### PR DESCRIPTION
## Description

Gitlab requires that the project path be fully encoded. See the docs for details. https://docs.gitlab.com/ee/api/rest/#namespaced-path-encoding Pulls in the url encoding crate here. Might not be needed when you have the choice to just update the documentation. I don't think the end user should be required to url encode their own strings. It might be nicer to just add the subgroup paradigm to the gitlab config in general for the future. This will fix the problem for now.

## Motivation and Context
I want to use git cliff on my self hosted gitlab.
https://github.com/orhun/git-cliff/issues/687

## How Has This Been Tested?
I wrote a test. Doesn't cover the case on IF the end user url encodes their own string. This will break unexpectedly, but I rushed this in.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
