### PR TITLE
refactor(clippy): apply inefficient_to_string lint

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -327,8 +327,11 @@ impl TextProcessor {
 			*rendered = self.pattern.replace_all(rendered, text).to_string();
 		} else if let Some(command) = &self.replace_command {
 			if self.pattern.is_match(rendered) {
-				*rendered =
-					command::run(command, Some(rendered.to_string()), command_envs)?;
+				*rendered = command::run(
+					command,
+					Some((*rendered).to_string()),
+					command_envs,
+				)?;
 			}
 		}
 		Ok(())

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -191,7 +191,7 @@ mod test {
 				extra: None,
 				commits: commits
 					.iter()
-					.map(|v| Commit::from(v.to_string()))
+					.map(|&v| Commit::from(v.to_string()))
 					.collect(),
 				commit_id: None,
 				timestamp: 0,

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -427,7 +427,7 @@ impl Repository {
 					})?
 					.rev()
 					.collect();
-				if let (Some(owner), Some(repo)) =
+				if let (Some(&owner), Some(&repo)) =
 					(segments.get(1), segments.first())
 				{
 					return Ok(Remote {


### PR DESCRIPTION
## Description

Apply [inefficient_to_string ](https://rust-lang.github.io/rust-clippy/master/index.html#/inefficient_to_string) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::inefficient_to_string
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
