### PR TITLE
refactor(clippy): apply case_sensitive_file_extension_comparisons lint

### DIFF
--- a/git-cliff-core/src/embed.rs
+++ b/git-cliff-core/src/embed.rs
@@ -4,6 +4,7 @@ use crate::error::{
 	Result,
 };
 use rust_embed::RustEmbed;
+use std::path::Path;
 use std::str;
 
 /// Default configuration file embedder/extractor.
@@ -44,7 +45,10 @@ pub struct BuiltinConfig;
 impl BuiltinConfig {
 	/// Extracts the embedded content.
 	pub fn get_config(mut name: String) -> Result<String> {
-		if !name.ends_with(".toml") {
+		if !Path::new(&name)
+			.extension()
+			.map_or(false, |ext| ext.eq_ignore_ascii_case("toml"))
+		{
 			name = format!("{name}.toml");
 		}
 		let contents = match Self::get(&name) {


### PR DESCRIPTION
## Description

Apply [case_sensitive_file_extension_comparisons](https://rust-lang.github.io/rust-clippy/master/index.html#/case_sensitive_file_extension_comparisons) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

I also apply those changes to get more familiar with the project and later I will take some of the open issues.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::case_sensitive_file_extension_comparisons
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
