### PR TITLE
fix(monorepo): do not set include-path if workdir is set

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -220,7 +220,10 @@ fn process_repository<'a>(
 	if let Some(mut path_diff) =
 		pathdiff::diff_paths(env::current_dir()?, repository.path())
 	{
-		if include_path.is_none() && path_diff != Path::new("") {
+		if args.workdir.is_none() &&
+			include_path.is_none() &&
+			path_diff != Path::new("")
+		{
 			info!(
 				"Including changes from the current directory: {:?}",
 				path_diff.display()


### PR DESCRIPTION
## Motivation and Context

Fixes #996

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
