### PR TITLE
refactor: use IOError::other

### DIFF
--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use std::io::{
 	Error as IoError,
-	ErrorKind as IoErrorKind,
 	Write,
 };
 use std::process::{
@@ -42,9 +41,10 @@ pub fn run(
 			.spawn()
 	}?;
 	if let Some(input) = input {
-		let mut stdin = child.stdin.take().ok_or_else(|| {
-			IoError::new(IoErrorKind::Other, "stdin is not captured")
-		})?;
+		let mut stdin = child
+			.stdin
+			.take()
+			.ok_or_else(|| IoError::other("stdin is not captured"))?;
 		thread::spawn(move || {
 			stdin
 				.write_all(input.as_bytes())
@@ -61,11 +61,10 @@ pub fn run(
 				log::error!("{}", output);
 			}
 		}
-		Err(IoError::new(
-			IoErrorKind::Other,
-			format!("command exited with {:?}", output.status),
+		Err(
+			IoError::other(format!("command exited with {:?}", output.status))
+				.into(),
 		)
-		.into())
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes the following linter error:

```
error: this can be `std::io::Error::other(_)`
  --> git-cliff-core/src/command.rs:46:4
   |
46 |             IoError::new(IoErrorKind::Other, "stdin is not captured")
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
   = note: `-D clippy::io-other-error` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::io_other_error)]`
help: use `std::io::Error::other`
   |
46 -             IoError::new(IoErrorKind::Other, "stdin is not captured")
46 +             IoError::other("stdin is not captured")
   |

error: this can be `std::io::Error::other(_)`
  --> git-cliff-core/src/command.rs:64:7
   |
64 |           Err(IoError::new(
   |  _____________^
65 | |             IoErrorKind::Other,
66 | |             format!("command exited with {:?}", output.status),
67 | |         )
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error

error: could not compile `git-cliff-core` (lib) due to 2 previous errors
```

## Motivation and Context

Resolve linter errors.

## How Has This Been Tested?

Existing test suite.

## Screenshots / Logs (if applicable)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
