### PR TITLE
fix(fixtures): evaluate the rc of git-cliff correctly

### DIFF
--- a/.github/actions/run-fixtures-test/action.yml
+++ b/.github/actions/run-fixtures-test/action.yml
@@ -39,13 +39,14 @@ runs:
 
     - name: Generate a changelog
       working-directory: ${{ inputs.fixtures-dir }}
+      shell: bash
       run: |
-        git cliff --config cliff.toml ${{ inputs.command }} > output.md || true
+        set +e
+        git cliff --config cliff.toml ${{ inputs.command }} > output.md
         echo "$?" > output.rc
         if [ -f output.md ]; then
           cat output.md
         fi
-      shell: bash
 
     - name: Compare the output with the expected output
       working-directory: ${{ inputs.fixtures-dir }}
@@ -67,7 +68,7 @@ runs:
       shell: bash
       run: |
         if [ -f expected.rc ]; then
-          if ! diff --strip-trailing-cr output.rc expected.rc; then
+          if ! diff --strip-trailing-cr --ignore-all-space output.rc expected.rc; then
             echo "The return code does not match the expected return code."
             exit 1
           fi

--- a/.github/fixtures/test-require-conventional-skipped/cliff.toml
+++ b/.github/fixtures/test-require-conventional-skipped/cliff.toml
@@ -45,7 +45,8 @@ require_conventional = true
 # Assigns commits to groups.
 # Optionally sets the commit's scope and can decide to exclude commits from further processing.
 commit_parsers = [
-    { message = "^feat", group = "Features", default_scope = "app", skip = true },
+    { message = "^feat", group = "Features", default_scope = "app" },
+    { message = "^fix", group = "Bug Fixes", skip = true },
     { message = "Initial commit", skip = true },
 ]
 # Prevent commits that are breaking from being excluded by commit parsers.

--- a/.github/fixtures/test-require-conventional-skipped/commit.sh
+++ b/.github/fixtures/test-require-conventional-skipped/commit.sh
@@ -3,7 +3,7 @@ set -e
 
 GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit --allow-empty -m "Initial commit"
 GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit --allow-empty -m "feat: add feature 1"
-GIT_COMMITTER_DATE="2022-04-06 01:25:10" git commit --allow-empty -m "fix!: fix feature 1"
+GIT_COMMITTER_DATE="2022-04-06 01:25:10" git commit --allow-empty -m "fix: fix feature 1"
 GIT_COMMITTER_DATE="2022-04-06 01:25:11" git commit --allow-empty -m "feat(gui)!: add feature 2"
 GIT_COMMITTER_DATE="2022-04-06 01:25:12" git commit --allow-empty -m "fix(gui)!: fix feature 2"
 

--- a/.github/fixtures/test-require-conventional-skipped/expected.md
+++ b/.github/fixtures/test-require-conventional-skipped/expected.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-#### Cli
+#### Gui
 
-- Fix feature 1
 - Fix feature 2
 
 ### Features
+
+#### App
+
+- Add feature 1
 
 #### Gui
 


### PR DESCRIPTION
## Description

Fixes the test fixtures for #1061.

## Motivation and Context

#1061 changed the fixtures system to allow checking git-cliff's return code. This unintentionally broke all fixtures. The problem was caused by GitHub running all bash scripts with `set -e` by default, leading to any failing command failing the entire script. I circumvented this by appending the git-cliff command with `|| true`, thereby breaking the subsequent checks.

This PR fixes the problem by adding `set +e` prior to running git-cliff, thus allowing evaluation of its rc as intended.

Additionally it fixes the fixture `test-require-conventional-skipped`. This fixture never worked right, but was deemed successful due to the bug.

## How Has This Been Tested?

Running fixtures locally and in GitHub actions.

## Screenshots / Logs (if applicable)

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
