### PR TITLE
doc: add installation instruction

### DIFF
--- a/website/docs/installation/index.md
+++ b/website/docs/installation/index.md
@@ -3,6 +3,11 @@ sidebar_position: 2
 ---
 # Installation
 
+```bash
+# install using pip
+pip install git-cliff
+```
+
 <details>
   <summary>Packaging status</summary>
 


### PR DESCRIPTION
## Description

Add an instruction to install using `pip`. 
## Motivation and Context

No installation instructions have been given on the installation page. In the Github readme page, I follow `Installation` link, but only `Packaging status` is given.

## How Has This Been Tested?

```
pip install git-cliff
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
