### PR TITLE
feat(args): allow GitLab groups with `--gitlab-repo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "secrecy",
  "shellexpand",
  "update-informer",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ log = "0.4.21"
 secrecy = { version = "0.8.0", features = ["serde"] }
 lazy_static = "1.5.0"
 dirs = "5.0.1"
+url = "2.5.2"
 
 [profile.dev]
 opt-level = 0

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -73,7 +73,7 @@ tokio = { version = "1.38.0", features = [
   "macros",
 ], optional = true }
 futures = { version = "0.3.30", optional = true }
-url = "2.5.2"
+url.workspace = true
 dyn-clone = "1.0.17"
 urlencoding = "2.1.3"
 cacache = { version = "13.0.0", features = ["mmap"], default-features = false }

--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -56,6 +56,7 @@ indicatif = { version = "0.17.8", optional = true }
 env_logger = "0.10.2"
 pprof = { version = "0.13", optional = true }
 rand = { version = "0.8.4", optional = true }
+url.workspace = true
 
 [dependencies.git-cliff-core]
 version = "2.4.0" # managed by release.sh


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The cli argument `--gitlab-repo` is split at `/` and the last two parts are used as `owner` and `repo`. This PR changes this behavior, splits at the right most `/` and takes the first part as `owner` and the second part as `repo`.


| |raw string|owner|repo|
|--|--|--|--|
|before| `gitlab/group/a/repo_name` | `a` | `repo_name` |
|after this PR| `gitlab/group/a/repo_name` | `gitlab/group/a` | `repo_name` |

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GitLab allows projects to be organized in groups. Groups can also be part of groups. Because of that projects are not identified by `owner` and `repo`, but by `group/path` and `repo`.

The same behavior can be achieved by using the following inside the config:

```
[remote.gitlab]
owner = "gitlab/group/a"
repo = "repo_name"
```

But since I would like to use the same config in multiple projects, I rather provide the `remote` information via an environment variable.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this with GitLab projects that are organized in groups.

There was a testcase that ignored the `https://github.com` domain if it was included. Since I never saw this inside the documentation I simply removed it, but I'm happy to adjust this PR in a way that this test would still pass, if needed.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
