### PR TITLE
feat: add option git.require-grouped

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -145,6 +145,7 @@ impl<'a> Changelog<'a> {
 						vec![commit]
 					}
 				})
+				.filter(|commit| !commit.is_skipped)
 				.collect::<Vec<Commit>>();
 		});
 


### PR DESCRIPTION
## Description

Adds a new option `git.require-grouped`. When this option is set to `true`, all commits contained within the changelog *must* be assigned to a group via `CommitParser`. If any ungrouped commit is found, an error is logged and changelog generation fails.

The check happens after running the `CommitParsers`. Thus it is still possible to intentionally skip commits.

## Motivation and Context

Just like #1061, this option aids in enforcing contribution guidelines by preventing the use of unsupported groups or scopes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
