### PR TITLE
fix: don't create regex inside a loop

### DIFF
--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -266,6 +266,11 @@ fn generate_changelog() -> Result<()> {
 	let template = Template::new("test", changelog_config.body.unwrap(), false)?;
 
 	writeln!(out, "{}", changelog_config.header.unwrap()).unwrap();
+	let text_processors = [TextProcessor {
+		pattern:         Regex::new("<DATE>").unwrap(),
+		replace:         Some(String::from("2023")),
+		replace_command: None,
+	}];
 	for release in releases {
 		write!(
 			out,
@@ -273,11 +278,7 @@ fn generate_changelog() -> Result<()> {
 			template.render(
 				&release,
 				Option::<HashMap<&str, String>>::None.as_ref(),
-				&[TextProcessor {
-					pattern:         Regex::new("<DATE>").unwrap(),
-					replace:         Some(String::from("2023")),
-					replace_command: None,
-				}]
+				&text_processors
 			)?
 		)
 		.unwrap();


### PR DESCRIPTION
## Description

Moves the creation of an array of `TextProcessor` objects, that includes the contruction of a `Regex` to the outside of a loop. The array is only ever user by reference, so reusing a single instance will produce the same effects.

## Motivation and Context

The Lints CI check is failing due to the creation of the same Regex within a loop.

## How Has This Been Tested?

The change is within the integration tests, and those continue to pass.

## Screenshots / Logs (if applicable)

<img width="863" alt="image" src="https://github.com/user-attachments/assets/30945a4d-65fd-4624-a40d-6a2ccff75982">

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [ ] ~I have updated the documentation accordingly.~
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
