### PR TITLE
chore(ci): update pedantic lint command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,24 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --tests --verbose -- -W clippy::pedantic
+          args: --all-targets --verbose -- -W clippy::pedantic \
+                -A clippy::needless_raw_string_hashes \
+                -A clippy::unreadable_literal \
+                -A clippy::redundant_else \
+                -A clippy::items_after_statements \
+                -A clippy::missing_errors_doc \
+                -A clippy::module_name_repetitions \
+                -A clippy::uninlined_format_args \
+                -A clippy::manual_string_new \
+                -A clippy::must_use_candidate \
+                -A clippy::too_many_lines \
+                -A clippy::wildcard_imports \
+                -A clippy::missing_panics_doc  \
+                -A clippy::inefficient_to_string \
+                -A clippy::redundant_closure_for_method_calls \
+                -A clippy::map_unwrap_or \
+                -A clippy::struct_excessive_bools \
+                -A clippy::unnecessary_wraps
 
   rustfmt:
     name: Formatting


### PR DESCRIPTION
## Description

Update the Pedantic lint command in CI to have fewer warnings.

## Motivation and Context

We are addressing some of the pedantic warnings and ignoring others (based on preferences). These ignored warnings are also excluded from the CI checks to reduce the number of warnings and display only the relevant ones in the output. 

## How Has This Been Tested?

I tested the command manually in the terminal.
I tested the CI in that pull request

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other - CI

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
