### PR TITLE
refactor(clippy): apply single_match_else lint

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -425,38 +425,36 @@ impl Serialize for Commit<'_> {
 
 		let mut commit = serializer.serialize_struct("Commit", 9)?;
 		commit.serialize_field("id", &self.id)?;
-		match &self.conv {
-			Some(conv) => {
-				commit.serialize_field("message", conv.description())?;
-				commit.serialize_field("body", &conv.body())?;
-				commit.serialize_field("footers", &SerializeFooters(self))?;
-				commit.serialize_field(
-					"group",
-					self.group.as_ref().unwrap_or(&conv.type_().to_string()),
-				)?;
-				commit.serialize_field(
-					"breaking_description",
-					&conv.breaking_description(),
-				)?;
-				commit.serialize_field("breaking", &conv.breaking())?;
-				commit.serialize_field(
-					"scope",
-					&self
-						.scope
-						.as_deref()
-						.or_else(|| conv.scope().map(|v| v.as_str()))
-						.or(self.default_scope.as_deref()),
-				)?;
-			}
-			None => {
-				commit.serialize_field("message", &self.message)?;
-				commit.serialize_field("group", &self.group)?;
-				commit.serialize_field(
-					"scope",
-					&self.scope.as_deref().or(self.default_scope.as_deref()),
-				)?;
-			}
+		if let Some(conv) = &self.conv {
+			commit.serialize_field("message", conv.description())?;
+			commit.serialize_field("body", &conv.body())?;
+			commit.serialize_field("footers", &SerializeFooters(self))?;
+			commit.serialize_field(
+				"group",
+				self.group.as_ref().unwrap_or(&conv.type_().to_string()),
+			)?;
+			commit.serialize_field(
+				"breaking_description",
+				&conv.breaking_description(),
+			)?;
+			commit.serialize_field("breaking", &conv.breaking())?;
+			commit.serialize_field(
+				"scope",
+				&self
+					.scope
+					.as_deref()
+					.or_else(|| conv.scope().map(|v| v.as_str()))
+					.or(self.default_scope.as_deref()),
+			)?;
+		} else {
+			commit.serialize_field("message", &self.message)?;
+			commit.serialize_field("group", &self.group)?;
+			commit.serialize_field(
+				"scope",
+				&self.scope.as_deref().or(self.default_scope.as_deref()),
+			)?;
 		}
+
 		commit.serialize_field("links", &self.links)?;
 		commit.serialize_field("author", &self.author)?;
 		commit.serialize_field("committer", &self.committer)?;

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -260,21 +260,17 @@ impl Bump {
 	///
 	/// This function also logs the returned value.
 	pub fn get_initial_tag(&self) -> String {
-		match self.initial_tag.clone() {
-			Some(tag) => {
-				warn!(
-					"No releases found, using initial tag '{tag}' as the next \
-					 version."
-				);
-				tag
-			}
-			None => {
-				warn!(
-					"No releases found, using {DEFAULT_INITIAL_TAG} as the next \
-					 version."
-				);
-				DEFAULT_INITIAL_TAG.into()
-			}
+		if let Some(tag) = self.initial_tag.clone() {
+			warn!(
+				"No releases found, using initial tag '{tag}' as the next version."
+			);
+			tag
+		} else {
+			warn!(
+				"No releases found, using {DEFAULT_INITIAL_TAG} as the next \
+				 version."
+			);
+			DEFAULT_INITIAL_TAG.into()
 		}
 	}
 }


### PR DESCRIPTION
## Description

Apply [single_match_else](https://rust-lang.github.io/rust-clippy/master/index.html#/single_match_else) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::single_match_else
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
