### PR TITLE
fix(args): support using use_branch_tags from both config and args

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -464,6 +464,13 @@ pub fn run(mut args: Opt) -> Result<()> {
 			args.topo_order = topo_order;
 		}
 	}
+
+	if !args.use_branch_tags {
+		if let Some(use_branch_tags) = config.git.use_branch_tags {
+			args.use_branch_tags = use_branch_tags;
+		}
+	}
+
 	if args.github_token.is_some() {
 		config.remote.github.token.clone_from(&args.github_token);
 	}


### PR DESCRIPTION
## Description

 sync use_branch_tags from config to args

## Motivation and Context

i oversighted in #808. the command line argument works but not from the configuration 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
