### PR TITLE
refactor(clippy): apply unnested_or_patterns clippy lint

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -110,7 +110,7 @@ impl Repository {
 	/// directory.
 	fn normalize_pattern(pattern: Pattern) -> Pattern {
 		let star_added = match pattern.as_str().chars().last() {
-			Some('/') | Some('\\') => Pattern::new(&format!("{pattern}**"))
+			Some('/' | '\\') => Pattern::new(&format!("{pattern}**"))
 				.expect("failed to add '**' to the end of glob"),
 			_ => pattern,
 		};


### PR DESCRIPTION
## Description

Apply [unnested_or_patterns](https://rust-lang.github.io/rust-clippy/master/index.html#/unnested_or_patterns) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

I also apply those changes to get more familiar with the project and later I will take some of the open issues.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::unnested_or_patterns
```
The cargo build and test passed successfully. Standard usage of linter and formatter also passed.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
