### PR TITLE
support configuring initial_tag via cli

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -320,8 +320,14 @@ impl Bump {
 	/// Returns the initial tag.
 	///
 	/// This function also logs the returned value.
-	pub fn get_initial_tag(&self) -> String {
-		if let Some(tag) = self.initial_tag.clone() {
+	pub fn get_initial_tag(&self,  cli_initial_tag: Option<String>) -> String {
+	    if let Some(tag) = cli_initial_tag {
+			warn!(
+			    "No releases found, using initial tag '{tag}' as the next version."
+			);
+			tag		
+		}
+		else if let Some(tag) = self.initial_tag.clone() {
 			warn!(
 				"No releases found, using initial tag '{tag}' as the next version."
 			);

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -174,7 +174,7 @@ impl Release<'_> {
 					Ok(next_version)
 				}
 			}
-			None => Ok(config.get_initial_tag()),
+			None => Ok(config.get_initial_tag(None)),
 		}
 	}
 }

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -223,6 +223,10 @@ pub struct Opt {
 	/// Prints bumped version for unreleased changes.
 	#[arg(long, help_heading = Some("FLAGS"))]
 	pub bumped_version:   bool,
+	
+	#[arg(long)]
+	pub initial_tag: Option<String>,
+	
 	/// Sets the template for the changelog body.
 	#[arg(
 		short,

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -810,8 +810,8 @@ pub fn run_with_changelog_modifier(
 		{
 			warn!("There is nothing to bump.");
 			last_version
-		} else if changelog.releases.is_empty() {
-			config.bump.get_initial_tag()
+		} else if changelog.releases.is_empty() || args.initial_tag.is_some() {
+			config.bump.get_initial_tag(args.initial_tag.clone())
 		} else {
 			return Ok(());
 		};


### PR DESCRIPTION
## Description

Add support to configure initial_tag via cli.

## Motivation and Context

`initial_tag` can only be configured in the configuration file for now.
#1100 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
