### PR TITLE
chore(npm): bump git-cliff to 2.9.1

### DIFF
--- a/npm/git-cliff/yarn.lock
+++ b/npm/git-cliff/yarn.lock
@@ -1404,44 +1404,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-arm64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-darwin-arm64@npm:2.9.0"
+"git-cliff-darwin-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-darwin-arm64@npm:2.9.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-x64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-darwin-x64@npm:2.9.0"
+"git-cliff-darwin-x64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-darwin-x64@npm:2.9.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-arm64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-linux-arm64@npm:2.9.0"
+"git-cliff-linux-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-linux-arm64@npm:2.9.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-x64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-linux-x64@npm:2.9.0"
+"git-cliff-linux-x64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-linux-x64@npm:2.9.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-arm64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-windows-arm64@npm:2.9.0"
+"git-cliff-windows-arm64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-windows-arm64@npm:2.9.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-x64@npm:2.9.0":
-  version: 2.9.0
-  resolution: "git-cliff-windows-x64@npm:2.9.0"
+"git-cliff-windows-x64@npm:2.9.1":
+  version: 2.9.1
+  resolution: "git-cliff-windows-x64@npm:2.9.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1457,12 +1457,12 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.6.0"
     eslint: "npm:^9.11.0"
     execa: "npm:^8.0.1"
-    git-cliff-darwin-arm64: "npm:2.9.0"
-    git-cliff-darwin-x64: "npm:2.9.0"
-    git-cliff-linux-arm64: "npm:2.9.0"
-    git-cliff-linux-x64: "npm:2.9.0"
-    git-cliff-windows-arm64: "npm:2.9.0"
-    git-cliff-windows-x64: "npm:2.9.0"
+    git-cliff-darwin-arm64: "npm:2.9.1"
+    git-cliff-darwin-x64: "npm:2.9.1"
+    git-cliff-linux-arm64: "npm:2.9.1"
+    git-cliff-linux-x64: "npm:2.9.1"
+    git-cliff-windows-arm64: "npm:2.9.1"
+    git-cliff-windows-x64: "npm:2.9.1"
     tsup: "npm:^8.3.0"
     typescript: "npm:^5.6.2"
     typescript-eslint: "npm:^8.6.0"


### PR DESCRIPTION
## Description

Update git-cliff-* versions in package.json from 2.8.0 to 2.9.1 and regenerate yarn.lock.

## Motivation and Context

Fixes #1155 

## How Has This Been Tested?

This is a metadata-only update. No runtime code was affected.
CI should pass as long as lockfile updates are accepted.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
