### PR TITLE
feat(cli): add synergy between init and config flags

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -380,7 +380,7 @@ pub fn run(mut args: Opt) -> Result<()> {
 			None => EmbeddedConfig::get_config()?,
 		};
 
-		let output_path = if args.config == PathBuf::from(DEFAULT_CONFIG) {
+		let config_path = if args.config == PathBuf::from(DEFAULT_CONFIG) {
 			PathBuf::from(DEFAULT_CONFIG)
 		} else {
 			args.config.clone()
@@ -389,9 +389,9 @@ pub fn run(mut args: Opt) -> Result<()> {
 		info!(
 			"Saving the configuration file{} to {:?}",
 			init_config.map(|v| format!(" ({v})")).unwrap_or_default(),
-			output_path
+			config_path
 		);
-		fs::write(output_path, contents)?;
+		fs::write(config_path, contents)?;
 		return Ok(());
 	}
 

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -47,7 +47,10 @@ use std::fs::{
 	File,
 };
 use std::io;
-use std::path::Path;
+use std::path::{
+	Path,
+	PathBuf,
+};
 use std::time::{
 	SystemTime,
 	UNIX_EPOCH,
@@ -376,12 +379,19 @@ pub fn run(mut args: Opt) -> Result<()> {
 			Some(ref name) => BuiltinConfig::get_config(name.to_string())?,
 			None => EmbeddedConfig::get_config()?,
 		};
+
+		let output_path = if args.config == PathBuf::from(DEFAULT_CONFIG) {
+			PathBuf::from(DEFAULT_CONFIG)
+		} else {
+			args.config.clone()
+		};
+
 		info!(
 			"Saving the configuration file{} to {:?}",
 			init_config.map(|v| format!(" ({v})")).unwrap_or_default(),
-			DEFAULT_CONFIG
+			output_path
 		);
-		fs::write(DEFAULT_CONFIG, contents)?;
+		fs::write(output_path, contents)?;
 		return Ok(());
 	}
 

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -100,15 +100,3 @@ Skip running the commands defined in [pre](/docs/configuration/git#commit_prepro
 # No external command execution
 git cliff --no-exec
 ```
-
-Write default config to cliff.toml:
-
-```bash
-git-cliff --init
-```
-
-Write default config to custom path:
-
-```bash
-git-cliff --config custom.toml --init
-```

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -100,3 +100,15 @@ Skip running the commands defined in [pre](/docs/configuration/git#commit_prepro
 # No external command execution
 git cliff --no-exec
 ```
+
+Write default config to cliff.toml:
+
+```bash
+git-cliff --init
+```
+
+Write default config to custom path:
+
+```bash
+git-cliff --config custom.toml --init
+```

--- a/website/docs/usage/initializing.md
+++ b/website/docs/usage/initializing.md
@@ -9,6 +9,9 @@ The default [configuration file](/docs/configuration) (`cliff.toml`) can be gene
 ```bash
 # create cliff.toml
 git cliff --init
+
+# create a config file with a custom name
+git-cliff --init --config custom.toml
 ```
 
 There are also other templates under the [examples](https://github.com/orhun/git-cliff/blob/main/examples) directory. See the [template examples](/docs/templating/examples) for previewing the templates.


### PR DESCRIPTION
## Description
Allow user to define init file by passing `--config` alongside to `--init` 
closes #932 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran locally using `--init` and `--config` flags together as well as separate to make sure there where no breaking changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)
![image](https://github.com/user-attachments/assets/88d83930-3a54-4d52-b0b3-2b6d1bf6c7f2)
![image](https://github.com/user-attachments/assets/5f953246-6159-447a-8ca7-cf5dbec6338a)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
