### PR TITLE
docs(website): add conversion to pdf to tips-and-tricks

### DIFF
--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -90,3 +90,15 @@ commit_parsers = [
 ```jinja2
 {{ get_env(name="CI_PROJECT_URL") }}/-/tags/{{ version }}
 ```
+
+## Convert the markdown output to pdf
+
+```bash
+pandoc --from=gfm --to=pdf -o CHANGELOG.pdf CHANGELOG.md
+```
+
+To support unicode characters use `xelatex` as pdf engine and a font family which includes the needed unicode characters
+
+```bash
+pandoc --from=gfm --to=pdf --pdf-engine=xelatex -o CHANGELOG.pdf CHANGELOG.md --variable mainfont="Segoe UI Emoji"
+```

--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -91,7 +91,7 @@ commit_parsers = [
 {{ get_env(name="CI_PROJECT_URL") }}/-/tags/{{ version }}
 ```
 
-## Convert the markdown output to pdf
+## Convert markdown output to PDF
 
 ```bash
 pandoc --from=gfm --to=pdf -o CHANGELOG.pdf CHANGELOG.md

--- a/website/docs/tips-and-tricks.md
+++ b/website/docs/tips-and-tricks.md
@@ -97,7 +97,7 @@ commit_parsers = [
 pandoc --from=gfm --to=pdf -o CHANGELOG.pdf CHANGELOG.md
 ```
 
-To support unicode characters use `xelatex` as pdf engine and a font family which includes the needed unicode characters
+To support unicode characters, use `xelatex` as PDF engine and a font family which includes the needed unicode characters:
 
 ```bash
 pandoc --from=gfm --to=pdf --pdf-engine=xelatex -o CHANGELOG.pdf CHANGELOG.md --variable mainfont="Segoe UI Emoji"


### PR DESCRIPTION
## Description

Using `pandoc` as separate command, the markdown output can be converted to pdf

## Motivation and Context

If you need to share the changelog as pdf this could be handy
