### PR TITLE
perf(changelog): cache commit retain checks (258 times faster generation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +858,8 @@ dependencies = [
 name = "git-cliff-core"
 version = "2.4.0"
 dependencies = [
+ "bincode 2.0.0-rc.3",
+ "cacache",
  "config",
  "dirs",
  "document-features",
@@ -1033,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ffb12b95bb2a369fe47ca8924016c72c2fa0e6059ba98bd1516f558696c5a8"
 dependencies = [
  "async-trait",
- "bincode",
+ "bincode 1.3.3",
  "cacache",
  "http 1.1.0",
  "http-cache-semantics",
@@ -3138,6 +3159,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "temp-dir",
  "tera",
  "thiserror",
  "tokio",
@@ -2688,6 +2689,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f227968ec00f0e5322f9b8173c7a0cbcff6181a0a5b28e9892491c286277231"
 
 [[package]]
 name = "tempfile"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-cliff-core"
-version = "2.4.0" # managed by release.sh
+version = "2.4.0"                                               # managed by release.sh
 description = "Core library of git-cliff"
 authors = ["git-cliff contributors <git-cliff@protonmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -75,6 +75,7 @@ futures = { version = "0.3.30", optional = true }
 url = "2.5.2"
 dyn-clone = "1.0.17"
 urlencoding = "2.1.3"
+cached = { version = "0.53.1", features = ["disk_store"], default-features = true}
 
 [dependencies.git2]
 version = "0.19.0"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -52,6 +52,7 @@ lazy_static.workspace = true
 thiserror = "1.0.61"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.118"
+bincode = "2.0.0-rc.3"
 serde_regex = "1.1.0"
 tera = "1.20.0"
 indexmap = { version = "2.2.6", optional = true }

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-cliff-core"
-version = "2.4.0"                                               # managed by release.sh
+version = "2.4.0" # managed by release.sh
 description = "Core library of git-cliff"
 authors = ["git-cliff contributors <git-cliff@protonmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -75,7 +75,7 @@ futures = { version = "0.3.30", optional = true }
 url = "2.5.2"
 dyn-clone = "1.0.17"
 urlencoding = "2.1.3"
-cached = { version = "0.53.1", features = ["disk_store"], default-features = true}
+cacache = { version = "13.0.0", features = ["mmap"], default-features = false }
 
 [dependencies.git2]
 version = "0.19.0"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -99,6 +99,7 @@ features = ["debug-embed", "compression"]
 [dev-dependencies]
 pretty_assertions = "1.4.0"
 expect-test = "1.5.0"
+temp-dir = "0.1.13"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -196,7 +196,7 @@ impl Repository {
 		// If the cache is not found, calculate the result and set it to the cache.
 		let result = self.commit_changed_files_no_cache(commit);
 		match bincode::encode_to_vec(
-			&self.commit_changed_files_no_cache(commit),
+			self.commit_changed_files_no_cache(commit),
 			bincode::config::standard(),
 		) {
 			Ok(v) => {

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -196,6 +196,15 @@ impl Repository {
 						.map(|path| path.to_owned()),
 				);
 			}
+		} else {
+			// If there is no parent, it is the first commit.
+			// So get all the files in the tree.
+			if let Ok(tree) = commit.tree() {
+				changed_files.extend(
+					tree.iter()
+						.filter_map(|entry| entry.name().map(PathBuf::from)),
+				);
+			}
 		}
 
 		changed_files

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -21,10 +21,7 @@ use lazy_regex::{
 	Regex,
 };
 use std::io;
-use std::path::{
-	Path,
-	PathBuf,
-};
+use std::path::PathBuf;
 use url::Url;
 
 /// Regex for replacing the signature part of a tag message.
@@ -268,15 +265,14 @@ impl Repository {
 					}
 
 					// get the full path of the file
-					let name =
-						Path::new(entry.name().expect("Failed to get entry name"));
+					let name = entry.name().expect("Failed to get entry name");
 					let entry_path = if dir != "," {
-						Path::new(dir).join(name)
+						format!("{}/{}", dir, name)
 					} else {
-						name.to_path_buf()
+						name.to_string()
 					};
 
-					changed_files.push(entry_path);
+					changed_files.push(entry_path.into());
 
 					0
 				})

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -71,8 +71,8 @@ impl Repository {
 	pub fn commits(
 		&self,
 		range: Option<&str>,
-		include_path: Option<&[Pattern]>,
-		exclude_path: Option<&[Pattern]>,
+		include_path: Option<Vec<Pattern>>,
+		exclude_path: Option<Vec<Pattern>>,
 	) -> Result<Vec<Commit>> {
 		let mut revwalk = self.inner.revwalk()?;
 		revwalk.set_sorting(Sort::TOPOLOGICAL)?;
@@ -539,7 +539,7 @@ mod test {
 		let remote = repository.upstream_remote()?;
 		assert_eq!(
 			Remote {
-				owner: 	   remote.owner.clone(),
+				owner:     remote.owner.clone(),
 				repo:      String::from("git-cliff"),
 				token:     None,
 				is_custom: false,

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -213,8 +213,8 @@ fn process_repository<'a>(
 	}
 	let mut commits = repository.commits(
 		commit_range.as_deref(),
-		args.include_path.as_deref(),
-		args.exclude_path.as_deref(),
+		args.include_path.clone(),
+		args.exclude_path.clone(),
 	)?;
 	if let Some(commit_limit_value) = config.git.limit_commits {
 		commits.truncate(commit_limit_value);


### PR DESCRIPTION
## Description

This caches the commit retain checks whenever include/exclude paths are specified.

This speeds up changelog generation by `258` times in a big repository I have:
```
Now: 0.080 s
Before:  20.633 s
```

Fixes #767 

It also improves handling including/excluding patterns, considering the first commit, and various other improvements.


## How Has This Been Tested?

I tested this on the repository mentioned in #767

## Screenshots / Logs (if applicable)

Here are the profiling flamegraphs created via #768. The bottleneck is removed after this fix is applied as seen in the above image (4366 samples to only 16 samples). After the fix, other parts of the code finally show up in the profiler.

After - Fully Cached:

![git-cliff - after cached - flamegraph](https://github.com/user-attachments/assets/d29339a5-1c82-4630-bcb8-0b3466d8710a)


After - Cached + new commit:

![git-cliff - after new commit - flamegraph](https://github.com/user-attachments/assets/104866b8-38cf-499d-b904-7409d4d5a938)


Before:

![git-cliff - Before - flamegraph](https://github.com/user-attachments/assets/e7cff5e2-0d69-4b9d-beac-9b6939f23553)




## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
