### PR TITLE
fix: check if commit.footers is defined in detailed example

### DIFF
--- a/.github/fixtures/test-commit-footers/cliff.toml
+++ b/.github/fixtures/test-commit-footers/cliff.toml
@@ -14,11 +14,11 @@ body = """
     ### {{ group | upper_first }}
     {% for commit in commits %}
         - {{ commit.message | upper_first }}\
-          {% if commit.footers %}
+          {% if commit.footers %}\
             {% for footer in commit.footers -%}
                 , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
             {% endfor %}\
-          {% endif %}
+          {% endif %}\
     {% endfor %}
 {% endfor %}\n
 """

--- a/.github/fixtures/test-commit-footers/cliff.toml
+++ b/.github/fixtures/test-commit-footers/cliff.toml
@@ -14,9 +14,11 @@ body = """
     ### {{ group | upper_first }}
     {% for commit in commits %}
         - {{ commit.message | upper_first }}\
-          {% for footer in commit.footers -%}
-            , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
-          {% endfor %}\
+          {% if commit.footers %}
+            {% for footer in commit.footers -%}
+                , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
+            {% endfor %}\
+          {% endif %}
     {% endfor %}
 {% endfor %}\n
 """

--- a/examples/detailed.toml
+++ b/examples/detailed.toml
@@ -26,9 +26,11 @@ body = """
     ### {{ group | upper_first }}
     {% for commit in commits %}
         - {{ commit.message | split(pat="\n") | first | upper_first | trim }} ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))\
-          {% for footer in commit.footers -%}
-            , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
-          {% endfor %}\
+          {% if commit.footers %}
+            {% for footer in commit.footers -%}
+                , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
+            {% endfor %}\
+          {% endif %}
     {% endfor %}
 {% endfor %}\n
 """

--- a/examples/detailed.toml
+++ b/examples/detailed.toml
@@ -26,11 +26,11 @@ body = """
     ### {{ group | upper_first }}
     {% for commit in commits %}
         - {{ commit.message | split(pat="\n") | first | upper_first | trim }} ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))\
-          {% if commit.footers %}
+          {% if commit.footers %}\
             {% for footer in commit.footers -%}
                 , {{ footer.token }}{{ footer.separator }}{{ footer.value }}\
             {% endfor %}\
-          {% endif %}
+          {% endif %}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Check if the `commit.footers` array was defined in the body template. An alternative would be to always pass `commit.footers` and empty if there are no footers. I don't have enough Rust knowledge to make that change related to https://github.com/orhun/git-cliff/pull/97.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The change is required to fix a bug in `examples/detailed.toml`. That configuration assumes that all the commits will have a footer. This is a bug when rendering the `body` template because sometimes there could be commits without footers because the PR author merged without a footer. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Creating a `detailed.toml` configuration in my private repository and applying the fix.

## Screenshots / Logs (if applicable)
Variable `commit.footers` not found in context while rendering 'body'
![image](https://github.com/user-attachments/assets/7700e9ea-d0f2-4947-ab79-035d33e4c039)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
