### PR TITLE
chore(ci): check pedantic lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
         with:
           command: clippy
           args: --tests --verbose -- -D warnings
+      - name: Check the pedantic lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests --verbose -- -W clippy::pedantic
 
   rustfmt:
     name: Formatting


### PR DESCRIPTION
## Description

Add pedantic lints checking to the CI and do not fail the CI if warnings exist.

## Motivation and Context

It is good to have some reports about pedantic errors at the merging level, especially in pull requests. Now, users can see the quality of their code on a pedantic linter level. 

We are currently resolving many pedantic errors in the existing code in the other MR.

## How Has This Been Tested?

I tested the command manually in the terminal.
I tested the CI in that pull request. If the build passes and we have an extra step in the Lints job with pedantic warnings, that means we have configured the CI correctly.
![image](https://github.com/user-attachments/assets/6fb1cff1-3e34-413e-b0d8-c1d136ddc044)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other  - CI 

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
