### PR TITLE
fix(remote): Fix detection of GitLab merge request sha if commits were squashed

### DIFF
--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -170,7 +170,10 @@ impl RemotePullRequest for GitLabMergeRequest {
 	}
 
 	fn merge_commit(&self) -> Option<String> {
-		self.merge_commit_sha.clone().or(Some(self.sha.clone()))
+		self.merge_commit_sha
+			.clone()
+			.or(self.squash_commit_sha.clone())
+			.or(Some(self.sha.clone()))
 	}
 }
 
@@ -315,6 +318,17 @@ mod test {
 	fn merge_request_no_merge_commit() {
 		let mr = GitLabMergeRequest {
 			sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+			..Default::default()
+		};
+		assert!(mr.merge_commit().is_some());
+	}
+
+	#[test]
+	fn merge_request_squash_commit() {
+		let mr = GitLabMergeRequest {
+			squash_commit_sha: Some(String::from(
+				"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+			)),
 			..Default::default()
 		};
 		assert!(mr.merge_commit().is_some());


### PR DESCRIPTION
## Description

`GitLabMergeRequest::merge_commit()` now returns the `squash_commit_sha` instead of None if the commits where squashed in the Merge Request.

## Motivation and Context

In the generation of the changelog commits were not linked to their GitLab MR if the commits were squashed.
This change allows to identify the corresponding GitLab MR independently if the commit in the MR were squashed or not.

## How Has This Been Tested?

Unittest added.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly. [imho not necessary]
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
