### PR TITLE
fix(changelog): allow using `--bumped-version` without conventional commits

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -14,6 +14,9 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
+/// Default initial tag.
+const DEFAULT_INITIAL_TAG: &str = "0.1.0";
+
 /// Manifest file information and regex for matching contents.
 #[derive(Debug)]
 struct ManifestInfo {
@@ -244,6 +247,30 @@ pub struct Bump {
 
 	/// Force to always bump in major, minor or patch.
 	pub bump_type: Option<BumpType>,
+}
+
+impl Bump {
+	/// Returns the initial tag.
+	///
+	/// This function also logs the returned value.
+	pub fn get_initial_tag(&self) -> String {
+		match self.initial_tag.clone() {
+			Some(tag) => {
+				warn!(
+					"No releases found, using initial tag '{tag}' as the next \
+					 version."
+				);
+				tag
+			}
+			None => {
+				warn!(
+					"No releases found, using {DEFAULT_INITIAL_TAG} as the next \
+					 version."
+				);
+				DEFAULT_INITIAL_TAG.into()
+			}
+		}
+	}
 }
 
 /// Parser for grouping commits.

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -154,19 +154,7 @@ impl<'a> Release<'a> {
 					Ok(next_version)
 				}
 			}
-			None => match config.initial_tag.clone() {
-				Some(tag) => {
-					warn!(
-						"No releases found, using initial tag '{tag}' as the next \
-						 version."
-					);
-					Ok(tag)
-				}
-				None => {
-					warn!("No releases found, using 0.1.0 as the next version.");
-					Ok(String::from("0.1.0"))
-				}
-			},
+			None => Ok(config.get_initial_tag()),
 		}
 	}
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -583,6 +583,8 @@ pub fn run(mut args: Opt) -> Result<()> {
 		{
 			warn!("There is nothing to bump.");
 			last_version
+		} else if changelog.releases.is_empty() {
+			config.bump.get_initial_tag()
 		} else {
 			return Ok(());
 		};


### PR DESCRIPTION
## Motivation and Context

fixes #805

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
