### PR TITLE
refactor(clippy): apply doc_markdown and ignored_unit_patterns lint

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -327,7 +327,7 @@ pub struct CommitParser {
 	pub pattern:       Option<Regex>,
 }
 
-/// TextProcessor, e.g. for modifying commit messages.
+/// `TextProcessor`, e.g. for modifying commit messages.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextProcessor {
 	/// Regex for matching a text to replace.

--- a/git-cliff-core/src/error.rs
+++ b/git-cliff-core/src/error.rs
@@ -71,7 +71,7 @@ pub enum Error {
 	/// value matchers.
 	#[error("Field error: `{0}`")]
 	FieldError(String),
-	/// Error that may occur while parsing a SemVer version or version
+	/// Error that may occur while parsing a `SemVer` version or version
 	/// requirement.
 	#[error("Semver error: `{0}`")]
 	SemverError(#[from] semver::Error),
@@ -84,7 +84,7 @@ pub enum Error {
 	#[error("HTTP client with middleware error: `{0}`")]
 	#[cfg(feature = "remote")]
 	HttpClientMiddlewareError(#[from] reqwest_middleware::Error),
-	/// A possible error when converting a HeaderValue from a string or byte
+	/// A possible error when converting a `HeaderValue` from a string or byte
 	/// slice.
 	#[error("HTTP header error: `{0}`")]
 	#[cfg(feature = "remote")]

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -135,7 +135,7 @@ pub struct GitLabMergeRequest {
 	pub id:                i64,
 	/// Iid
 	pub iid:               i64,
-	/// ProjectId
+	/// Project Id
 	pub project_id:        i64,
 	/// Title
 	pub title:             String,
@@ -153,7 +153,7 @@ pub struct GitLabMergeRequest {
 	pub merge_commit_sha:  Option<String>,
 	/// Squash Commit Sha
 	pub squash_commit_sha: Option<String>,
-	/// WebUrl
+	/// Web Url
 	pub web_url:           String,
 	/// Labels
 	pub labels:            Vec<String>,

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -310,12 +310,12 @@ impl Repository {
 		None
 	}
 
-	/// Decide whether to include tag
+	/// Decide whether to include tag.
 	///
 	/// `head_commit` is the `latest` commit to generate changelog. It can be a
 	/// branch head or a detached head. `tag_commit` is a tagged commit. If the
-	/// commit is in the descendant graph of the head_commit or is the
-	/// head_commit itself, Changelog should include the tag.
+	/// commit is in the descendant graph of the `head_commit` or is the
+	/// `head_commit` itself, Changelog should include the tag.
 	fn should_include_tag(
 		&self,
 		head_commit: &Commit,

--- a/git-cliff/src/bin/completions.rs
+++ b/git-cliff/src/bin/completions.rs
@@ -9,7 +9,7 @@ use std::io::Result;
 
 /// Shell completions can be created with:
 /// `cargo run --bin git-cliff-completions`
-/// in a directory specified by the environment variable OUT_DIR.
+/// in a directory specified by the environment variable `OUT_DIR`.
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
 	let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");

--- a/git-cliff/src/bin/mangen.rs
+++ b/git-cliff/src/bin/mangen.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 /// Man page can be created with:
 /// `cargo run --bin git-cliff-mangen`
-/// in a directory specified by the environment variable OUT_DIR.
+/// in a directory specified by the environment variable `OUT_DIR`.
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
 	let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");

--- a/git-cliff/src/main.rs
+++ b/git-cliff/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
 
 	// Run git-cliff
 	let exit_code = match git_cliff::run(args) {
-		Ok(_) => 0,
+		Ok(()) => 0,
 		Err(e) => {
 			log::error!("{}", e);
 			1


### PR DESCRIPTION
## Description

Apply [doc_markdown](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_markdown) clippy lint from the pedantic group. Also Apply [ignored_unit_patterns](https://rust-lang.github.io/rust-clippy/master/index.html#/ignored_unit_patterns) clippy lint from the pedantic group.

## Motivation and Context

Some of the checks from pedantic group are very useful to apply into the project. I will select the useful ones, and apply each to own MR, for maintainer to easy see the changes and easier decided which he want to apply and which not.
I think it's useful to apply them every once in a while, but not to use them by default.

I use the refactor(clippy) format for my commits, which is omitted from the changelog report.

## How Has This Been Tested?

I ran the specific lint checks and solved the problem until the linter no longer told me any issue.
Command:
```sh
cargo clippy --all-targets -- -D warnings -W clippy::doc_markdown
```
and
```sh
cargo clippy --all-targets -- -D warnings -W clippy::ignored_unit_patterns
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
