### PR TITLE
docs(contributing): mention fetching the tags for running tests successfully

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,21 +23,33 @@ git clone https://github.com/{username}/git-cliff && cd git-cliff
 cargo build
 ```
 
-4. Start committing your changes. Follow the [conventional commit specification](https://www.conventionalcommits.org/) while doing so.
-
-5. Add your tests (if you haven't already) or update the existing tests according to the changes. And check if the tests are passed.
+4. Make sure your initial state is successfully prepared by running the tests.
 
 ```sh
 cargo test
 ```
 
-6. If needed, update the snapshot tests (i.e. tests using `expect_test`):
+If you want to execute tests successfully, you need tags in your repository. The easiest way to do this is to fetch tags from the [git-cliff](https://github.com/orhun/git-cliff) repository.
+
+```sh
+git fetch --tags https://github.com/orhun/git-cliff
+```
+
+5. Start committing your changes. Follow the [conventional commit specification](https://www.conventionalcommits.org/) while doing so.
+
+6. Add your tests (if you haven't already) or update the existing tests according to the changes. And check if the tests are passed.
+
+```sh
+cargo test
+```
+
+7. If needed, update the snapshot tests (i.e. tests using `expect_test`):
 
 ```sh
 env UPDATE_EXPECT=1 cargo test
 ```
 
-7. Make sure [rustfmt](https://github.com/rust-lang/rustfmt) and [clippy](https://github.com/rust-lang/rust-clippy) don't complain about your changes.
+8. Make sure [rustfmt](https://github.com/rust-lang/rustfmt) and [clippy](https://github.com/rust-lang/rust-clippy) don't complain about your changes.
 
 We use the `nightly` channel for `rustfmt` so please set the appropriate settings for your editor/IDE for that.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Note that we have a [Code of Conduct](./CODE_OF_CONDUCT.md), please follow it in
 git clone https://github.com/{username}/git-cliff && cd git-cliff
 ```
 
-To ensure the successful execution of the test, it is essential to fetch the tags.
+To ensure the successful execution of the tests, it is essential to fetch the tags as follows:
 
 ```sh
 git fetch --tags https://github.com/orhun/git-cliff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,39 +17,33 @@ Note that we have a [Code of Conduct](./CODE_OF_CONDUCT.md), please follow it in
 git clone https://github.com/{username}/git-cliff && cd git-cliff
 ```
 
+To ensure the successful execution of the test, it is essential to fetch the tags.
+
+```sh
+git fetch --tags https://github.com/orhun/git-cliff
+```
+
 3. Make sure that you have [Rust](https://www.rust-lang.org/) `1.64.0` or later installed and build the project.
 
 ```sh
 cargo build
 ```
 
-4. Make sure your initial state is successfully prepared by running the tests.
+4. Start committing your changes. Follow the [conventional commit specification](https://www.conventionalcommits.org/) while doing so.
+
+5. Add your tests (if you haven't already) or update the existing tests according to the changes. And check if the tests are passed.
 
 ```sh
 cargo test
 ```
 
-If you want to execute tests successfully, you need tags in your repository. The easiest way to do this is to fetch tags from the [git-cliff](https://github.com/orhun/git-cliff) repository.
-
-```sh
-git fetch --tags https://github.com/orhun/git-cliff
-```
-
-5. Start committing your changes. Follow the [conventional commit specification](https://www.conventionalcommits.org/) while doing so.
-
-6. Add your tests (if you haven't already) or update the existing tests according to the changes. And check if the tests are passed.
-
-```sh
-cargo test
-```
-
-7. If needed, update the snapshot tests (i.e. tests using `expect_test`):
+6. If needed, update the snapshot tests (i.e. tests using `expect_test`):
 
 ```sh
 env UPDATE_EXPECT=1 cargo test
 ```
 
-8. Make sure [rustfmt](https://github.com/rust-lang/rustfmt) and [clippy](https://github.com/rust-lang/rust-clippy) don't complain about your changes.
+7. Make sure [rustfmt](https://github.com/rust-lang/rustfmt) and [clippy](https://github.com/rust-lang/rust-clippy) don't complain about your changes.
 
 We use the `nightly` channel for `rustfmt` so please set the appropriate settings for your editor/IDE for that.
 


### PR DESCRIPTION
## Description

Mention in the CONTRIBUTING.md file that tags are necessary for running tests successfully. 

## Motivation and Context

I wanted to contribute to the project, but when I followed the instructions on the contributing page, I didn't realize that some tests required tags in the repositories. When I forked the repository, the tags were usually not included. Following the contributing steps, I noticed that the tests failed after making my changes. I started investigating whether my changes broke the code, and later, I realized that the tests failed because I forked the repository without tags. For this reason, I decided to change the order of operations in contributing.md file to build and run tests before making any changes to verify the initial state. I hope the improved contributing guide will help other contributors avoid repeating my mistakes and struggles. 

## How Has This Been Tested?

Just repeat the steps,

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
