### PR TITLE
feat(remote): activate integration if remote is set manually

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -206,9 +206,9 @@ impl<'a> Changelog<'a> {
 	#[cfg(feature = "github")]
 	fn get_github_metadata(&self) -> Result<crate::remote::RemoteMetadata> {
 		use crate::remote::github;
-		if self
-			.body_template
-			.contains_variable(github::TEMPLATE_VARIABLES) ||
+		if self.config.remote.github.is_custom ||
+			self.body_template
+				.contains_variable(github::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
 				.map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
@@ -262,9 +262,9 @@ impl<'a> Changelog<'a> {
 	#[cfg(feature = "gitlab")]
 	fn get_gitlab_metadata(&self) -> Result<crate::remote::RemoteMetadata> {
 		use crate::remote::gitlab;
-		if self
-			.body_template
-			.contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+		if self.config.remote.gitlab.is_custom ||
+			self.body_template
+				.contains_variable(gitlab::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
 				.map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
@@ -326,9 +326,9 @@ impl<'a> Changelog<'a> {
 	#[cfg(feature = "gitea")]
 	fn get_gitea_metadata(&self) -> Result<crate::remote::RemoteMetadata> {
 		use crate::remote::gitea;
-		if self
-			.body_template
-			.contains_variable(gitea::TEMPLATE_VARIABLES) ||
+		if self.config.remote.gitea.is_custom ||
+			self.body_template
+				.contains_variable(gitea::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
 				.map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
@@ -379,9 +379,9 @@ impl<'a> Changelog<'a> {
 	#[cfg(feature = "bitbucket")]
 	fn get_bitbucket_metadata(&self) -> Result<crate::remote::RemoteMetadata> {
 		use crate::remote::bitbucket;
-		if self
-			.body_template
-			.contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+		if self.config.remote.bitbucket.is_custom ||
+			self.body_template
+				.contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
 				.map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
@@ -791,24 +791,28 @@ mod test {
 			},
 			remote:    RemoteConfig {
 				github:    Remote {
-					owner: String::from("coolguy"),
-					repo:  String::from("awesome"),
-					token: None,
+					owner:     String::from("coolguy"),
+					repo:      String::from("awesome"),
+					token:     None,
+					is_custom: false,
 				},
 				gitlab:    Remote {
-					owner: String::from("coolguy"),
-					repo:  String::from("awesome"),
-					token: None,
+					owner:     String::from("coolguy"),
+					repo:      String::from("awesome"),
+					token:     None,
+					is_custom: false,
 				},
 				gitea:     Remote {
-					owner: String::from("coolguy"),
-					repo:  String::from("awesome"),
-					token: None,
+					owner:     String::from("coolguy"),
+					repo:      String::from("awesome"),
+					token:     None,
+					is_custom: false,
 				},
 				bitbucket: Remote {
-					owner: String::from("coolguy"),
-					repo:  String::from("awesome"),
-					token: None,
+					owner:     String::from("coolguy"),
+					repo:      String::from("awesome"),
+					token:     None,
+					is_custom: false,
 				},
 			},
 			bump:      Bump::default(),

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -138,12 +138,20 @@ pub struct RemoteConfig {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Remote {
 	/// Owner of the remote.
-	pub owner: String,
+	pub owner:     String,
 	/// Repository name.
-	pub repo:  String,
+	pub repo:      String,
 	/// Access token.
 	#[serde(skip_serializing)]
-	pub token: Option<SecretString>,
+	pub token:     Option<SecretString>,
+	/// Whether if the remote is set manually.
+	#[serde(skip_deserializing, default = "default_true")]
+	pub is_custom: bool,
+}
+
+/// Returns `true` for serde's `default` attribute.
+fn default_true() -> bool {
+	true
 }
 
 impl fmt::Display for Remote {
@@ -162,9 +170,10 @@ impl Remote {
 	/// Constructs a new instance.
 	pub fn new<S: Into<String>>(owner: S, repo: S) -> Self {
 		Self {
-			owner: owner.into(),
-			repo:  repo.into(),
-			token: None,
+			owner:     owner.into(),
+			repo:      repo.into(),
+			token:     None,
+			is_custom: false,
 		}
 	}
 

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -244,9 +244,10 @@ impl Repository {
 					(segments.get(1), segments.first())
 				{
 					return Ok(Remote {
-						owner: owner.to_string(),
-						repo:  repo.trim_end_matches(".git").to_string(),
-						token: None,
+						owner:     owner.to_string(),
+						repo:      repo.trim_end_matches(".git").to_string(),
+						token:     None,
+						is_custom: false,
 					});
 				}
 			}
@@ -360,9 +361,10 @@ mod test {
 		let remote = repository.upstream_remote()?;
 		assert_eq!(
 			Remote {
-				owner: String::from("orhun"),
-				repo:  String::from("git-cliff"),
-				token: None,
+				owner:     String::from("orhun"),
+				repo:      String::from("git-cliff"),
+				token:     None,
+				is_custom: false,
 			},
 			remote
 		);

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -115,6 +115,7 @@ fn process_repository<'a>(
 				debug!("No GitHub remote is set, using remote: {}", remote);
 				config.remote.github.owner = remote.owner;
 				config.remote.github.repo = remote.repo;
+				config.remote.github.is_custom = remote.is_custom;
 			}
 			Err(e) => {
 				debug!("Failed to get remote from GitHub repository: {:?}", e);
@@ -126,6 +127,7 @@ fn process_repository<'a>(
 				debug!("No GitLab remote is set, using remote: {}", remote);
 				config.remote.gitlab.owner = remote.owner;
 				config.remote.gitlab.repo = remote.repo;
+				config.remote.gitlab.is_custom = remote.is_custom;
 			}
 			Err(e) => {
 				debug!("Failed to get remote from GitLab repository: {:?}", e);
@@ -137,6 +139,7 @@ fn process_repository<'a>(
 				debug!("No Gitea remote is set, using remote: {}", remote);
 				config.remote.gitea.owner = remote.owner;
 				config.remote.gitea.repo = remote.repo;
+				config.remote.gitea.is_custom = remote.is_custom;
 			}
 			Err(e) => {
 				debug!("Failed to get remote from Gitea repository: {:?}", e);
@@ -148,6 +151,7 @@ fn process_repository<'a>(
 				debug!("No Bitbucket remote is set, using remote: {}", remote);
 				config.remote.bitbucket.owner = remote.owner;
 				config.remote.bitbucket.repo = remote.repo;
+				config.remote.bitbucket.is_custom = remote.is_custom;
 			}
 			Err(e) => {
 				debug!("Failed to get remote from Bitbucket repository: {:?}", e);
@@ -465,14 +469,22 @@ pub fn run(mut args: Opt) -> Result<()> {
 	if let Some(ref remote) = args.github_repo {
 		config.remote.github.owner = remote.0.owner.to_string();
 		config.remote.github.repo = remote.0.repo.to_string();
+		config.remote.github.is_custom = true;
 	}
 	if let Some(ref remote) = args.gitlab_repo {
 		config.remote.gitlab.owner = remote.0.owner.to_string();
 		config.remote.gitlab.repo = remote.0.repo.to_string();
+		config.remote.gitlab.is_custom = true;
 	}
 	if let Some(ref remote) = args.bitbucket_repo {
 		config.remote.bitbucket.owner = remote.0.owner.to_string();
 		config.remote.bitbucket.repo = remote.0.repo.to_string();
+		config.remote.bitbucket.is_custom = true;
+	}
+	if let Some(ref remote) = args.gitea_repo {
+		config.remote.gitea.owner = remote.0.owner.to_string();
+		config.remote.gitea.repo = remote.0.repo.to_string();
+		config.remote.gitea.is_custom = true;
 	}
 	if args.no_exec {
 		if let Some(ref mut preprocessors) = config.git.commit_preprocessors {


### PR DESCRIPTION
## Description

Before this change the only way of activating a remote integration (and fetching remote data) used to be incorporating the related variables in a template.

This meant that the changelog context won't contain e.g. GitHub related fields unless you use e.g. `github.contributors` in your template.

This PR adds support for enabling the remote integration for the following cases as well:

- If the `[remote]` table is configured.
- If remote is set via command-line arguments (e.g. `--github-repo`)

So the following output will contain GitHub variables even with the default template (since the remote is set):

```sh
$ git cliff --context --github-repo orhun/git-cliff
```

## Motivation and Context

closes #780

## How Has This Been Tested?

Unit tests, local run.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
