### PR TITLE
refactor(clippy): apply semicolon_if_nothing_returned clippy lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -172,7 +172,7 @@ impl<'a> Changelog<'a> {
 							let skip_tag = r.is_match(version);
 							if skip_tag {
 								skipped_tags.push(version.clone());
-								trace!("Skipping release: {}", version)
+								trace!("Skipping release: {}", version);
 							}
 							skip_tag
 						})
@@ -1082,7 +1082,7 @@ mod test {
 
 		if let Some(parsers) = config.git.commit_parsers.as_mut() {
 			for parser in parsers.iter_mut().filter(|p| p.footer.is_some()) {
-				parser.skip = Some(true)
+				parser.skip = Some(true);
 			}
 		}
 

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -275,7 +275,7 @@ impl Commit<'_> {
 		for parser in parsers {
 			let mut regex_checks = Vec::new();
 			if let Some(message_regex) = parser.message.as_ref() {
-				regex_checks.push((message_regex, self.message.to_string()))
+				regex_checks.push((message_regex, self.message.to_string()));
 			}
 			let body = self
 				.conv
@@ -283,7 +283,7 @@ impl Commit<'_> {
 				.and_then(|v| v.body())
 				.map(|v| v.to_string());
 			if let Some(body_regex) = parser.body.as_ref() {
-				regex_checks.push((body_regex, body.clone().unwrap_or_default()))
+				regex_checks.push((body_regex, body.clone().unwrap_or_default()));
 			}
 			if let (Some(footer_regex), Some(footers)) = (
 				parser.footer.as_ref(),
@@ -489,7 +489,7 @@ mod test {
 			),
 		];
 		for (commit, is_conventional) in &test_cases {
-			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok())
+			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
 		}
 		let commit = test_cases[0].0.clone().parse(
 			&[CommitParser {
@@ -585,7 +585,7 @@ mod test {
 			),
 		];
 		for (commit, is_conventional) in &test_cases {
-			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok())
+			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
 		}
 		let commit = Commit::new(
 			String::from("123123"),

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -301,6 +301,6 @@ mod test {
 		assert_eq!(
 			"https://gitlab.test.com/api/v4/projects/abc%2Fdef%2Fxyz1",
 			GitLabProject::url(1, "https://gitlab.test.com/api/v4", &remote, 0)
-		)
+		);
 	}
 }

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -36,7 +36,7 @@ impl Template {
 				.lines()
 				.map(|v| v.trim())
 				.collect::<Vec<&str>>()
-				.join("\n")
+				.join("\n");
 		}
 		let mut tera = Tera::default();
 		if let Err(e) = tera.add_raw_template("template", &template) {

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -449,7 +449,7 @@ mod tests {
 
 	#[test]
 	fn verify_cli() {
-		Opt::command().debug_assert()
+		Opt::command().debug_assert();
 	}
 
 	#[test]

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -103,7 +103,7 @@ fn process_repository<'a>(
 		let count = count_tags.map_or(true, |r| {
 			let count_tag = r.is_match(name);
 			if count_tag {
-				trace!("Counting release: {}", name)
+				trace!("Counting release: {}", name);
 			}
 			count_tag
 		});
@@ -115,7 +115,7 @@ fn process_repository<'a>(
 
 			let ignore_tag = r.is_match(name);
 			if ignore_tag {
-				trace!("Ignoring release: {}", name)
+				trace!("Ignoring release: {}", name);
 			}
 			ignore_tag
 		});
@@ -239,7 +239,7 @@ fn process_repository<'a>(
 		if let Some(commit_id) = commits.first().map(|c| c.id().to_string()) {
 			match tags.get(&commit_id) {
 				Some(tag) => {
-					warn!("There is already a tag ({:?}) for {}", tag, commit_id)
+					warn!("There is already a tag ({:?}) for {}", tag, commit_id);
 				}
 				None => {
 					tags.insert(commit_id, repository.resolve_tag(tag));
@@ -535,7 +535,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 
 	// Process commits and releases for the changelog.
 	if let Some(BumpOption::Specific(bump_type)) = args.bump {
-		config.bump.bump_type = Some(bump_type)
+		config.bump.bump_type = Some(bump_type);
 	}
 
 	// Generate changelog from context.
@@ -575,7 +575,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 						sha: Some(sha1.to_string()),
 						skip: Some(true),
 						..Default::default()
-					})
+					});
 				}
 			}
 


### PR DESCRIPTION
## Description

Apply [semicolon_if_nothing_returned](https://rust-lang.github.io/rust-clippy/master/index.html#/semicolon_if_nothing_returned) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the `refactor(clippy)` format for my commits, which is omitted from the changelog report. 

I also apply those changes to get more familiar with the project and later I will take some of the open issues.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::semicolon_if_nothing_returned
```
The cargo build and test passed successfully. Standard usage of linter and formatter also passed.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
