### PR TITLE
feat: jujustu support

### DIFF
--- a/website/docs/usage/jujutsu.md
+++ b/website/docs/usage/jujutsu.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 12
+---
+
+# Jujutsu
+
+You can use with a repository that has been cloned using [jujutsu](https://martinvonz.github.io/jj/latest/).
+
+## Colocated
+
+If the repository was cloned by `jujutsu` using the `--colocate` option, then all you need to do is make sure that
+you have checked out your mainline branch using git.
+If you don't, then you will likely see an error about an unborn branch.
+
+## Non-colocated
+
+If the repository was cloned by `jujutsu` but *not* using the `--colocate` option,
+then the Git repository, normally the `.git` directory, is located in `.jj/repo/store/git`
+
+Create a file in the root of your repository that tells Git, and `git-cliff` where the Git repository is
+and update the `HEAD` to point to your main remote branch:
+
+e.g.:
+
+```bash
+jj git clone https://github.com/orhun/menyoki
+cd menyoki
+echo "gitdir: .jj/repo/store/git" > .git
+echo "ref: refs/remotes/origin/master" > .jj/repo/store/git/HEAD
+```
+
+N.B.: Replace `master` in the last command with the name of your main remote branch. e.g. `main`, `trunk`, etc.
+


### PR DESCRIPTION
## Description

Adds support for opening the Git repository used when a repository is cloned using Jujutsu and the `--colocate` option was *NOT* used.

Note: this requires that the user updates the `HEAD` of the git repository to point to their mainline branch, as the Git repository the Jujutsu creates isn't 100% configured.

If the .git directory can't be opened (usually because the `.git` directory is missing) it attempts to find the git repository in the location used by Jujutsu (i.e. `.jj/repo/store/git`). If the Jujutsu git directory doesn't exist, then the origin error is propogated.

## Motivation and Context

Jujutsu is a Version Control System that uses Git as it's local store, and can work as an effective replacement for Git on a Developer's workstation.

When a Git repository is cloned by Jujutsu, the default location for the Git respository files is `.jj/repo/store/git`, rather than the usual `.git`. `git-cliff` expectes the `.git` location. This PR teaches `git-cliff` to also check the `.jj/repo/store/git` location.

Closes #875

## How Has This Been Tested?

### Test with Jujutsu repository:

- Cloned a Git repository using Jujutsu: `jj git clone git@git.kemitix.net:kemitix/git-next.git && cd git-next`
- Update the HEAD to point to the remote `main` branch: `echo 'ref: refs/remotes/origin/main`
- Run `git-cliff`: `../git-cliff/target/debug/git-cliff`

### Regression test with a Git repository:

- Cloned a Git repository using Jujutsu: `git clone git@git.kemitix.net:kemitix/git-next.git git-next-git && cd git-next-git`
- Run `git-cliff`: `../git-cliff/target/debug/git-cliff`

## Screenshots / Logs (if applicable)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
