### PR TITLE
feat(changelog): skip ssh and x509 signatures in tag messages

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -25,7 +25,8 @@ use url::Url;
 
 /// Regex for replacing the signature part of a tag message.
 static TAG_SIGNATURE_REGEX: Lazy<Regex> = lazy_regex!(
-	r"(?s)-----BEGIN PGP SIGNATURE-----(.*?)-----END PGP SIGNATURE-----"
+	// https://git-scm.com/docs/gitformat-signature#_description
+	r"(?s)-----BEGIN (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----(.*?)-----END (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----"
 );
 
 /// Wrapper for [`Repository`] type from git2.


### PR DESCRIPTION
## Description

Support for tag messages was added in 3eb828e69ad3a5b94833f67dfe287e7d8b31a274. The commit contains code for stripping GPG signatures from the tag message, but git [supports SSH signatures and x509 signatures as well](https://git-scm.com/docs/gitformat-signature#_description).

This PR adds support for stripping those signature types.

The regex is not 100% accurate (e.g. this would allow `SSH MESSAGE`, which is not part of the gitformat-signature description), but I prioritized readability over correctness in this case (since the code is for replacing text, not verifying the signature).

<!--- Describe your changes in detail -->

## Motivation and Context

Signatures should not show up in the changelog, regardless of what kind of signature was used.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have no x509 certificates, but I [created a SSH-signed tag in my fork](https://github.com/PigeonF/git-cliff/releases/tag/example-ssh-signed-tag), and then ran the [`resolves_existing_tag_with_name_and_message` test](https://github.com/orhun/git-cliff/blob/main/git-cliff-core/src/repo.rs#L372-L386) and replaced the tag that is checked from `v0.2.3` to `example-ssh-signed-tag`

```diff
diff --git a/git-cliff-core/src/repo.rs b/git-cliff-core/src/repo.rs
index 95843d76840ce4d5..219d7a6e979e3db3 100644
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -372,8 +372,8 @@ mod test {
        #[test]
        fn resolves_existing_tag_with_name_and_message() -> Result<()> {
                let repository = get_repository()?;
-               let tag = repository.resolve_tag("v0.2.3");
-               assert_eq!(tag.name, "v0.2.3");
+               let tag = repository.resolve_tag("example-ssh-signed-tag");
+               assert_eq!(tag.name, "example-ssh-signed-tag");
                assert_eq!(
                        tag.message,
                        Some(
```

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

Arguably this could also be a bug fix.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->

I did not update any documentation, since I could find no mention of the gpg signature stripping.

I am not sure how to add a test: the existing functionality is covered by reading a tag that is GPG signed, but I have no way to add a SSH signed tag to this repository :^)