### PR TITLE
docs(config): fix typo in comment of default config file

### DIFF
--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -6,7 +6,7 @@
 # See documentation for more information on available options.
 
 [changelog]
-# template for the changelog footer
+# template for the changelog header
 header = """
 # Changelog\n
 All notable changes to this project will be documented in this file.\n


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR changes the comment of the `header` field in the default `cliff.toml` config, from `# template for the changelog footer` to `# template for the changelog header`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

That field is for headers so `footer` in the comment seems to be a typo.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As a change to comments, no tests are required.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
