### PR TITLE
refactor(clippy): apply needless_pass_by_value lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -96,7 +96,7 @@ impl<'a> Changelog<'a> {
 
 	/// Processes a single commit and returns/logs the result.
 	fn process_commit(
-		commit: Commit<'a>,
+		commit: &Commit<'a>,
 		git_config: &GitConfig,
 	) -> Option<Commit<'a>> {
 		match commit.process(git_config) {
@@ -122,7 +122,7 @@ impl<'a> Changelog<'a> {
 				.commits
 				.iter()
 				.cloned()
-				.filter_map(|commit| Self::process_commit(commit, &self.config.git))
+				.filter_map(|commit| Self::process_commit(&commit, &self.config.git))
 				.flat_map(|commit| {
 					if self.config.git.split_commits.unwrap_or(false) {
 						commit
@@ -132,7 +132,7 @@ impl<'a> Changelog<'a> {
 								let mut c = commit.clone();
 								c.message = line.to_string();
 								if !c.message.is_empty() {
-									Self::process_commit(c, &self.config.git)
+									Self::process_commit(&c, &self.config.git)
 								} else {
 									None
 								}

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -301,8 +301,8 @@ impl Repository {
 	}
 
 	/// Returns the commit object of the given ID.
-	pub fn find_commit(&self, id: String) -> Option<Commit> {
-		if let Ok(oid) = Oid::from_str(&id) {
+	pub fn find_commit(&self, id: &str) -> Option<Commit> {
+		if let Ok(oid) = Oid::from_str(id) {
 			if let Ok(commit) = self.inner.find_commit(oid) {
 				return Some(commit);
 			}

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -338,7 +338,7 @@ fn process_repository<'a>(
 				commit_id: Some(commit_id.to_string()),
 				version: Some(tag.name.clone()),
 				timestamp: repository
-					.find_commit(commit_id.to_string())
+					.find_commit(commit_id)
 					.map(|v| v.time().seconds())
 					.unwrap_or_default(),
 				..Default::default()


### PR DESCRIPTION
## Description

Apply [needless_pass_by_value](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_value) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::needless_pass_by_value
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
