### PR TITLE
fix(remote) Fix detection of GitLab merge request sha

### DIFF
--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -170,7 +170,7 @@ impl RemotePullRequest for GitLabMergeRequest {
 	}
 
 	fn merge_commit(&self) -> Option<String> {
-		self.merge_commit_sha.clone()
+		self.merge_commit_sha.clone().or(Some(self.sha.clone()))
 	}
 }
 
@@ -309,5 +309,14 @@ mod test {
 		};
 
 		assert_eq!(Some(1626610479), remote_commit.timestamp());
+	}
+
+	#[test]
+	fn merge_request_no_merge_commit() {
+		let mr = GitLabMergeRequest {
+			sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+			..Default::default()
+		};
+		assert!(mr.merge_commit().is_some());
 	}
 }


### PR DESCRIPTION
## Description

`GitLabMergeRequest::merge_commit()` now returns the commit's sha instead of `None` if the Merge Request was not merged using a merge commit but with fast-forward. 

## Motivation and Context

In the generation of the changelog commits were not linked to their GitLab MR if the commit was merged using fast-forward.
This change allows to identify the corresponding GitLab MR independently if the MR was merged with a merge commit or with fast-forward.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests are sufficient and still pass.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. [imho not necessary]
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
