### PR TITLE
fix(git): handle worktrees while retrieving the path of repository

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -12,6 +12,7 @@ use git2::{
 	Repository as GitRepository,
 	Sort,
 	TreeWalkMode,
+	Worktree,
 };
 use glob::Pattern;
 use indexmap::IndexMap;
@@ -76,12 +77,17 @@ impl Repository {
 	}
 
 	/// Returns the path of the repository.
-	pub fn path(&self) -> PathBuf {
-		let mut path = self.inner.path().to_path_buf();
+	pub fn path(&self) -> Result<PathBuf> {
+		let mut path = if self.inner.is_worktree() {
+			let worktree = Worktree::open_from_repository(&self.inner)?;
+			worktree.path().to_path_buf()
+		} else {
+			self.inner.path().to_path_buf()
+		};
 		if path.ends_with(".git") {
 			path.pop();
 		}
-		path
+		Ok(path)
 	}
 
 	/// Sets the range for the commit search.

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -221,7 +221,7 @@ fn process_repository<'a>(
 	// Include only the current directory if not running from the root repository
 	let mut include_path = args.include_path.clone();
 	if let Some(mut path_diff) =
-		pathdiff::diff_paths(env::current_dir()?, repository.path())
+		pathdiff::diff_paths(env::current_dir()?, repository.path()?)
 	{
 		if args.workdir.is_none() &&
 			include_path.is_none() &&
@@ -272,12 +272,13 @@ fn process_repository<'a>(
 	// Process releases.
 	let mut previous_release = Release::default();
 	let mut first_processed_tag = None;
+	let repository_path = repository.path()?.to_string_lossy().into_owned();
 	for git_commit in commits.iter().rev() {
 		let release = releases.last_mut().unwrap();
 		let commit = Commit::from(git_commit);
 		let commit_id = commit.id.to_string();
 		release.commits.push(commit);
-		release.repository = Some(repository.path().to_string_lossy().into_owned());
+		release.repository = Some(repository_path.clone());
 		if let Some(tag) = tags.get(&commit_id) {
 			release.version = Some(tag.name.to_string());
 			release.message.clone_from(&tag.message);


### PR DESCRIPTION
## Description

Now we take worktrees into account while retrieving the path of the repositories.

## Motivation and Context

Closes #1052

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
