### PR TITLE
feat(config): allow configuring output file from config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -76,6 +76,8 @@ trim = true
 postprocessors = [
   { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
 ]
+# output file path
+output = "test.md"
 
 [git]
 # parse the commits based on https://www.conventionalcommits.org

--- a/cliff.toml
+++ b/cliff.toml
@@ -76,8 +76,6 @@ trim = true
 postprocessors = [
   { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
 ]
-# output file path
-output = "test.md"
 
 [git]
 # parse the commits based on https://www.conventionalcommits.org

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -38,6 +38,8 @@ trim = true
 postprocessors = [
   # { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
 ]
+# output file path
+# output = "test.md"
 
 [git]
 # parse the commits based on https://www.conventionalcommits.org

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -652,6 +652,7 @@ mod test {
 					replace:         Some(String::from("exciting")),
 					replace_command: None,
 				}]),
+				output:         None,
 			},
 			git:       GitConfig {
 				conventional_commits:     Some(true),

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -79,6 +79,8 @@ pub struct ChangelogConfig {
 	pub trim:           Option<bool>,
 	/// Changelog postprocessors.
 	pub postprocessors: Option<Vec<TextProcessor>>,
+	/// Output file path.
+	pub output:         Option<PathBuf>,
 }
 
 /// Git configuration

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -41,6 +41,7 @@ fn generate_changelog() -> Result<()> {
 		footer:         Some(String::from("eoc - end of changelog")),
 		trim:           None,
 		postprocessors: None,
+		output:         None,
 	};
 	let git_config = GitConfig {
 		conventional_commits:     Some(true),

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -416,6 +416,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 	}
 
 	// Update the configuration based on command line arguments and vice versa.
+	let output = args.output.clone().or(config.changelog.output.clone());
 	match args.strip {
 		Some(Strip::Header) => {
 			config.changelog.header = None;
@@ -437,9 +438,9 @@ pub fn run(mut args: Opt) -> Result<()> {
 			)));
 		}
 	}
-	if args.output.is_some() &&
+	if output.is_some() &&
 		args.prepend.is_some() &&
-		args.output.as_ref() == args.prepend.as_ref()
+		output.as_ref() == args.prepend.as_ref()
 	{
 		return Err(Error::ArgumentError(String::from(
 			"'-o' and '-p' can only be used together if they point to different \
@@ -580,7 +581,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 	};
 
 	// Print the result.
-	let mut out: Box<dyn io::Write> = if let Some(path) = &args.output {
+	let mut out: Box<dyn io::Write> = if let Some(path) = &output {
 		if path == Path::new("-") {
 			Box::new(io::stdout())
 		} else {
@@ -616,7 +617,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 		let mut out = io::BufWriter::new(File::create(path)?);
 		changelog.prepend(changelog_before, &mut out)?;
 	}
-	if args.output.is_some() || args.prepend.is_none() {
+	if output.is_some() || args.prepend.is_none() {
 		changelog.generate(&mut out)?;
 	}
 

--- a/website/docs/configuration/changelog.md
+++ b/website/docs/configuration/changelog.md
@@ -55,3 +55,7 @@ It is useful for adding indentation to the template for readability, as shown [i
 An array of commit postprocessors for manipulating the changelog before outputting.
 Can e.g. be used for replacing commit author with GitHub usernames.
 Internally postprocessors and preprocessors are the same. See [commit_preprocessors](/docs/configuration/git#commit_preprocessors) for more detail and examples, it uses the same syntax.
+
+### output
+
+Output file path for the changelog. You can also use the `--output` argument to override this value.


### PR DESCRIPTION
## Description

This PR adds a new configuration option as follows:

```toml
[changelog]
output = "CHANGELOG.md"
```

It does not take precedence over command-line arguments which means you can override it with the `--output` option.

## Motivation and Context

closes #827

## How Has This Been Tested?

Locally.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
