### PR TITLE
fix(template): include for-loop arguments in template variables

### DIFF
--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -101,6 +101,13 @@ impl Template {
 				for node in &forloop.empty_body.clone().unwrap_or_default() {
 					Self::find_identifiers(node, names);
 				}
+				for (_, expr) in
+					forloop.container.filters.iter().flat_map(|v| v.args.iter())
+				{
+					if let ast::ExprVal::String(ref v) = expr.val {
+						names.insert(v.clone());
+					}
+				}
 			}
 			ast::Node::If(cond, _) => {
 				for (_, expr, nodes) in &cond.conditions {
@@ -128,6 +135,7 @@ impl Template {
 		for node in ast {
 			Self::find_identifiers(node, &mut variables);
 		}
+		trace!("Template variables: {variables:?}");
 		Ok(variables.into_iter().collect())
 	}
 


### PR DESCRIPTION
## Description

Tobias Bieniek on [Mastodon](https://hachyderm.io/@tb/113012369376683372) reported that even when he used the GitHub-related template variables [in this comment](https://github.com/orhun/git-cliff/issues/461#issuecomment-1913595602), `git-cliff` wasn't querying GitHub.

The problem turned out to be in the AST parsing. It was simply not taking for-loop arguments into account.

## Motivation and Context

Fixes the issue that mentioned above.

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
