### PR TITLE
refactor(clippy): apply assigning_clones lint

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -349,7 +349,7 @@ impl Commit<'_> {
 						};
 						self.group = parser.group.clone().map(regex_replace);
 						self.scope = parser.scope.clone().map(regex_replace);
-						self.default_scope = parser.default_scope.clone();
+						self.default_scope.clone_from(&parser.default_scope);
 						return Ok(self);
 					}
 				}

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -268,7 +268,7 @@ fn process_repository<'a>(
 		release.repository = Some(repository.path.to_string_lossy().into_owned());
 		if let Some(tag) = tags.get(&commit_id) {
 			release.version = Some(tag.name.to_string());
-			release.message = tag.message.clone();
+			release.message.clone_from(&tag.message);
 			release.commit_id = Some(commit_id);
 			release.timestamp = if args.tag.as_deref() == Some(tag.name.as_str()) {
 				match tag_timestamp {


### PR DESCRIPTION
## Description

Apply [assigning_clones](https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:

```sh
cargo clippy --all-targets -- -D warnings -W clippy::assigning_clones
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
