### PR TITLE
refactor(clippy): apply redundant_else clippy lint

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -325,13 +325,12 @@ impl Commit<'_> {
 					return Err(AppError::GroupError(String::from(
 						"Skipping commit",
 					)));
-				} else {
-					self.group = parser.group.clone().or(self.group);
-					self.scope = parser.scope.clone().or(self.scope);
-					self.default_scope =
-						parser.default_scope.clone().or(self.default_scope);
-					return Ok(self);
 				}
+				self.group = parser.group.clone().or(self.group);
+				self.scope = parser.scope.clone().or(self.scope);
+				self.default_scope =
+					parser.default_scope.clone().or(self.default_scope);
+				return Ok(self);
 			}
 			for (regex, text) in regex_checks {
 				if regex.is_match(text.trim()) {
@@ -339,21 +338,17 @@ impl Commit<'_> {
 						return Err(AppError::GroupError(String::from(
 							"Skipping commit",
 						)));
-					} else {
-						let regex_replace = |mut value: String| {
-							for mat in regex.find_iter(&text) {
-								value =
-									regex.replace(mat.as_str(), value).to_string();
-							}
-							value
-						};
-						self.group =
-							parser.group.as_ref().cloned().map(regex_replace);
-						self.scope =
-							parser.scope.as_ref().cloned().map(regex_replace);
-						self.default_scope = parser.default_scope.as_ref().cloned();
-						return Ok(self);
 					}
+					let regex_replace = |mut value: String| {
+						for mat in regex.find_iter(&text) {
+							value = regex.replace(mat.as_str(), value).to_string();
+						}
+						value
+					};
+					self.group = parser.group.as_ref().cloned().map(regex_replace);
+					self.scope = parser.scope.as_ref().cloned().map(regex_replace);
+					self.default_scope = parser.default_scope.as_ref().cloned();
+					return Ok(self);
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Apply [redundant_else](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_else) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

I also apply those changes to get more familiar with the project and later I will take some of the open issues.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::redundant_else
```

The cargo build and test passed successfully. Standard usage of linter and formatter also passed.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.