### PR TITLE
fix(template): correctly serialize JSON for the commit fields

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -729,7 +729,15 @@ mod test {
 			timestamp: 0x0,
 		};
 
-		let parsed_commit = commit.parse(
+		commit.remote = Some(crate::contributor::RemoteContributor {
+			username:      None,
+			pr_title:      Some("feat: do something".to_string()),
+			pr_number:     None,
+			pr_labels:     Vec::new(),
+			is_first_time: true,
+		});
+
+		let parsed_commit = commit.clone().parse(
 			&[CommitParser {
 				sha:           None,
 				message:       None,
@@ -748,20 +756,7 @@ mod test {
 
 		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let mut commit = Commit::new(
-			String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-			String::from("feat: do something"),
-		);
-
-		commit.remote = Some(crate::contributor::RemoteContributor {
-			username:      None,
-			pr_title:      Some("feat: do something".to_string()),
-			pr_number:     None,
-			pr_labels:     Vec::new(),
-			is_first_time: true,
-		});
-
-		let parsed_commit = commit.parse(
+		let parsed_commit = commit.clone().parse(
 			&[CommitParser {
 				sha:           None,
 				message:       None,
@@ -779,6 +774,29 @@ mod test {
 		)?;
 
 		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+
+		let parse_result = commit.clone().parse(
+			&[CommitParser {
+				sha:           None,
+				message:       None,
+				body:          None,
+				footer:        None,
+				group:         Some(String::from("Invalid group")),
+				default_scope: None,
+				scope:         None,
+				skip:          None,
+				field:         Some(String::from("remote.pr_labels")),
+				pattern:       Regex::new(".*").ok(),
+			}],
+			false,
+			false,
+		);
+
+		assert!(
+			parse_result.is_err(),
+			"Expected error when using unsupported field `remote.pr_labels`, but \
+			 got Ok"
+		);
 
 		Ok(())
 	}


### PR DESCRIPTION
## Description

Fixes inconsistent serde_json::Value string representations when applying regex matchers. Specifically, it ensures that:

 - `Value::String` does not include surrounding quotes,
 - other scalar types (`Number`, `Bool`, `Null`) are stringified appropriately,
 - `Object` and `Array` are treated as unsupported and result in an error.
 
 Closes #1143 

## Motivation and Context

Previously, `serde_json::Value::String("example")` was converted using `to_string()`, resulting in `"\"example\""`, which broke regex patterns expecting plain strings. This PR fixes that by:

 - Matching and extracting raw strings for `Value::String`,
 - Applying `to_string()` to `Number`, `Bool`, and `Null`,
 - Raising a user-friendly error if the field is an `Object` or `Array`.

This makes pattern matching robust and predictable when working with JSON input from commit metadata or remote PR context.

## How Has This Been Tested?

- Added unit tests for `Commit::parse` to verify field-based parsing logic using both `author` and `remote` attributes.
- Verified correct parser behavior using the following `commit_parsers` configuration in `cliff.toml`:
 ```toml
 commit_parsers = [
  { message = "$^", skip = true },
  { field = "author.name", pattern = "github-actions", skip = true },
  { field = "author.email", pattern = "github-actions@github.com", skip = true },
  { field = "committer.name", pattern = "github-actions", skip = true },
  { field = "committer.email", pattern = "github-actions@github.com", skip = true },
  { field = "remote.pr_title", pattern = "^feat", group = "<!-- 00 -->🚀 Features" },
  { field = "remote.pr_title", pattern = "^fix", group = "<!-- 01 -->🐛 Bug Fixes" },
  { field = "remote.pr_title", pattern = "^refactor", group = "<!-- 02 -->🚜 Refactor" },
  { field = "remote.pr_title", pattern = "^docs", group = "<!-- 03 -->📚 Documentation" },
  { field = "remote.pr_title", pattern = "^perf", group = "<!-- 04 -->⚡ Performance" },
  { field = "remote.pr_title", pattern = "^style", group = "<!-- 05 -->🎨 Styling" },
  { field = "remote.pr_title", pattern = "^test", group = "<!-- 06 -->🧪 Testing" },
  { field = "remote.pr_title", pattern = "^chore\\(release\\)", skip = true },
  { field = "remote.pr_title", pattern = "^chore\\(deps.*\\)", skip = true },
  { field = "remote.pr_title", pattern = "^chore\\(pr\\)", skip = true },
  { field = "remote.pr_title", pattern = "^chore\\(pull\\)", skip = true },
  { field = "remote.pr_title", pattern = "^(chore|ci)", group = "<!-- 07 -->⚙️ Miscellaneous Tasks" },
  { field = "remote.pr_title", pattern = "^revert", group = "<!-- 08 -->◀️ Revert" },
  { field = "remote.pr_title", pattern = ".*", group = "<!-- 09 -->💼 Other" },
]
 ```

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
