### PR TITLE
refactor(clippy): apply map_unwrap_or lint

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -223,8 +223,7 @@ impl<'a> Changelog<'a> {
 				.contains_variable(github::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
-				.map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
+				.is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
 		{
 			warn!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
 			let github_client =
@@ -279,8 +278,7 @@ impl<'a> Changelog<'a> {
 				.contains_variable(gitlab::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
-				.map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
+				.is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
 		{
 			warn!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
 			let gitlab_client =
@@ -343,8 +341,7 @@ impl<'a> Changelog<'a> {
 				.contains_variable(gitea::TEMPLATE_VARIABLES) ||
 			self.footer_template
 				.as_ref()
-				.map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
+				.is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
 		{
 			warn!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
 			let gitea_client =
@@ -394,11 +391,9 @@ impl<'a> Changelog<'a> {
 		if self.config.remote.bitbucket.is_custom ||
 			self.body_template
 				.contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-			self.footer_template
-				.as_ref()
-				.map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
-		{
+			self.footer_template.as_ref().is_some_and(|v| {
+				v.contains_variable(bitbucket::TEMPLATE_VARIABLES)
+			}) {
 			warn!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
 			let bitbucket_client =
 				BitbucketClient::try_from(self.config.remote.bitbucket.clone())?;

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -257,7 +257,7 @@ impl Commit<'_> {
 	/// `false`. Returns `true` otherwise.
 	fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
 		parser.skip.unwrap_or(false) &&
-			!(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) &&
+			!(self.conv.as_ref().is_some_and(|c| c.breaking()) &&
 				protect_breaking)
 	}
 


### PR DESCRIPTION
## Description

Apply [map_unwrap_or](https://rust-lang.github.io/rust-clippy/master/index.html#/map_unwrap_or) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::map_unwrap_or
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
