### PR TITLE
refactor(clippy): apply option_as_ref_cloned lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -154,7 +154,7 @@ impl<'a> Changelog<'a> {
 			.rev()
 			.filter(|release| {
 				if release.commits.is_empty() {
-					if let Some(version) = release.version.as_ref().cloned() {
+					if let Some(version) = release.version.clone() {
 						trace!("Release doesn't have any commits: {}", version);
 					}
 					false

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -347,11 +347,9 @@ impl Commit<'_> {
 							}
 							value
 						};
-						self.group =
-							parser.group.as_ref().cloned().map(regex_replace);
-						self.scope =
-							parser.scope.as_ref().cloned().map(regex_replace);
-						self.default_scope = parser.default_scope.as_ref().cloned();
+						self.group = parser.group.clone().map(regex_replace);
+						self.scope = parser.scope.clone().map(regex_replace);
+						self.default_scope = parser.default_scope.clone();
 						return Ok(self);
 					}
 				}


### PR DESCRIPTION
## Description

Apply [option_as_ref_cloned](https://rust-lang.github.io/rust-clippy/master/index.html#/option_as_ref_cloned) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

I also apply those changes to get more familiar with the project and later I will take some of the open issues.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::option_as_ref_cloned
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
