### PR TITLE
chore(project): migrate to Rust 2024 edition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4.3-labs
-FROM lukemathwalker/cargo-chef:0.1.70-rust-1.84.0-slim AS chef
+FROM lukemathwalker/cargo-chef:0.1.71-rust-1.85.0-slim-bookworm AS chef
 WORKDIR app
 
 FROM chef AS planner

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1736320768,
-        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1737512878,
-        "narHash": "sha256-dgF6htdmfNnZzVInifks6npnCAyVsIHWSpWNs10RSW0=",
+        "lastModified": 1745116541,
+        "narHash": "sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "06b8ed0eee289fe94c66f1202ced9a6a2c59a14c",
+        "rev": "e2142ef330a61c02f274ac9a9cb6f8487a5d0080",
         "type": "github"
       },
       "original": {

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -8,8 +8,8 @@ readme = "../README.md"
 homepage = "https://github.com/orhun/git-cliff"
 repository = "https://github.com/orhun/git-cliff"
 keywords = ["changelog", "generator", "conventional", "commit"]
-edition = "2021"
-rust-version = "1.83.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 [features]
 default = ["repo"]

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -8,19 +8,19 @@ use crate::error::{
 	Error as AppError,
 	Result,
 };
+use git_conventional::{
+	Commit as ConventionalCommit,
+	Footer as ConventionalFooter,
+};
 #[cfg(feature = "repo")]
 use git2::{
 	Commit as GitCommit,
 	Signature as CommitSignature,
 };
-use git_conventional::{
-	Commit as ConventionalCommit,
-	Footer as ConventionalFooter,
-};
 use lazy_regex::{
-	lazy_regex,
 	Lazy,
 	Regex,
+	lazy_regex,
 };
 use serde::ser::{
 	SerializeStruct,

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -490,9 +490,11 @@ mod test {
 		const TAG_PATTERN_VALUE: &str = ".*[0-9].*";
 		const IGNORE_TAGS_VALUE: &str = "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+";
 
-		env::set_var("GIT_CLIFF__CHANGELOG__FOOTER", FOOTER_VALUE);
-		env::set_var("GIT_CLIFF__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
-		env::set_var("GIT_CLIFF__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
+		unsafe {
+			env::set_var("GIT_CLIFF__CHANGELOG__FOOTER", FOOTER_VALUE);
+			env::set_var("GIT_CLIFF__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
+			env::set_var("GIT_CLIFF__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
+		};
 
 		let config = Config::parse(&path)?;
 

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -22,9 +22,9 @@ use crate::error::{
 };
 use dyn_clone::DynClone;
 use futures::{
+	StreamExt,
 	future,
 	stream,
-	StreamExt,
 };
 use http_cache_reqwest::{
 	CACacheManager,
@@ -33,11 +33,11 @@ use http_cache_reqwest::{
 	HttpCache,
 	HttpCacheOptions,
 };
+use reqwest::Client;
 use reqwest::header::{
 	HeaderMap,
 	HeaderValue,
 };
-use reqwest::Client;
 use reqwest_middleware::{
 	ClientBuilder,
 	ClientWithMiddleware,
@@ -52,8 +52,8 @@ use std::env;
 use std::fmt::Debug;
 use std::time::Duration;
 use time::{
-	format_description::well_known::Rfc3339,
 	OffsetDateTime,
+	format_description::well_known::Rfc3339,
 };
 
 /// User agent for interacting with the GitHub API.

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -17,9 +17,9 @@ use git2::{
 use glob::Pattern;
 use indexmap::IndexMap;
 use lazy_regex::{
-	lazy_regex,
 	Lazy,
 	Regex,
+	lazy_regex,
 };
 use std::io;
 use std::path::{
@@ -238,12 +238,11 @@ impl Repository {
 				.expect("failed to add '**' to the end of glob"),
 			_ => pattern,
 		};
-		let pattern_normal = match star_added.as_str().strip_prefix("./") {
+		match star_added.as_str().strip_prefix("./") {
 			Some(stripped) => Pattern::new(stripped)
 				.expect("failed to remove leading ./ from glob"),
 			None => star_added,
-		};
-		pattern_normal
+		}
 	}
 
 	/// Calculates whether the commit should be retained or not.
@@ -710,9 +709,11 @@ mod test {
 	#[test]
 	fn commit_search() -> Result<()> {
 		let repository = get_repository()?;
-		assert!(repository
-			.find_commit("e936ed571533ea6c41a1dd2b1a29d085c8dbada5")
-			.is_some());
+		assert!(
+			repository
+				.find_commit("e936ed571533ea6c41a1dd2b1a29d085c8dbada5")
+				.is_some()
+		);
 		Ok(())
 	}
 
@@ -912,10 +913,12 @@ mod test {
 
 		assert!(result.is_err());
 		if let Err(error) = result {
-			assert!(format!("{error:?}").contains(
-				format!("could not find repository at '{}'", path.display())
-					.as_str()
-			))
+			assert!(
+				format!("{error:?}").contains(
+					format!("could not find repository at '{}'", path.display())
+						.as_str()
+				)
+			)
 		}
 	}
 
@@ -945,13 +948,10 @@ mod test {
 			.expect("failed to execute git commit");
 		assert!(output.status.success(), "git commit failed {:?}", output);
 
-		let last_commit = repo
-			.inner
+		repo.inner
 			.head()
 			.and_then(|head| head.peel_to_commit())
-			.expect("failed to get the last commit");
-
-		last_commit
+			.expect("failed to get the last commit")
 	}
 
 	#[test]

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -12,11 +12,11 @@ use std::collections::{
 };
 use std::error::Error as ErrorImpl;
 use tera::{
-	ast,
 	Context as TeraContext,
 	Result as TeraResult,
 	Tera,
 	Value,
+	ast,
 };
 
 /// Wrapper for [`Tera`].

--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/orhun/git-cliff"
 keywords = ["changelog", "generator", "conventional", "commit"]
 categories = ["command-line-utilities"]
 default-run = "git-cliff"
-edition = "2021"
-rust-version = "1.83.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 [[bin]]
 name = "git-cliff-completions"

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -1,27 +1,27 @@
 use clap::{
+	ArgAction,
+	Parser,
+	ValueEnum,
 	builder::{
+		Styles,
+		TypedValueParser,
+		ValueParserFactory,
 		styling::{
 			Ansi256Color,
 			AnsiColor,
 		},
-		Styles,
-		TypedValueParser,
-		ValueParserFactory,
 	},
 	error::{
 		ContextKind,
 		ContextValue,
 		ErrorKind,
 	},
-	ArgAction,
-	Parser,
-	ValueEnum,
 };
 use git_cliff_core::{
-	config::BumpType,
-	config::Remote,
 	DEFAULT_CONFIG,
 	DEFAULT_OUTPUT,
+	config::BumpType,
+	config::Remote,
 };
 use glob::Pattern;
 use regex::Regex;
@@ -512,12 +512,16 @@ mod tests {
 				OsStr::new("https://gitlab.archlinux.org/archlinux/packaging/packages/arch-repro-status")
 			)?
 		);
-		assert!(remote_value_parser
-			.parse_ref(&Opt::command(), None, OsStr::new("test"))
-			.is_err());
-		assert!(remote_value_parser
-			.parse_ref(&Opt::command(), None, OsStr::new(""))
-			.is_err());
+		assert!(
+			remote_value_parser
+				.parse_ref(&Opt::command(), None, OsStr::new("test"))
+				.is_err()
+		);
+		assert!(
+			remote_value_parser
+				.parse_ref(&Opt::command(), None, OsStr::new(""))
+				.is_err()
+		);
 		Ok(())
 	}
 
@@ -532,9 +536,11 @@ mod tests {
 				OsStr::new("auto")
 			)?
 		);
-		assert!(bump_option_parser
-			.parse_ref(&Opt::command(), None, OsStr::new("test"))
-			.is_err());
+		assert!(
+			bump_option_parser
+				.parse_ref(&Opt::command(), None, OsStr::new("test"))
+				.is_err()
+		);
 		assert_eq!(
 			BumpOption::Specific(BumpType::Major),
 			bump_option_parser.parse_ref(

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -584,11 +584,7 @@ pub fn run_with_changelog_modifier(
 	} else if let Some(discovered_path) =
 		env::current_dir()?.ancestors().find_map(|dir| {
 			let path = dir.join(DEFAULT_CONFIG);
-			if path.is_file() {
-				Some(path)
-			} else {
-				None
-			}
+			if path.is_file() { Some(path) } else { None }
 		}) {
 		info!(
 			"Using configuration from parent directory: {}",

--- a/git-cliff/src/logger.rs
+++ b/git-cliff/src/logger.rs
@@ -1,10 +1,10 @@
 use env_logger::{
+	Builder,
 	fmt::{
 		Color,
 		Style,
 		StyledValue,
 	},
-	Builder,
 };
 use git_cliff_core::error::{
 	Error,

--- a/git-cliff/src/main.rs
+++ b/git-cliff/src/main.rs
@@ -13,11 +13,11 @@ fn main() -> Result<()> {
 	// Parse the command line arguments
 	let args = Opt::parse();
 	if args.verbose == 1 {
-		env::set_var("RUST_LOG", "debug");
+		unsafe { env::set_var("RUST_LOG", "debug") };
 	} else if args.verbose > 1 {
-		env::set_var("RUST_LOG", "trace");
+		unsafe { env::set_var("RUST_LOG", "trace") };
 	} else if env::var_os("RUST_LOG").is_none() {
-		env::set_var("RUST_LOG", "info");
+		unsafe { env::set_var("RUST_LOG", "info") };
 	}
 	logger::init()?;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2024"
 max_width = 85
 newline_style = "Unix"
 hard_tabs = true


### PR DESCRIPTION
## Description

Migrates the codebase to Rust 2024 edition, see <https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/>

MSRV is now 1.85.0

## Motivation and Context

I'm always on the edge.

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
