### PR TITLE
refactor(clippy): apply manual_is_variant_and lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -163,16 +163,14 @@ impl<'a> Changelog<'a> {
 					}
 					false
 				} else if let Some(version) = &release.version {
-					!skip_regex
-						.map(|r| {
-							let skip_tag = r.is_match(version);
-							if skip_tag {
-								skipped_tags.push(version.clone());
-								trace!("Skipping release: {}", version);
-							}
-							skip_tag
-						})
-						.unwrap_or_default()
+					!skip_regex.is_some_and(|r| {
+						let skip_tag = r.is_match(version);
+						if skip_tag {
+							skipped_tags.push(version.clone());
+							trace!("Skipping release: {}", version);
+						}
+						skip_tag
+					})
 				} else {
 					true
 				}


### PR DESCRIPTION
## Description

Apply [manual_is_variant_and](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_is_variant_and) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::manual_is_variant_and
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
