### PR TITLE
doc: Fix inconsistency in documentation of Gitea integration

### DIFF
--- a/website/docs/integration/bitbucket.md
+++ b/website/docs/integration/bitbucket.md
@@ -96,7 +96,7 @@ https://bitbucket.org/{{ remote.bitbucket.owner }}/{{ remote.bitbucket.repo }}/c
 
 ### Commit authors
 
-For each commit, Bitbucket related values are added as a nested object (named `bitbucket`) to the [template context](/docs/templating/context):
+For each commit, Bitbucket related values are added as a nested object (named `remote`) to the [template context](/docs/templating/context):
 
 ```json
 {

--- a/website/docs/integration/gitea.md
+++ b/website/docs/integration/gitea.md
@@ -96,7 +96,7 @@ https://codeberg.org/{{ remote.gitea.owner }}/{{ remote.gitea.repo }}/commits/ta
 
 ### Commit authors
 
-For each commit, Gitea related values are added as a nested object (named `gitea`) to the [template context](/docs/templating/context):
+For each commit, Gitea related values are added as a nested object (named `remote`) to the [template context](/docs/templating/context):
 
 ```json
 {

--- a/website/docs/integration/github.md
+++ b/website/docs/integration/github.md
@@ -100,7 +100,7 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{
 
 ### Commit authors
 
-For each commit, GitHub related values are added as a nested object (named `github`) to the [template context](/docs/templating/context):
+For each commit, GitHub related values are added as a nested object (named `remote`) to the [template context](/docs/templating/context):
 
 ```json
 {

--- a/website/docs/integration/gitlab.md
+++ b/website/docs/integration/gitlab.md
@@ -108,7 +108,7 @@ If you are using GitLab CI, you can use [`CI_PROJECT_URL`](https://docs.gitlab.c
 
 ### Commit authors
 
-For each commit, GitLab related values are added as a nested object (named `gitlab`) to the [template context](/docs/templating/context):
+For each commit, GitLab related values are added as a nested object (named `remote`) to the [template context](/docs/templating/context):
 
 ```json
 {


### PR DESCRIPTION
The text says that the extra information is added in a `gitea` nested object, but it's in fact a `remote` object according to the examples.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
