### PR TITLE
fix(changelog): don't change the context when provided via `--from-context`

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -430,13 +430,20 @@ impl<'a> Changelog<'a> {
 		}
 	}
 
-	/// Adds remote data (e.g. GitHub commits) to the releases.
-	pub fn add_remote_data(&mut self) -> Result<()> {
-		debug!("Adding remote data...");
+	/// Adds information about the remote to the template context.
+	pub fn add_remote_context(&mut self) -> Result<()> {
 		self.additional_context.insert(
 			"remote".to_string(),
 			serde_json::to_value(self.config.remote.clone())?,
 		);
+		Ok(())
+	}
+
+	/// Adds remote data (e.g. GitHub commits) to the releases.
+	pub fn add_remote_data(&mut self) -> Result<()> {
+		debug!("Adding remote data...");
+		self.add_remote_context()?;
+
 		#[cfg(feature = "github")]
 		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set()
 		{

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -535,7 +535,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 			Box::new(File::open(context_path)?)
 		};
 		let mut changelog = Changelog::from_context(&mut input, &config)?;
-		changelog.add_remote_data()?;
+		changelog.add_remote_context()?;
 		changelog
 	} else {
 		// Process the repositories.


### PR DESCRIPTION

closes orhun/git-cliff/issues/819

## Description

A method is added that only adds the additional context `remote` inside the `Changelog` struct and does not query commit information.

## Motivation and Context

see issue orhun/git-cliff/issues/819

## How Has This Been Tested?

I created a changelog and checked that the Gitlab PR information are not changed.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
