### PR TITLE
feat: support skipping based on blame.ignoreRevsFile

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -725,6 +725,7 @@ mod test {
 				filter_unconventional:    Some(false),
                 blame_ignore_revs_file:   Some(BLAME_IGNORE_FILE.to_string()),
 				filter_blame_ignored_revs:                Some(false),
+				filter_mono_commits_to_blame_ignore_file: Some(true),
 				split_commits:            Some(false),
 				commit_preprocessors:     Some(vec![TextProcessor {
 					pattern:         Regex::new("<preprocess>")

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -686,6 +686,7 @@ mod test {
 		RemoteConfig,
 		TextProcessor,
 	};
+	use crate::BLAME_IGNORE_FILE;
 	use pretty_assertions::assert_eq;
 	use regex::Regex;
 	use std::str;
@@ -722,6 +723,8 @@ mod test {
 				conventional_commits:     Some(true),
 				require_conventional:     Some(false),
 				filter_unconventional:    Some(false),
+                blame_ignore_revs_file:   Some(BLAME_IGNORE_FILE.to_string()),
+				filter_blame_ignored_revs:                Some(false),
 				split_commits:            Some(false),
 				commit_preprocessors:     Some(vec![TextProcessor {
 					pattern:         Regex::new("<preprocess>")

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -96,6 +96,13 @@ pub struct GitConfig {
 	/// Exclude commits that do not match the conventional commits specification
 	/// from the changelog.
 	pub filter_unconventional: Option<bool>,
+
+	/// Path to a file containing revision hashes to ignore when blaming
+	/// This is typically configured with `git config blame.ignoreRevsFile`
+	pub blame_ignore_revs_file:                   Option<String>,
+	/// Exclude commits with refs in the `blame_ignore_revs_file`
+	pub filter_blame_ignored_revs:                Option<bool>,
+
 	/// Split commits on newlines, treating each line as an individual commit.
 	pub split_commits:         Option<bool>,
 

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -102,6 +102,8 @@ pub struct GitConfig {
 	pub blame_ignore_revs_file:                   Option<String>,
 	/// Exclude commits with refs in the `blame_ignore_revs_file`
 	pub filter_blame_ignored_revs:                Option<bool>,
+	/// Exclude commits that only modify the `blame_ignore_revs_file`
+	pub filter_mono_commits_to_blame_ignore_file: Option<bool>,
 
 	/// Split commits on newlines, treating each line as an individual commit.
 	pub split_commits:         Option<bool>,

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -49,3 +49,5 @@ pub const DEFAULT_CONFIG: &str = "cliff.toml";
 pub const DEFAULT_OUTPUT: &str = "CHANGELOG.md";
 /// Default ignore file.
 pub const IGNORE_FILE: &str = ".cliffignore";
+/// Default blame ignore file.
+pub const BLAME_IGNORE_FILE: &str = ".git-blame-ignore-revs";

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -221,7 +221,7 @@ impl Repository {
 	///
 	/// If the cache is not found, it calculates the changed files and adds them
 	/// to the cache via [`Self::commit_changed_files_no_cache`].
-	fn commit_changed_files(&self, commit: &Commit) -> Vec<PathBuf> {
+	pub fn commit_changed_files(&self, commit: &Commit) -> Vec<PathBuf> {
 		// Cache key is generated from the repository path and commit id
 		let cache_key = format!("commit_id:{}", commit.id());
 

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -46,14 +46,14 @@ fn generate_changelog() -> Result<()> {
 		output:         None,
 	};
 	let git_config = GitConfig {
-		conventional_commits: Some(true),
-		require_conventional: Some(false),
-		filter_unconventional: Some(true),
-		blame_ignore_revs_file: Some(String::from(BLAME_IGNORE_FILE)),
-		filter_blame_ignored_revs: Some(false),
-		filter_mono_commits_to_blame_ignore_file: Some(true),
-		split_commits: Some(false),
-		commit_preprocessors: Some(vec![TextProcessor {
+		conventional_commits:                     Some(true),
+		require_conventional:                     Some(false),
+		filter_unconventional:                    Some(true),
+        blame_ignore_revs_file:                   Some(String::from(BLAME_IGNORE_FILE)),
+		filter_blame_ignored_revs:                Some(false),
+        filter_mono_commits_to_blame_ignore_file: Some(true),
+		split_commits:                            Some(false),
+		commit_preprocessors:                     Some(vec![TextProcessor {
 			pattern:         Regex::new(r"\(fixes (#[1-9]+)\)").unwrap(),
 			replace:         Some(String::from("[closes Issue${1}]")),
 			replace_command: None,

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -12,6 +12,7 @@ use git_cliff_core::config::{
 use git_cliff_core::error::Result;
 use git_cliff_core::release::*;
 use git_cliff_core::template::Template;
+use git_cliff_core::BLAME_IGNORE_FILE;
 use pretty_assertions::assert_eq;
 use regex::Regex;
 use std::collections::HashMap;
@@ -45,16 +46,19 @@ fn generate_changelog() -> Result<()> {
 		output:         None,
 	};
 	let git_config = GitConfig {
-		conventional_commits:     Some(true),
-		require_conventional:     Some(false),
-		filter_unconventional:    Some(true),
-		split_commits:            Some(false),
-		commit_preprocessors:     Some(vec![TextProcessor {
+		conventional_commits: Some(true),
+		require_conventional: Some(false),
+		filter_unconventional: Some(true),
+		blame_ignore_revs_file: Some(String::from(BLAME_IGNORE_FILE)),
+		filter_blame_ignored_revs: Some(false),
+		filter_mono_commits_to_blame_ignore_file: Some(true),
+		split_commits: Some(false),
+		commit_preprocessors: Some(vec![TextProcessor {
 			pattern:         Regex::new(r"\(fixes (#[1-9]+)\)").unwrap(),
 			replace:         Some(String::from("[closes Issue${1}]")),
 			replace_command: None,
 		}]),
-		commit_parsers:           Some(vec![
+		commit_parsers: Some(vec![
 			CommitParser {
 				sha:           Some(String::from("coffee")),
 				message:       None,
@@ -117,15 +121,15 @@ fn generate_changelog() -> Result<()> {
 			},
 		]),
 		protect_breaking_commits: None,
-		filter_commits:           Some(true),
-		tag_pattern:              None,
-		skip_tags:                None,
-		ignore_tags:              None,
-		count_tags:               None,
-		use_branch_tags:          None,
-		topo_order:               None,
-		sort_commits:             None,
-		link_parsers:             Some(vec![
+		filter_commits: Some(true),
+		tag_pattern: None,
+		skip_tags: None,
+		ignore_tags: None,
+		count_tags: None,
+		use_branch_tags: None,
+		topo_order: None,
+		sort_commits: None,
+		link_parsers: Some(vec![
 			LinkParser {
 				pattern: Regex::new("#(\\d+)").unwrap(),
 				href:    String::from("https://github.com/$1"),
@@ -137,7 +141,7 @@ fn generate_changelog() -> Result<()> {
 				text:    Some(String::from("$1")),
 			},
 		]),
-		limit_commits:            None,
+		limit_commits: None,
 	};
 
 	let mut commit_with_author = Commit::new(

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -37,6 +37,7 @@ use git_cliff_core::error::{
 use git_cliff_core::release::Release;
 use git_cliff_core::repo::Repository;
 use git_cliff_core::{
+	BLAME_IGNORE_FILE,
 	DEFAULT_CONFIG,
 	IGNORE_FILE,
 };
@@ -654,6 +655,16 @@ pub fn run_with_changelog_modifier(
 			let ignore_file = repository.join(IGNORE_FILE);
 			if ignore_file.exists() {
 				let contents = fs::read_to_string(ignore_file)?;
+				let commits = contents
+					.lines()
+					.filter(|v| !(v.starts_with('#') || v.trim().is_empty()))
+					.map(|v| String::from(v.trim()))
+					.collect::<Vec<String>>();
+				skip_list.extend(commits);
+			}
+			let blame_ignore_file = repository.join(BLAME_IGNORE_FILE);
+			if blame_ignore_file.exists() {
+				let contents = fs::read_to_string(blame_ignore_file)?;
 				let commits = contents
 					.lines()
 					.filter(|v| !(v.starts_with('#') || v.trim().is_empty()))

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -9,6 +9,7 @@ filter_unconventional = true
 require_conventional = false
 blame_ignore_revs_file = ".git-blame-ignore-revs"
 filter_blame_ignored_revs = false
+filter_mono_commits_to_blame_ignore_file = true
 split_commits = false
 commit_parsers = [
     { message = "^feat", group = "Features"},
@@ -117,6 +118,16 @@ If set to `true`, commits that are listed in the `blame_ignore_revs_file` will b
 [git]
 blame_ignore_revs_file = ".git-blame-ignore-revs"
 filter_blame_ignored_revs = false
+```
+
+### filter_mono_commits_to_blame_ignore_file
+
+If set to `true`, commits that only modify the `blame_ignore_revs_file` will be excluded from the changelog.
+
+```toml
+[git]
+blame_ignore_revs_file = ".git-blame-ignore-revs"
+filter_mono_commits_to_blame_ignore_file = true
 ```
 
 ### split_commits

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -7,6 +7,8 @@ This section contains the parsing and git related configuration options.
 conventional_commits = true
 filter_unconventional = true
 require_conventional = false
+blame_ignore_revs_file = ".git-blame-ignore-revs"
+filter_blame_ignored_revs = false
 split_commits = false
 commit_parsers = [
     { message = "^feat", group = "Features"},
@@ -95,6 +97,27 @@ commit_parsers = [
 If set to `true`, this option takes precedence over `filter_unconventional`.
 
 Checking takes place after `commit_parsers`. Thus commits can be skipped by matching parsers.
+
+### blame_ignore_revs_file
+
+Path to a file containing a list of commit refs to ignore when generating blame information (configured with `git config blame.ignoreRevsFile`). The file should contain one commit ref per line. By convention, this file is named `.git-blame-ignore-revs` and is located in the root of the repository.
+
+When used with `filter_blame_ignored_revs` set to `true`, commits that are listed in the file will be excluded from the changelog.
+
+```toml
+[git]
+blame_ignore_revs_file = ".git-blame-ignore-revs"
+```
+
+### filter_blame_ignored_revs
+
+If set to `true`, commits that are listed in the `blame_ignore_revs_file` will be excluded from the changelog.
+
+```toml
+[git]
+blame_ignore_revs_file = ".git-blame-ignore-revs"
+filter_blame_ignored_revs = false
+```
 
 ### split_commits
 


### PR DESCRIPTION
## Description

Added support for:

- excluding hashes listed in the blame ignore file from the changelog
- excluding commits that only touch the blame ignore file from the changelog

## Motivation and Context

This PR addressed #1054.

## How Has This Been Tested?

I just ran `cargo test`.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
