### PR TITLE
refactor(clippy): apply if_not_else lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -131,10 +131,10 @@ impl<'a> Changelog<'a> {
 							.filter_map(|line| {
 								let mut c = commit.clone();
 								c.message = line.to_string();
-								if !c.message.is_empty() {
-									Self::process_commit(&c, &self.config.git)
-								} else {
+								if c.message.is_empty() {
 									None
+								} else {
+									Self::process_commit(&c, &self.config.git)
 								}
 							})
 							.collect()

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -355,12 +355,12 @@ impl Commit<'_> {
 				}
 			}
 		}
-		if !filter {
-			Ok(self)
-		} else {
+		if filter {
 			Err(AppError::GroupError(String::from(
 				"Commit does not belong to any group",
 			)))
+		} else {
+			Ok(self)
 		}
 	}
 

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -249,10 +249,10 @@ impl Repository {
 						return 0;
 					}
 					let name = entry.name().expect("failed to get entry name");
-					let entry_path = if dir != "," {
-						format!("{dir}/{name}")
-					} else {
+					let entry_path = if dir == "," {
 						name.to_string()
+					} else {
+						format!("{dir}/{name}")
 					};
 					changed_files.push(entry_path.into());
 					0


### PR DESCRIPTION
## Description

Apply [if_not_else](https://rust-lang.github.io/rust-clippy/master/index.html#/if_not_else) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::if_not_else
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
