### PR TITLE
fix(template): resolve parsing issues with `raw`/`endraw` in Jinja

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -45,9 +45,8 @@ body = """
     | filter(attribute="scope")
     | sort(attribute="scope") %}
         {{ self::print_commit(commit=commit) }}
-    {%- endfor -%}
-    {% raw %}\n{% endraw %}\
-    {%- for commit in commits %}
+    {%- endfor %}
+    {% for commit in commits %}
         {%- if not commit.scope -%}
             {{ self::print_commit(commit=commit) }}
         {% endif -%}
@@ -64,7 +63,8 @@ body = """
     {%- endif %}
 {%- endfor -%}
 {%- endif %}
-{% raw %}\n{% endraw -%}
+
+
 """
 # template for the changelog footer
 footer = """


### PR DESCRIPTION
## Description

This pull request removes the usage of `{% raw %}` and `{% endraw %}` tags from the template files. The presence of these tags caused parsing issues for higher-level callers that also utilize the Jinja engine.

## Motivation and Context

The change is necessary because using `{% raw %}` and `{% endraw %}` tags can interfere with the correct parsing of templates by higher-level callers using the Jinja engine. This modification ensures compatibility and proper parsing for all Jinja-based template users. This PR addresses an issue where templates could not be parsed correctly due to the conflict caused by these tags.

closes #818

## How Has This Been Tested?

Tested.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
