### PR TITLE
style: update formatting rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Check the formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check --verbose
+        run: cargo +nightly fmt --all -- --check --verbose
 
   doctest:
     name: Doctests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check the formatting
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: fmt
-          args: --all -- --check --verbose
+        run: cargo +nightly fmt --all -- --check --verbose
 
   doctest:
     name: Doctests

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -212,8 +212,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref())
-                    == Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -242,12 +242,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom
-            || self
-                .body_template
-                .contains_variable(github::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -298,12 +296,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom
-            || self
-                .body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -361,12 +357,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom
-            || self
-                .body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -420,12 +414,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom
-            || self
-                .body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -1049,29 +1041,24 @@ mod test {
             timestamp: Some(50000000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(
-                String::from("submodule_one"),
-                vec![
-                    Commit::new(
-                        String::from("sub0jkl12"),
-                        String::from("chore(app): submodule_one do nothing"),
-                    ),
-                    Commit::new(
-                        String::from("subqwerty"),
-                        String::from("chore: submodule_one <preprocess>"),
-                    ),
-                    Commit::new(
-                        String::from("subqwertz"),
-                        String::from("feat!: submodule_one support breaking commits"),
-                    ),
-                    Commit::new(
-                        String::from("subqwert0"),
-                        String::from(
-                            "match(group): submodule_one support regex-replace for groups",
-                        ),
-                    ),
-                ],
-            )]),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1180,20 +1167,14 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (
-                        String::from("submodule_one"),
-                        vec![
-                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                        ],
-                    ),
-                    (
-                        String::from("submodule_two"),
-                        vec![Commit::new(
-                            String::from("ab76ef"),
-                            String::from("sub_two bump"),
-                        )],
-                    ),
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -19,689 +19,645 @@ use crate::template::Template;
 /// Changelog generator.
 #[derive(Debug)]
 pub struct Changelog<'a> {
-	/// Releases that the changelog will contain.
-	pub releases:       Vec<Release<'a>>,
-	header_template:    Option<Template>,
-	body_template:      Template,
-	footer_template:    Option<Template>,
-	config:             &'a Config,
-	additional_context: HashMap<String, serde_json::Value>,
+    /// Releases that the changelog will contain.
+    pub releases: Vec<Release<'a>>,
+    header_template: Option<Template>,
+    body_template: Template,
+    footer_template: Option<Template>,
+    config: &'a Config,
+    additional_context: HashMap<String, serde_json::Value>,
 }
 
 impl<'a> Changelog<'a> {
-	/// Constructs a new instance.
-	pub fn new(
-		releases: Vec<Release<'a>>,
-		config: &'a Config,
-		range: Option<&str>,
-	) -> Result<Self> {
-		let mut changelog = Changelog::build(releases, config)?;
-		changelog.add_remote_data(range)?;
-		changelog.process_commits()?;
-		changelog.process_releases();
-		Ok(changelog)
-	}
+    /// Constructs a new instance.
+    pub fn new(
+        releases: Vec<Release<'a>>,
+        config: &'a Config,
+        range: Option<&str>,
+    ) -> Result<Self> {
+        let mut changelog = Changelog::build(releases, config)?;
+        changelog.add_remote_data(range)?;
+        changelog.process_commits()?;
+        changelog.process_releases();
+        Ok(changelog)
+    }
 
-	/// Builds a changelog from releases and config.
-	fn build(releases: Vec<Release<'a>>, config: &'a Config) -> Result<Self> {
-		let trim = config.changelog.trim;
-		Ok(Self {
-			releases,
-			header_template: match &config.changelog.header {
-				Some(header) => {
-					Some(Template::new("header", header.to_string(), trim)?)
-				}
-				None => None,
-			},
-			body_template: get_body_template(config, trim)?,
-			footer_template: match &config.changelog.footer {
-				Some(footer) => {
-					Some(Template::new("footer", footer.to_string(), trim)?)
-				}
-				None => None,
-			},
-			config,
-			additional_context: HashMap::new(),
-		})
-	}
+    /// Builds a changelog from releases and config.
+    fn build(releases: Vec<Release<'a>>, config: &'a Config) -> Result<Self> {
+        let trim = config.changelog.trim;
+        Ok(Self {
+            releases,
+            header_template: match &config.changelog.header {
+                Some(header) => Some(Template::new("header", header.to_string(), trim)?),
+                None => None,
+            },
+            body_template: get_body_template(config, trim)?,
+            footer_template: match &config.changelog.footer {
+                Some(footer) => Some(Template::new("footer", footer.to_string(), trim)?),
+                None => None,
+            },
+            config,
+            additional_context: HashMap::new(),
+        })
+    }
 
-	/// Constructs an instance from a serialized context object.
-	pub fn from_context<R: Read>(input: &mut R, config: &'a Config) -> Result<Self> {
-		Changelog::build(serde_json::from_reader(input)?, config)
-	}
+    /// Constructs an instance from a serialized context object.
+    pub fn from_context<R: Read>(input: &mut R, config: &'a Config) -> Result<Self> {
+        Changelog::build(serde_json::from_reader(input)?, config)
+    }
 
-	/// Adds a key value pair to the template context.
-	///
-	/// These values will be used when generating the changelog.
-	///
-	/// # Errors
-	///
-	/// This operation fails if the deserialization fails.
-	pub fn add_context(
-		&mut self,
-		key: impl Into<String>,
-		value: impl serde::Serialize,
-	) -> Result<()> {
-		self.additional_context
-			.insert(key.into(), serde_json::to_value(value)?);
-		Ok(())
-	}
+    /// Adds a key value pair to the template context.
+    ///
+    /// These values will be used when generating the changelog.
+    ///
+    /// # Errors
+    ///
+    /// This operation fails if the deserialization fails.
+    pub fn add_context(
+        &mut self,
+        key: impl Into<String>,
+        value: impl serde::Serialize,
+    ) -> Result<()> {
+        self.additional_context
+            .insert(key.into(), serde_json::to_value(value)?);
+        Ok(())
+    }
 
-	/// Processes a single commit and returns/logs the result.
-	fn process_commit(
-		commit: &Commit<'a>,
-		git_config: &GitConfig,
-	) -> Option<Commit<'a>> {
-		match commit.process(git_config) {
-			Ok(commit) => Some(commit),
-			Err(e) => {
-				trace!(
-					"{} - {} ({})",
-					commit.id.chars().take(7).collect::<String>(),
-					e,
-					commit.message.lines().next().unwrap_or_default().trim()
-				);
-				None
-			}
-		}
-	}
+    /// Processes a single commit and returns/logs the result.
+    fn process_commit(commit: &Commit<'a>, git_config: &GitConfig) -> Option<Commit<'a>> {
+        match commit.process(git_config) {
+            Ok(commit) => Some(commit),
+            Err(e) => {
+                trace!(
+                    "{} - {} ({})",
+                    commit.id.chars().take(7).collect::<String>(),
+                    e,
+                    commit.message.lines().next().unwrap_or_default().trim()
+                );
+                None
+            }
+        }
+    }
 
-	/// Checks the commits and returns an error if any unconventional commits
-	/// are found.
-	fn check_conventional_commits(commits: &Vec<Commit<'a>>) -> Result<()> {
-		debug!("Verifying that all commits are conventional.");
-		let mut unconventional_count = 0;
+    /// Checks the commits and returns an error if any unconventional commits
+    /// are found.
+    fn check_conventional_commits(commits: &Vec<Commit<'a>>) -> Result<()> {
+        debug!("Verifying that all commits are conventional.");
+        let mut unconventional_count = 0;
 
-		commits.iter().for_each(|commit| {
-			if commit.conv.is_none() {
-				error!(
-					"Commit {id} is not conventional:\n{message}",
-					id = &commit.id[..7],
-					message = commit
-						.message
-						.lines()
-						.map(|line| { format!("    | {}", line.trim()) })
-						.collect::<Vec<String>>()
-						.join("\n")
-				);
-				unconventional_count += 1;
-			}
-		});
+        commits.iter().for_each(|commit| {
+            if commit.conv.is_none() {
+                error!(
+                    "Commit {id} is not conventional:\n{message}",
+                    id = &commit.id[..7],
+                    message = commit
+                        .message
+                        .lines()
+                        .map(|line| { format!("    | {}", line.trim()) })
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                );
+                unconventional_count += 1;
+            }
+        });
 
-		if unconventional_count > 0 {
-			return Err(Error::UnconventionalCommitsError(unconventional_count));
-		}
+        if unconventional_count > 0 {
+            return Err(Error::UnconventionalCommitsError(unconventional_count));
+        }
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	fn process_commit_list(
-		commits: &mut Vec<Commit<'a>>,
-		git_config: &GitConfig,
-	) -> Result<()> {
-		*commits = commits
-			.iter()
-			.filter_map(|commit| Self::process_commit(commit, git_config))
-			.flat_map(|commit| {
-				if git_config.split_commits {
-					commit
-						.message
-						.lines()
-						.filter_map(|line| {
-							let mut c = commit.clone();
-							c.message = line.to_string();
-							c.links.clear();
-							if c.message.is_empty() {
-								None
-							} else {
-								Self::process_commit(&c, git_config)
-							}
-						})
-						.collect()
-				} else {
-					vec![commit]
-				}
-			})
-			.collect::<Vec<Commit>>();
+    fn process_commit_list(commits: &mut Vec<Commit<'a>>, git_config: &GitConfig) -> Result<()> {
+        *commits = commits
+            .iter()
+            .filter_map(|commit| Self::process_commit(commit, git_config))
+            .flat_map(|commit| {
+                if git_config.split_commits {
+                    commit
+                        .message
+                        .lines()
+                        .filter_map(|line| {
+                            let mut c = commit.clone();
+                            c.message = line.to_string();
+                            c.links.clear();
+                            if c.message.is_empty() {
+                                None
+                            } else {
+                                Self::process_commit(&c, git_config)
+                            }
+                        })
+                        .collect()
+                } else {
+                    vec![commit]
+                }
+            })
+            .collect::<Vec<Commit>>();
 
-		if git_config.require_conventional {
-			Self::check_conventional_commits(commits)?;
-		}
+        if git_config.require_conventional {
+            Self::check_conventional_commits(commits)?;
+        }
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	/// Processes the commits and omits the ones that doesn't match the
-	/// criteria set by configuration file.
-	fn process_commits(&mut self) -> Result<()> {
-		debug!("Processing the commits...");
-		for release in self.releases.iter_mut() {
-			Self::process_commit_list(&mut release.commits, &self.config.git)?;
-			for submodule_commits in release.submodule_commits.values_mut() {
-				Self::process_commit_list(submodule_commits, &self.config.git)?;
-			}
-		}
-		Ok(())
-	}
+    /// Processes the commits and omits the ones that doesn't match the
+    /// criteria set by configuration file.
+    fn process_commits(&mut self) -> Result<()> {
+        debug!("Processing the commits...");
+        for release in self.releases.iter_mut() {
+            Self::process_commit_list(&mut release.commits, &self.config.git)?;
+            for submodule_commits in release.submodule_commits.values_mut() {
+                Self::process_commit_list(submodule_commits, &self.config.git)?;
+            }
+        }
+        Ok(())
+    }
 
-	/// Processes the releases and filters them out based on the configuration.
-	fn process_releases(&mut self) {
-		debug!("Processing {} release(s)...", self.releases.len());
-		let skip_regex = self.config.git.skip_tags.as_ref();
-		let mut skipped_tags = Vec::new();
-		self.releases = self
-			.releases
-			.clone()
-			.into_iter()
-			.rev()
-			.filter(|release| {
-				if let Some(version) = &release.version {
-					if skip_regex.is_some_and(|r| r.is_match(version)) {
-						skipped_tags.push(version.clone());
-						trace!("Skipping release: {}", version);
-						return false;
-					}
-				}
-				if release.commits.is_empty() {
-					if let Some(version) = release.version.clone() {
-						trace!("Release doesn't have any commits: {}", version);
-					}
-					match &release.previous {
-						Some(prev_release) if prev_release.commits.is_empty() => {
-							return self.config.changelog.render_always;
-						}
-						_ => return false,
-					}
-				}
-				true
-			})
-			.map(|release| release.with_statistics())
-			.collect();
-		for skipped_tag in &skipped_tags {
-			if let Some(release_index) = self.releases.iter().position(|release| {
-				release
-					.previous
-					.as_ref()
-					.and_then(|release| release.version.as_ref()) ==
-					Some(skipped_tag)
-			}) {
-				if let Some(previous_release) =
-					self.releases.get_mut(release_index + 1)
-				{
-					previous_release.previous = None;
-					self.releases[release_index].previous =
-						Some(Box::new(previous_release.clone()));
-				} else if release_index == self.releases.len() - 1 {
-					self.releases[release_index].previous = None;
-				}
-			}
-		}
-	}
+    /// Processes the releases and filters them out based on the configuration.
+    fn process_releases(&mut self) {
+        debug!("Processing {} release(s)...", self.releases.len());
+        let skip_regex = self.config.git.skip_tags.as_ref();
+        let mut skipped_tags = Vec::new();
+        self.releases = self
+            .releases
+            .clone()
+            .into_iter()
+            .rev()
+            .filter(|release| {
+                if let Some(version) = &release.version {
+                    if skip_regex.is_some_and(|r| r.is_match(version)) {
+                        skipped_tags.push(version.clone());
+                        trace!("Skipping release: {}", version);
+                        return false;
+                    }
+                }
+                if release.commits.is_empty() {
+                    if let Some(version) = release.version.clone() {
+                        trace!("Release doesn't have any commits: {}", version);
+                    }
+                    match &release.previous {
+                        Some(prev_release) if prev_release.commits.is_empty() => {
+                            return self.config.changelog.render_always;
+                        }
+                        _ => return false,
+                    }
+                }
+                true
+            })
+            .map(|release| release.with_statistics())
+            .collect();
+        for skipped_tag in &skipped_tags {
+            if let Some(release_index) = self.releases.iter().position(|release| {
+                release
+                    .previous
+                    .as_ref()
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
+            }) {
+                if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
+                    previous_release.previous = None;
+                    self.releases[release_index].previous =
+                        Some(Box::new(previous_release.clone()));
+                } else if release_index == self.releases.len() - 1 {
+                    self.releases[release_index].previous = None;
+                }
+            }
+        }
+    }
 
-	/// Returns the GitHub metadata needed for the changelog.
-	///
-	/// This function creates a multithread async runtime for handling the
-	/// requests. The following are fetched from the GitHub REST API:
-	///
-	/// - Commits
-	/// - Pull requests
-	///
-	/// Each of these are paginated requests so they are being run in parallel
-	/// for speedup.
-	///
-	/// If no GitHub related variable is used in the template then this function
-	/// returns empty vectors.
-	#[cfg(feature = "github")]
-	fn get_github_metadata(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<crate::remote::RemoteMetadata> {
-		use crate::remote::github;
-		if self.config.remote.github.is_custom ||
-			self.body_template
-				.contains_variable(github::TEMPLATE_VARIABLES) ||
-			self.footer_template
-				.as_ref()
-				.map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
-		{
-			debug!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
-			let github_client =
-				GitHubClient::try_from(self.config.remote.github.clone())?;
-			info!(
-				"{} ({})",
-				github::START_FETCHING_MSG,
-				self.config.remote.github
-			);
-			let data = tokio::runtime::Builder::new_multi_thread()
-				.enable_all()
-				.build()?
-				.block_on(async {
-					let (commits, pull_requests) = tokio::try_join!(
-						github_client.get_commits(ref_name),
-						github_client.get_pull_requests(ref_name),
-					)?;
-					debug!("Number of GitHub commits: {}", commits.len());
-					debug!(
-						"Number of GitHub pull requests: {}",
-						pull_requests.len()
-					);
-					Ok((commits, pull_requests))
-				});
-			info!("{}", github::FINISHED_FETCHING_MSG);
-			data
-		} else {
-			Ok((vec![], vec![]))
-		}
-	}
+    /// Returns the GitHub metadata needed for the changelog.
+    ///
+    /// This function creates a multithread async runtime for handling the
+    /// requests. The following are fetched from the GitHub REST API:
+    ///
+    /// - Commits
+    /// - Pull requests
+    ///
+    /// Each of these are paginated requests so they are being run in parallel
+    /// for speedup.
+    ///
+    /// If no GitHub related variable is used in the template then this function
+    /// returns empty vectors.
+    #[cfg(feature = "github")]
+    fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
+        use crate::remote::github;
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
+                .as_ref()
+                .map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
+                .unwrap_or(false)
+        {
+            debug!(
+                "You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>"
+            );
+            let github_client = GitHubClient::try_from(self.config.remote.github.clone())?;
+            info!(
+                "{} ({})",
+                github::START_FETCHING_MSG,
+                self.config.remote.github
+            );
+            let data = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(async {
+                    let (commits, pull_requests) = tokio::try_join!(
+                        github_client.get_commits(ref_name),
+                        github_client.get_pull_requests(ref_name),
+                    )?;
+                    debug!("Number of GitHub commits: {}", commits.len());
+                    debug!("Number of GitHub pull requests: {}", pull_requests.len());
+                    Ok((commits, pull_requests))
+                });
+            info!("{}", github::FINISHED_FETCHING_MSG);
+            data
+        } else {
+            Ok((vec![], vec![]))
+        }
+    }
 
-	/// Returns the GitLab metadata needed for the changelog.
-	///
-	/// This function creates a multithread async runtime for handling the
-	///
-	/// requests. The following are fetched from the GitLab REST API:
-	///
-	/// - Commits
-	/// - Merge requests
-	///
-	/// Each of these are paginated requests so they are being run in parallel
-	/// for speedup.
-	///
-	///
-	/// If no GitLab related variable is used in the template then this function
-	/// returns empty vectors.
-	#[cfg(feature = "gitlab")]
-	fn get_gitlab_metadata(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<crate::remote::RemoteMetadata> {
-		use crate::remote::gitlab;
-		if self.config.remote.gitlab.is_custom ||
-			self.body_template
-				.contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-			self.footer_template
-				.as_ref()
-				.map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
-		{
-			debug!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
-			let gitlab_client =
-				GitLabClient::try_from(self.config.remote.gitlab.clone())?;
-			info!(
-				"{} ({})",
-				gitlab::START_FETCHING_MSG,
-				self.config.remote.gitlab
-			);
-			let data = tokio::runtime::Builder::new_multi_thread()
-				.enable_all()
-				.build()?
-				.block_on(async {
-					// Map repo/owner to gitlab id
-					let project_id =
-						match tokio::join!(gitlab_client.get_project(ref_name)) {
-							(Ok(project),) => project.id,
-							(Err(err),) => {
-								error!("Failed to lookup project! {}", err);
-								return Err(err);
-							}
-						};
-					let (commits, merge_requests) = tokio::try_join!(
-						// Send id to these functions
-						gitlab_client.get_commits(project_id, ref_name),
-						gitlab_client.get_merge_requests(project_id, ref_name),
-					)?;
-					debug!("Number of GitLab commits: {}", commits.len());
-					debug!(
-						"Number of GitLab merge requests: {}",
-						merge_requests.len()
-					);
-					Ok((commits, merge_requests))
-				});
-			info!("{}", gitlab::FINISHED_FETCHING_MSG);
-			data
-		} else {
-			Ok((vec![], vec![]))
-		}
-	}
+    /// Returns the GitLab metadata needed for the changelog.
+    ///
+    /// This function creates a multithread async runtime for handling the
+    ///
+    /// requests. The following are fetched from the GitLab REST API:
+    ///
+    /// - Commits
+    /// - Merge requests
+    ///
+    /// Each of these are paginated requests so they are being run in parallel
+    /// for speedup.
+    ///
+    ///
+    /// If no GitLab related variable is used in the template then this function
+    /// returns empty vectors.
+    #[cfg(feature = "gitlab")]
+    fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
+        use crate::remote::gitlab;
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
+                .as_ref()
+                .map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
+                .unwrap_or(false)
+        {
+            debug!(
+                "You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>"
+            );
+            let gitlab_client = GitLabClient::try_from(self.config.remote.gitlab.clone())?;
+            info!(
+                "{} ({})",
+                gitlab::START_FETCHING_MSG,
+                self.config.remote.gitlab
+            );
+            let data = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(async {
+                    // Map repo/owner to gitlab id
+                    let project_id = match tokio::join!(gitlab_client.get_project(ref_name)) {
+                        (Ok(project),) => project.id,
+                        (Err(err),) => {
+                            error!("Failed to lookup project! {}", err);
+                            return Err(err);
+                        }
+                    };
+                    let (commits, merge_requests) = tokio::try_join!(
+                        // Send id to these functions
+                        gitlab_client.get_commits(project_id, ref_name),
+                        gitlab_client.get_merge_requests(project_id, ref_name),
+                    )?;
+                    debug!("Number of GitLab commits: {}", commits.len());
+                    debug!("Number of GitLab merge requests: {}", merge_requests.len());
+                    Ok((commits, merge_requests))
+                });
+            info!("{}", gitlab::FINISHED_FETCHING_MSG);
+            data
+        } else {
+            Ok((vec![], vec![]))
+        }
+    }
 
-	/// Returns the Gitea metadata needed for the changelog.
-	///
-	/// This function creates a multithread async runtime for handling the
-	/// requests. The following are fetched from the GitHub REST API:
-	///
-	/// - Commits
-	/// - Pull requests
-	///
-	/// Each of these are paginated requests so they are being run in parallel
-	/// for speedup.
-	///
-	/// If no Gitea related variable is used in the template then this function
-	/// returns empty vectors.
-	#[cfg(feature = "gitea")]
-	fn get_gitea_metadata(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<crate::remote::RemoteMetadata> {
-		use crate::remote::gitea;
-		if self.config.remote.gitea.is_custom ||
-			self.body_template
-				.contains_variable(gitea::TEMPLATE_VARIABLES) ||
-			self.footer_template
-				.as_ref()
-				.map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
-		{
-			debug!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
-			let gitea_client =
-				GiteaClient::try_from(self.config.remote.gitea.clone())?;
-			info!(
-				"{} ({})",
-				gitea::START_FETCHING_MSG,
-				self.config.remote.gitea
-			);
-			let data = tokio::runtime::Builder::new_multi_thread()
-				.enable_all()
-				.build()?
-				.block_on(async {
-					let (commits, pull_requests) = tokio::try_join!(
-						gitea_client.get_commits(ref_name),
-						gitea_client.get_pull_requests(ref_name),
-					)?;
-					debug!("Number of Gitea commits: {}", commits.len());
-					debug!("Number of Gitea pull requests: {}", pull_requests.len());
-					Ok((commits, pull_requests))
-				});
-			info!("{}", gitea::FINISHED_FETCHING_MSG);
-			data
-		} else {
-			Ok((vec![], vec![]))
-		}
-	}
+    /// Returns the Gitea metadata needed for the changelog.
+    ///
+    /// This function creates a multithread async runtime for handling the
+    /// requests. The following are fetched from the GitHub REST API:
+    ///
+    /// - Commits
+    /// - Pull requests
+    ///
+    /// Each of these are paginated requests so they are being run in parallel
+    /// for speedup.
+    ///
+    /// If no Gitea related variable is used in the template then this function
+    /// returns empty vectors.
+    #[cfg(feature = "gitea")]
+    fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
+        use crate::remote::gitea;
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
+                .as_ref()
+                .map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
+                .unwrap_or(false)
+        {
+            debug!(
+                "You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>"
+            );
+            let gitea_client = GiteaClient::try_from(self.config.remote.gitea.clone())?;
+            info!(
+                "{} ({})",
+                gitea::START_FETCHING_MSG,
+                self.config.remote.gitea
+            );
+            let data = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(async {
+                    let (commits, pull_requests) = tokio::try_join!(
+                        gitea_client.get_commits(ref_name),
+                        gitea_client.get_pull_requests(ref_name),
+                    )?;
+                    debug!("Number of Gitea commits: {}", commits.len());
+                    debug!("Number of Gitea pull requests: {}", pull_requests.len());
+                    Ok((commits, pull_requests))
+                });
+            info!("{}", gitea::FINISHED_FETCHING_MSG);
+            data
+        } else {
+            Ok((vec![], vec![]))
+        }
+    }
 
-	/// Returns the Bitbucket metadata needed for the changelog.
-	///
-	/// This function creates a multithread async runtime for handling the
-	///
-	/// requests. The following are fetched from the bitbucket REST API:
-	///
-	/// - Commits
-	/// - Pull requests
-	///
-	/// Each of these are paginated requests so they are being run in parallel
-	/// for speedup.
-	///
-	///
-	/// If no bitbucket related variable is used in the template then this
-	/// function returns empty vectors.
-	#[cfg(feature = "bitbucket")]
-	fn get_bitbucket_metadata(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<crate::remote::RemoteMetadata> {
-		use crate::remote::bitbucket;
-		if self.config.remote.bitbucket.is_custom ||
-			self.body_template
-				.contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-			self.footer_template
-				.as_ref()
-				.map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
-				.unwrap_or(false)
-		{
-			debug!("You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>");
-			let bitbucket_client =
-				BitbucketClient::try_from(self.config.remote.bitbucket.clone())?;
-			info!(
-				"{} ({})",
-				bitbucket::START_FETCHING_MSG,
-				self.config.remote.bitbucket
-			);
-			let data = tokio::runtime::Builder::new_multi_thread()
-				.enable_all()
-				.build()?
-				.block_on(async {
-					let (commits, pull_requests) = tokio::try_join!(
-						bitbucket_client.get_commits(ref_name),
-						bitbucket_client.get_pull_requests(ref_name)
-					)?;
-					debug!("Number of Bitbucket commits: {}", commits.len());
-					debug!(
-						"Number of Bitbucket pull requests: {}",
-						pull_requests.len()
-					);
-					Ok((commits, pull_requests))
-				});
-			info!("{}", bitbucket::FINISHED_FETCHING_MSG);
-			data
-		} else {
-			Ok((vec![], vec![]))
-		}
-	}
+    /// Returns the Bitbucket metadata needed for the changelog.
+    ///
+    /// This function creates a multithread async runtime for handling the
+    ///
+    /// requests. The following are fetched from the bitbucket REST API:
+    ///
+    /// - Commits
+    /// - Pull requests
+    ///
+    /// Each of these are paginated requests so they are being run in parallel
+    /// for speedup.
+    ///
+    ///
+    /// If no bitbucket related variable is used in the template then this
+    /// function returns empty vectors.
+    #[cfg(feature = "bitbucket")]
+    fn get_bitbucket_metadata(
+        &self,
+        ref_name: Option<&str>,
+    ) -> Result<crate::remote::RemoteMetadata> {
+        use crate::remote::bitbucket;
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
+                .as_ref()
+                .map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
+                .unwrap_or(false)
+        {
+            debug!(
+                "You are using an experimental feature! Please report bugs at <https://git-cliff.org/issues>"
+            );
+            let bitbucket_client = BitbucketClient::try_from(self.config.remote.bitbucket.clone())?;
+            info!(
+                "{} ({})",
+                bitbucket::START_FETCHING_MSG,
+                self.config.remote.bitbucket
+            );
+            let data = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(async {
+                    let (commits, pull_requests) = tokio::try_join!(
+                        bitbucket_client.get_commits(ref_name),
+                        bitbucket_client.get_pull_requests(ref_name)
+                    )?;
+                    debug!("Number of Bitbucket commits: {}", commits.len());
+                    debug!("Number of Bitbucket pull requests: {}", pull_requests.len());
+                    Ok((commits, pull_requests))
+                });
+            info!("{}", bitbucket::FINISHED_FETCHING_MSG);
+            data
+        } else {
+            Ok((vec![], vec![]))
+        }
+    }
 
-	/// Adds information about the remote to the template context.
-	pub fn add_remote_context(&mut self) -> Result<()> {
-		self.additional_context.insert(
-			"remote".to_string(),
-			serde_json::to_value(self.config.remote.clone())?,
-		);
-		Ok(())
-	}
+    /// Adds information about the remote to the template context.
+    pub fn add_remote_context(&mut self) -> Result<()> {
+        self.additional_context.insert(
+            "remote".to_string(),
+            serde_json::to_value(self.config.remote.clone())?,
+        );
+        Ok(())
+    }
 
-	/// Adds remote data (e.g. GitHub commits) to the releases.
-	pub fn add_remote_data(&mut self, range: Option<&str>) -> Result<()> {
-		debug!("Adding remote data...");
-		self.add_remote_context()?;
+    /// Adds remote data (e.g. GitHub commits) to the releases.
+    pub fn add_remote_data(&mut self, range: Option<&str>) -> Result<()> {
+        debug!("Adding remote data...");
+        self.add_remote_context()?;
 
-		// Determine the ref at which to fetch remote commits, based on the commit
-		// range
-		let range_head = range.and_then(|r| r.split("..").last());
-		let ref_name = match range_head {
-			Some("HEAD") => None,
-			other => other,
-		};
+        // Determine the ref at which to fetch remote commits, based on the commit
+        // range
+        let range_head = range.and_then(|r| r.split("..").last());
+        let ref_name = match range_head {
+            Some("HEAD") => None,
+            other => other,
+        };
 
-		#[cfg(feature = "github")]
-		let (github_commits, github_pull_requests) = if self.config.remote.github.is_set()
-		{
-			self.get_github_metadata(ref_name)
-				.expect("Could not get github metadata")
-		} else {
-			(vec![], vec![])
-		};
-		#[cfg(feature = "gitlab")]
-		let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set()
-		{
-			self.get_gitlab_metadata(ref_name)
-				.expect("Could not get gitlab metadata")
-		} else {
-			(vec![], vec![])
-		};
-		#[cfg(feature = "gitea")]
-		let (gitea_commits, gitea_merge_request) = if self.config.remote.gitea.is_set() {
-			self.get_gitea_metadata(ref_name)
-				.expect("Could not get gitea metadata")
-		} else {
-			(vec![], vec![])
-		};
-		#[cfg(feature = "bitbucket")]
-		let (bitbucket_commits, bitbucket_pull_request) =
-			if self.config.remote.bitbucket.is_set() {
-				self.get_bitbucket_metadata(ref_name)
-					.expect("Could not get bitbucket metadata")
-			} else {
-				(vec![], vec![])
-			};
-		#[cfg(feature = "remote")]
-		for release in &mut self.releases {
-			#[cfg(feature = "github")]
-			release.update_github_metadata(
-				github_commits.clone(),
-				github_pull_requests.clone(),
-			)?;
-			#[cfg(feature = "gitlab")]
-			release.update_gitlab_metadata(
-				gitlab_commits.clone(),
-				gitlab_merge_request.clone(),
-			)?;
-			#[cfg(feature = "gitea")]
-			release.update_gitea_metadata(
-				gitea_commits.clone(),
-				gitea_merge_request.clone(),
-			)?;
-			#[cfg(feature = "bitbucket")]
-			release.update_bitbucket_metadata(
-				bitbucket_commits.clone(),
-				bitbucket_pull_request.clone(),
-			)?;
-		}
-		Ok(())
-	}
+        #[cfg(feature = "github")]
+        let (github_commits, github_pull_requests) = if self.config.remote.github.is_set() {
+            self.get_github_metadata(ref_name)
+                .expect("Could not get github metadata")
+        } else {
+            (vec![], vec![])
+        };
+        #[cfg(feature = "gitlab")]
+        let (gitlab_commits, gitlab_merge_request) = if self.config.remote.gitlab.is_set() {
+            self.get_gitlab_metadata(ref_name)
+                .expect("Could not get gitlab metadata")
+        } else {
+            (vec![], vec![])
+        };
+        #[cfg(feature = "gitea")]
+        let (gitea_commits, gitea_merge_request) = if self.config.remote.gitea.is_set() {
+            self.get_gitea_metadata(ref_name)
+                .expect("Could not get gitea metadata")
+        } else {
+            (vec![], vec![])
+        };
+        #[cfg(feature = "bitbucket")]
+        let (bitbucket_commits, bitbucket_pull_request) = if self.config.remote.bitbucket.is_set() {
+            self.get_bitbucket_metadata(ref_name)
+                .expect("Could not get bitbucket metadata")
+        } else {
+            (vec![], vec![])
+        };
+        #[cfg(feature = "remote")]
+        for release in &mut self.releases {
+            #[cfg(feature = "github")]
+            release.update_github_metadata(github_commits.clone(), github_pull_requests.clone())?;
+            #[cfg(feature = "gitlab")]
+            release.update_gitlab_metadata(gitlab_commits.clone(), gitlab_merge_request.clone())?;
+            #[cfg(feature = "gitea")]
+            release.update_gitea_metadata(gitea_commits.clone(), gitea_merge_request.clone())?;
+            #[cfg(feature = "bitbucket")]
+            release.update_bitbucket_metadata(
+                bitbucket_commits.clone(),
+                bitbucket_pull_request.clone(),
+            )?;
+        }
+        Ok(())
+    }
 
-	/// Increments the version for the unreleased changes based on semver.
-	pub fn bump_version(&mut self) -> Result<Option<String>> {
-		if let Some(ref mut last_release) = self.releases.iter_mut().next() {
-			if last_release.version.is_none() {
-				let next_version = last_release
-					.calculate_next_version_with_config(&self.config.bump)?;
-				debug!("Bumping the version to {next_version}");
-				last_release.version = Some(next_version.to_string());
-				last_release.timestamp = Some(
-					SystemTime::now()
-						.duration_since(UNIX_EPOCH)?
-						.as_secs()
-						.try_into()?,
-				);
-				return Ok(Some(next_version));
-			}
-		}
-		Ok(None)
-	}
+    /// Increments the version for the unreleased changes based on semver.
+    pub fn bump_version(&mut self) -> Result<Option<String>> {
+        if let Some(ref mut last_release) = self.releases.iter_mut().next() {
+            if last_release.version.is_none() {
+                let next_version =
+                    last_release.calculate_next_version_with_config(&self.config.bump)?;
+                debug!("Bumping the version to {next_version}");
+                last_release.version = Some(next_version.to_string());
+                last_release.timestamp = Some(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)?
+                        .as_secs()
+                        .try_into()?,
+                );
+                return Ok(Some(next_version));
+            }
+        }
+        Ok(None)
+    }
 
-	/// Generates the changelog and writes it to the given output.
-	pub fn generate<W: Write + ?Sized>(&self, out: &mut W) -> Result<()> {
-		debug!("Generating changelog...");
-		let postprocessors = self.config.changelog.postprocessors.clone();
+    /// Generates the changelog and writes it to the given output.
+    pub fn generate<W: Write + ?Sized>(&self, out: &mut W) -> Result<()> {
+        debug!("Generating changelog...");
+        let postprocessors = self.config.changelog.postprocessors.clone();
 
-		if let Some(header_template) = &self.header_template {
-			let write_result = writeln!(
-				out,
-				"{}",
-				header_template.render(
-					&Releases {
-						releases: &self.releases,
-					},
-					Some(&self.additional_context),
-					&postprocessors,
-				)?
-			);
-			if let Err(e) = write_result {
-				if e.kind() != std::io::ErrorKind::BrokenPipe {
-					return Err(e.into());
-				}
-			}
-		}
+        if let Some(header_template) = &self.header_template {
+            let write_result = writeln!(
+                out,
+                "{}",
+                header_template.render(
+                    &Releases {
+                        releases: &self.releases,
+                    },
+                    Some(&self.additional_context),
+                    &postprocessors,
+                )?
+            );
+            if let Err(e) = write_result {
+                if e.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(e.into());
+                }
+            }
+        }
 
-		for release in &self.releases {
-			let write_result = write!(
-				out,
-				"{}",
-				self.body_template.render(
-					&release,
-					Some(&self.additional_context),
-					&postprocessors
-				)?
-			);
-			if let Err(e) = write_result {
-				if e.kind() != std::io::ErrorKind::BrokenPipe {
-					return Err(e.into());
-				}
-			}
-		}
+        for release in &self.releases {
+            let write_result = write!(
+                out,
+                "{}",
+                self.body_template.render(
+                    &release,
+                    Some(&self.additional_context),
+                    &postprocessors
+                )?
+            );
+            if let Err(e) = write_result {
+                if e.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(e.into());
+                }
+            }
+        }
 
-		if let Some(footer_template) = &self.footer_template {
-			let write_result = writeln!(
-				out,
-				"{}",
-				footer_template.render(
-					&Releases {
-						releases: &self.releases,
-					},
-					Some(&self.additional_context),
-					&postprocessors,
-				)?
-			);
-			if let Err(e) = write_result {
-				if e.kind() != std::io::ErrorKind::BrokenPipe {
-					return Err(e.into());
-				}
-			}
-		}
+        if let Some(footer_template) = &self.footer_template {
+            let write_result = writeln!(
+                out,
+                "{}",
+                footer_template.render(
+                    &Releases {
+                        releases: &self.releases,
+                    },
+                    Some(&self.additional_context),
+                    &postprocessors,
+                )?
+            );
+            if let Err(e) = write_result {
+                if e.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(e.into());
+                }
+            }
+        }
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	/// Generates a changelog and prepends it to the given changelog.
-	pub fn prepend<W: Write + ?Sized>(
-		&self,
-		mut changelog: String,
-		out: &mut W,
-	) -> Result<()> {
-		debug!("Generating changelog and prepending...");
-		if let Some(header) = &self.config.changelog.header {
-			changelog = changelog.replacen(header, "", 1);
-		}
-		self.generate(out)?;
-		write!(out, "{changelog}")?;
-		Ok(())
-	}
+    /// Generates a changelog and prepends it to the given changelog.
+    pub fn prepend<W: Write + ?Sized>(&self, mut changelog: String, out: &mut W) -> Result<()> {
+        debug!("Generating changelog and prepending...");
+        if let Some(header) = &self.config.changelog.header {
+            changelog = changelog.replacen(header, "", 1);
+        }
+        self.generate(out)?;
+        write!(out, "{changelog}")?;
+        Ok(())
+    }
 
-	/// Prints the changelog context to the given output.
-	pub fn write_context<W: Write + ?Sized>(&self, out: &mut W) -> Result<()> {
-		let output = Releases {
-			releases: &self.releases,
-		}
-		.as_json()?;
-		writeln!(out, "{output}")?;
-		Ok(())
-	}
+    /// Prints the changelog context to the given output.
+    pub fn write_context<W: Write + ?Sized>(&self, out: &mut W) -> Result<()> {
+        let output = Releases {
+            releases: &self.releases,
+        }
+        .as_json()?;
+        writeln!(out, "{output}")?;
+        Ok(())
+    }
 }
 
 fn get_body_template(config: &Config, trim: bool) -> Result<Template> {
-	let template = Template::new("body", config.changelog.body.clone(), trim)?;
-	let deprecated_vars = [
-		"commit.github",
-		"commit.gitea",
-		"commit.gitlab",
-		"commit.bitbucket",
-	];
-	if template.contains_variable(&deprecated_vars) {
-		warn!(
-			"Variables {deprecated_vars:?} are deprecated and will be removed in \
-			 the future. Use `commit.remote` instead."
-		);
-	}
-	Ok(template)
+    let template = Template::new("body", config.changelog.body.clone(), trim)?;
+    let deprecated_vars = [
+        "commit.github",
+        "commit.gitea",
+        "commit.gitlab",
+        "commit.bitbucket",
+    ];
+    if template.contains_variable(&deprecated_vars) {
+        warn!(
+            "Variables {deprecated_vars:?} are deprecated and will be removed in the future. Use \
+             `commit.remote` instead."
+        );
+    }
+    Ok(template)
 }
 
 #[cfg(test)]
 mod test {
-	use std::str;
+    use std::str;
 
-	use pretty_assertions::assert_eq;
-	use regex::Regex;
+    use pretty_assertions::assert_eq;
+    use regex::Regex;
 
-	use super::*;
-	use crate::commit::Signature;
-	use crate::config::{
-		Bump, ChangelogConfig, CommitParser, LinkParser, Remote, RemoteConfig,
-		TextProcessor,
-	};
+    use super::*;
+    use crate::commit::Signature;
+    use crate::config::{
+        Bump, ChangelogConfig, CommitParser, LinkParser, Remote, RemoteConfig, TextProcessor,
+    };
 
-	fn get_test_data() -> (Config, Vec<Release<'static>>) {
-		let config = Config {
-			changelog: ChangelogConfig {
-				header:         Some(String::from("# Changelog")),
-				body:           String::from(
-					r#"{% if version %}
+    fn get_test_data() -> (Config, Vec<Release<'static>>) {
+        let config = Config {
+            changelog: ChangelogConfig {
+                header: Some(String::from("# Changelog")),
+                body: String::from(
+                    r#"{% if version %}
 				## Release [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }} - ({{ repository }})
 				{% if commit_id %}({{ commit_id }}){% endif %}{% else %}
 				## Unreleased{% endif %}
@@ -725,555 +681,534 @@ mod test {
 					- {{ statistics.days_passed_since_last_release }} day(s) passed between releases.
 				{%- endif %}
 				"#,
-				),
-				footer:         Some(String::from(
-					r#"-- total releases: {{ releases | length }} --"#,
-				)),
-				trim:           true,
-				postprocessors: vec![TextProcessor {
-					pattern:         Regex::new("boring")
-						.expect("failed to compile regex"),
-					replace:         Some(String::from("exciting")),
-					replace_command: None,
-				}],
-				render_always:  false,
-				output:         None,
-			},
-			git:       GitConfig {
-				conventional_commits:     true,
-				require_conventional:     false,
-				filter_unconventional:    false,
-				split_commits:            false,
-				commit_preprocessors:     vec![TextProcessor {
-					pattern:         Regex::new("<preprocess>")
-						.expect("failed to compile regex"),
-					replace:         Some(String::from(
-						"this commit is preprocessed",
-					)),
-					replace_command: None,
-				}],
-				commit_parsers:           vec![
-					CommitParser {
-						sha:           Some(String::from("tea")),
-						message:       None,
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("I love tea")),
-						default_scope: None,
-						scope:         None,
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           Some(String::from("coffee")),
-						message:       None,
-						body:          None,
-						footer:        None,
-						group:         None,
-						default_scope: None,
-						scope:         None,
-						skip:          Some(true),
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           Some(String::from("coffee2")),
-						message:       None,
-						body:          None,
-						footer:        None,
-						group:         None,
-						default_scope: None,
-						scope:         None,
-						skip:          Some(true),
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new(r".*merge.*").ok(),
-						body:          None,
-						footer:        None,
-						group:         None,
-						default_scope: None,
-						scope:         None,
-						skip:          Some(true),
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new("feat*").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("New features")),
-						default_scope: Some(String::from("other")),
-						scope:         None,
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new("^fix*").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("Bug Fixes")),
-						default_scope: None,
-						scope:         None,
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new("doc:").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("Documentation")),
-						default_scope: None,
-						scope:         Some(String::from("documentation")),
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new("docs:").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("Documentation")),
-						default_scope: None,
-						scope:         Some(String::from("documentation")),
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new(r"match\((.*)\):.*").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("Matched ($1)")),
-						default_scope: None,
-						scope:         None,
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       None,
-						body:          None,
-						footer:        Regex::new("Footer:.*").ok(),
-						group:         Some(String::from("Footer")),
-						default_scope: None,
-						scope:         Some(String::from("footer")),
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-					CommitParser {
-						sha:           None,
-						message:       Regex::new(".*").ok(),
-						body:          None,
-						footer:        None,
-						group:         Some(String::from("Other")),
-						default_scope: Some(String::from("other")),
-						scope:         None,
-						skip:          None,
-						field:         None,
-						pattern:       None,
-					},
-				],
-				protect_breaking_commits: false,
-				filter_commits:           false,
-				tag_pattern:              None,
-				skip_tags:                Regex::new("v3.*").ok(),
-				ignore_tags:              None,
-				count_tags:               None,
-				use_branch_tags:          false,
-				topo_order:               false,
-				topo_order_commits:       true,
-				sort_commits:             String::from("oldest"),
-				link_parsers:             vec![LinkParser {
-					pattern: Regex::new("#(\\d+)")
-						.expect("issue reference regex should be valid"),
-					href:    String::from("https://github.com/$1"),
-					text:    None,
-				}],
-				limit_commits:            None,
-				recurse_submodules:       None,
-				include_paths:            Vec::new(),
-				exclude_paths:            Vec::new(),
-			},
-			remote:    RemoteConfig {
-				github:    Remote {
-					owner:      String::from("coolguy"),
-					repo:       String::from("awesome"),
-					token:      None,
-					is_custom:  false,
-					api_url:    None,
-					native_tls: None,
-				},
-				gitlab:    Remote {
-					owner:      String::from("coolguy"),
-					repo:       String::from("awesome"),
-					token:      None,
-					is_custom:  false,
-					api_url:    None,
-					native_tls: None,
-				},
-				gitea:     Remote {
-					owner:      String::from("coolguy"),
-					repo:       String::from("awesome"),
-					token:      None,
-					is_custom:  false,
-					api_url:    None,
-					native_tls: None,
-				},
-				bitbucket: Remote {
-					owner:      String::from("coolguy"),
-					repo:       String::from("awesome"),
-					token:      None,
-					is_custom:  false,
-					api_url:    None,
-					native_tls: None,
-				},
-			},
-			bump:      Bump::default(),
-		};
-		let test_release = Release {
-			version: Some(String::from("v1.0.0")),
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit {
-					id: String::from("coffee"),
-					message: String::from("revert(app): skip this commit"),
-					committer: Signature {
-						timestamp: 48704000,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("tea"),
-					message: String::from("feat(app): damn right"),
-					committer: Signature {
-						timestamp: 48790400,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0bc123"),
-					message: String::from("feat(app): add cool features"),
-					committer: Signature {
-						timestamp: 48876800,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("000000"),
-					message: String::from("support unconventional commits"),
-					committer: Signature {
-						timestamp: 48963200,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0bc123"),
-					message: String::from("feat: support unscoped commits"),
-					committer: Signature {
-						timestamp: 49049600,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0werty"),
-					message: String::from("style(ui): make good stuff"),
-					committer: Signature {
-						timestamp: 49136000,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0w3rty"),
-					message: String::from("fix(ui): fix more stuff"),
-					committer: Signature {
-						timestamp: 49222400,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("qw3rty"),
-					message: String::from("doc: update docs"),
-					committer: Signature {
-						timestamp: 49308800,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0bc123"),
-					message: String::from("docs: add some documentation"),
-					committer: Signature {
-						timestamp: 49395200,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("0jkl12"),
-					message: String::from("chore(app): do nothing"),
-					committer: Signature {
-						timestamp: 49481600,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("qwerty"),
-					message: String::from("chore: <preprocess>"),
-					committer: Signature {
-						timestamp: 49568000,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("qwertz"),
-					message: String::from("feat!: support breaking commits"),
-					committer: Signature {
-						timestamp: 49654400,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("qwert0"),
-					message: String::from(
-						"match(group): support regex-replace for groups",
-					),
-					committer: Signature {
-						timestamp: 49740800,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("coffee"),
-					message: String::from("revert(app): skip this commit"),
-					committer: Signature {
-						timestamp: 49827200,
-						..Default::default()
-					},
-					..Default::default()
-				},
-				Commit {
-					id: String::from("footer"),
-					message: String::from("misc: use footer\n\nFooter: footer text"),
-					committer: Signature {
-						timestamp: 49913600,
-						..Default::default()
-					},
-					..Default::default()
-				},
-			],
-			commit_range: None,
-			commit_id: Some(String::from("0bc123")),
-			timestamp: Some(50000000),
-			previous: None,
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::from([(
-				String::from("submodule_one"),
-				vec![
-					Commit::new(
-						String::from("sub0jkl12"),
-						String::from("chore(app): submodule_one do nothing"),
-					),
-					Commit::new(
-						String::from("subqwerty"),
-						String::from("chore: submodule_one <preprocess>"),
-					),
-					Commit::new(
-						String::from("subqwertz"),
-						String::from(
-							"feat!: submodule_one support breaking commits",
-						),
-					),
-					Commit::new(
-						String::from("subqwert0"),
-						String::from(
-							"match(group): submodule_one support regex-replace for \
-							 groups",
-						),
-					),
-				],
-			)]),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		};
-		let releases = vec![
-			test_release.clone(),
-			Release {
-				version: Some(String::from("v3.0.0")),
-				commits: vec![Commit {
-					id: String::from("n0thin"),
-					message: String::from("feat(xyz): skip commit"),
-					committer: Signature {
-						timestamp: 49913600,
-						..Default::default()
-					},
-					..Default::default()
-				}],
-				..Release::default()
-			},
-			Release {
-				version: None,
-				message: None,
-				extra: None,
-				commits: vec![
-					Commit {
-						id: String::from("abc123"),
-						message: String::from("feat(app): add xyz"),
-						committer: Signature {
-							timestamp: 49395200,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("abc124"),
-						message: String::from("docs(app): document zyx"),
-						committer: Signature {
-							timestamp: 49481600,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("def789"),
-						message: String::from("merge #4"),
-						committer: Signature {
-							timestamp: 49568000,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("dev063"),
-						message: String::from("feat(app)!: merge #5"),
-						committer: Signature {
-							timestamp: 49654400,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("qwerty"),
-						message: String::from("fix(app): fix abc"),
-						committer: Signature {
-							timestamp: 49740800,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("hjkl12"),
-						message: String::from("chore(ui): do boring stuff"),
-						committer: Signature {
-							timestamp: 49827200,
-							..Default::default()
-						},
-						..Default::default()
-					},
-					Commit {
-						id: String::from("coffee2"),
-						message: String::from("revert(app): skip this commit"),
-						committer: Signature {
-							timestamp: 49913600,
-							..Default::default()
-						},
-						..Default::default()
-					},
-				],
-				commit_range: None,
-				commit_id: None,
-				timestamp: Some(1000),
-				previous: Some(Box::new(test_release)),
-				repository: Some(String::from("/root/repo")),
-				submodule_commits: HashMap::from([
-					(String::from("submodule_one"), vec![
-						Commit::new(
-							String::from("def349"),
-							String::from("sub_one merge #4"),
-						),
-						Commit::new(
-							String::from("da8912"),
-							String::from("sub_one merge #5"),
-						),
-					]),
-					(String::from("submodule_two"), vec![Commit::new(
-						String::from("ab76ef"),
-						String::from("sub_two bump"),
-					)]),
-				]),
-				statistics: None,
-				#[cfg(feature = "github")]
-				github: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "gitlab")]
-				gitlab: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "gitea")]
-				gitea: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "bitbucket")]
-				bitbucket: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-			},
-		];
-		(config, releases)
-	}
+                ),
+                footer: Some(String::from(
+                    r#"-- total releases: {{ releases | length }} --"#,
+                )),
+                trim: true,
+                postprocessors: vec![TextProcessor {
+                    pattern: Regex::new("boring").expect("failed to compile regex"),
+                    replace: Some(String::from("exciting")),
+                    replace_command: None,
+                }],
+                render_always: false,
+                output: None,
+            },
+            git: GitConfig {
+                conventional_commits: true,
+                require_conventional: false,
+                filter_unconventional: false,
+                split_commits: false,
+                commit_preprocessors: vec![TextProcessor {
+                    pattern: Regex::new("<preprocess>").expect("failed to compile regex"),
+                    replace: Some(String::from("this commit is preprocessed")),
+                    replace_command: None,
+                }],
+                commit_parsers: vec![
+                    CommitParser {
+                        sha: Some(String::from("tea")),
+                        message: None,
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("I love tea")),
+                        default_scope: None,
+                        scope: None,
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: Some(String::from("coffee")),
+                        message: None,
+                        body: None,
+                        footer: None,
+                        group: None,
+                        default_scope: None,
+                        scope: None,
+                        skip: Some(true),
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: Some(String::from("coffee2")),
+                        message: None,
+                        body: None,
+                        footer: None,
+                        group: None,
+                        default_scope: None,
+                        scope: None,
+                        skip: Some(true),
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new(r".*merge.*").ok(),
+                        body: None,
+                        footer: None,
+                        group: None,
+                        default_scope: None,
+                        scope: None,
+                        skip: Some(true),
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new("feat*").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("New features")),
+                        default_scope: Some(String::from("other")),
+                        scope: None,
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new("^fix*").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("Bug Fixes")),
+                        default_scope: None,
+                        scope: None,
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new("doc:").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("Documentation")),
+                        default_scope: None,
+                        scope: Some(String::from("documentation")),
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new("docs:").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("Documentation")),
+                        default_scope: None,
+                        scope: Some(String::from("documentation")),
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new(r"match\((.*)\):.*").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("Matched ($1)")),
+                        default_scope: None,
+                        scope: None,
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: None,
+                        body: None,
+                        footer: Regex::new("Footer:.*").ok(),
+                        group: Some(String::from("Footer")),
+                        default_scope: None,
+                        scope: Some(String::from("footer")),
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                    CommitParser {
+                        sha: None,
+                        message: Regex::new(".*").ok(),
+                        body: None,
+                        footer: None,
+                        group: Some(String::from("Other")),
+                        default_scope: Some(String::from("other")),
+                        scope: None,
+                        skip: None,
+                        field: None,
+                        pattern: None,
+                    },
+                ],
+                protect_breaking_commits: false,
+                filter_commits: false,
+                tag_pattern: None,
+                skip_tags: Regex::new("v3.*").ok(),
+                ignore_tags: None,
+                count_tags: None,
+                use_branch_tags: false,
+                topo_order: false,
+                topo_order_commits: true,
+                sort_commits: String::from("oldest"),
+                link_parsers: vec![LinkParser {
+                    pattern: Regex::new("#(\\d+)").expect("issue reference regex should be valid"),
+                    href: String::from("https://github.com/$1"),
+                    text: None,
+                }],
+                limit_commits: None,
+                recurse_submodules: None,
+                include_paths: Vec::new(),
+                exclude_paths: Vec::new(),
+            },
+            remote: RemoteConfig {
+                github: Remote {
+                    owner: String::from("coolguy"),
+                    repo: String::from("awesome"),
+                    token: None,
+                    is_custom: false,
+                    api_url: None,
+                    native_tls: None,
+                },
+                gitlab: Remote {
+                    owner: String::from("coolguy"),
+                    repo: String::from("awesome"),
+                    token: None,
+                    is_custom: false,
+                    api_url: None,
+                    native_tls: None,
+                },
+                gitea: Remote {
+                    owner: String::from("coolguy"),
+                    repo: String::from("awesome"),
+                    token: None,
+                    is_custom: false,
+                    api_url: None,
+                    native_tls: None,
+                },
+                bitbucket: Remote {
+                    owner: String::from("coolguy"),
+                    repo: String::from("awesome"),
+                    token: None,
+                    is_custom: false,
+                    api_url: None,
+                    native_tls: None,
+                },
+            },
+            bump: Bump::default(),
+        };
+        let test_release = Release {
+            version: Some(String::from("v1.0.0")),
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit {
+                    id: String::from("coffee"),
+                    message: String::from("revert(app): skip this commit"),
+                    committer: Signature {
+                        timestamp: 48704000,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("tea"),
+                    message: String::from("feat(app): damn right"),
+                    committer: Signature {
+                        timestamp: 48790400,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0bc123"),
+                    message: String::from("feat(app): add cool features"),
+                    committer: Signature {
+                        timestamp: 48876800,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("000000"),
+                    message: String::from("support unconventional commits"),
+                    committer: Signature {
+                        timestamp: 48963200,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0bc123"),
+                    message: String::from("feat: support unscoped commits"),
+                    committer: Signature {
+                        timestamp: 49049600,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0werty"),
+                    message: String::from("style(ui): make good stuff"),
+                    committer: Signature {
+                        timestamp: 49136000,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0w3rty"),
+                    message: String::from("fix(ui): fix more stuff"),
+                    committer: Signature {
+                        timestamp: 49222400,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("qw3rty"),
+                    message: String::from("doc: update docs"),
+                    committer: Signature {
+                        timestamp: 49308800,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0bc123"),
+                    message: String::from("docs: add some documentation"),
+                    committer: Signature {
+                        timestamp: 49395200,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("0jkl12"),
+                    message: String::from("chore(app): do nothing"),
+                    committer: Signature {
+                        timestamp: 49481600,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("qwerty"),
+                    message: String::from("chore: <preprocess>"),
+                    committer: Signature {
+                        timestamp: 49568000,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("qwertz"),
+                    message: String::from("feat!: support breaking commits"),
+                    committer: Signature {
+                        timestamp: 49654400,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("qwert0"),
+                    message: String::from("match(group): support regex-replace for groups"),
+                    committer: Signature {
+                        timestamp: 49740800,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("coffee"),
+                    message: String::from("revert(app): skip this commit"),
+                    committer: Signature {
+                        timestamp: 49827200,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                Commit {
+                    id: String::from("footer"),
+                    message: String::from("misc: use footer\n\nFooter: footer text"),
+                    committer: Signature {
+                        timestamp: 49913600,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            ],
+            commit_range: None,
+            commit_id: Some(String::from("0bc123")),
+            timestamp: Some(50000000),
+            previous: None,
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        };
+        let releases = vec![
+            test_release.clone(),
+            Release {
+                version: Some(String::from("v3.0.0")),
+                commits: vec![Commit {
+                    id: String::from("n0thin"),
+                    message: String::from("feat(xyz): skip commit"),
+                    committer: Signature {
+                        timestamp: 49913600,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                ..Release::default()
+            },
+            Release {
+                version: None,
+                message: None,
+                extra: None,
+                commits: vec![
+                    Commit {
+                        id: String::from("abc123"),
+                        message: String::from("feat(app): add xyz"),
+                        committer: Signature {
+                            timestamp: 49395200,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("abc124"),
+                        message: String::from("docs(app): document zyx"),
+                        committer: Signature {
+                            timestamp: 49481600,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("def789"),
+                        message: String::from("merge #4"),
+                        committer: Signature {
+                            timestamp: 49568000,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("dev063"),
+                        message: String::from("feat(app)!: merge #5"),
+                        committer: Signature {
+                            timestamp: 49654400,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("qwerty"),
+                        message: String::from("fix(app): fix abc"),
+                        committer: Signature {
+                            timestamp: 49740800,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("hjkl12"),
+                        message: String::from("chore(ui): do boring stuff"),
+                        committer: Signature {
+                            timestamp: 49827200,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    Commit {
+                        id: String::from("coffee2"),
+                        message: String::from("revert(app): skip this commit"),
+                        committer: Signature {
+                            timestamp: 49913600,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                ],
+                commit_range: None,
+                commit_id: None,
+                timestamp: Some(1000),
+                previous: Some(Box::new(test_release)),
+                repository: Some(String::from("/root/repo")),
+                submodule_commits: HashMap::from([
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
+                ]),
+                statistics: None,
+                #[cfg(feature = "github")]
+                github: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "gitlab")]
+                gitlab: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "gitea")]
+                gitea: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "bitbucket")]
+                bitbucket: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+            },
+        ];
+        (config, releases)
+    }
 
-	#[test]
-	fn changelog_generator() -> Result<()> {
-		let (config, releases) = get_test_data();
+    #[test]
+    fn changelog_generator() -> Result<()> {
+        let (config, releases) = get_test_data();
 
-		let mut changelog = Changelog::new(releases, &config, None)?;
-		changelog.bump_version()?;
-		changelog.releases[0].timestamp = Some(0);
-		let mut out = Vec::new();
-		changelog.generate(&mut out)?;
-		assert_eq!(
-			String::from(
-				r#"# Changelog
+        let mut changelog = Changelog::new(releases, &config, None)?;
+        changelog.bump_version()?;
+        changelog.releases[0].timestamp = Some(0);
+        let mut out = Vec::new();
+        changelog.generate(&mut out)?;
+        assert_eq!(
+            String::from(
+                r#"# Changelog
 
 			## Release [v1.1.0] - 1970-01-01 - (/root/repo)
 
@@ -1352,28 +1287,28 @@ mod test {
 			- 0 linked issue(s) detected in commits.
 			-- total releases: 2 --
 			"#
-			)
-			.replace("			", ""),
-			str::from_utf8(&out).unwrap_or_default()
-		);
+            )
+            .replace("			", ""),
+            str::from_utf8(&out).unwrap_or_default()
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn changelog_generator_render_always() -> Result<()> {
-		let (mut config, mut releases) = get_test_data();
-		config.changelog.render_always = true;
+    #[test]
+    fn changelog_generator_render_always() -> Result<()> {
+        let (mut config, mut releases) = get_test_data();
+        config.changelog.render_always = true;
 
-		releases[0].commits = Vec::new();
-		releases[2].commits = Vec::new();
-		releases[2].previous = Some(Box::new(releases[0].clone()));
-		let changelog = Changelog::new(releases, &config, None)?;
-		let mut out = Vec::new();
-		changelog.generate(&mut out)?;
-		assert_eq!(
-			String::from(
-				r#"# Changelog
+        releases[0].commits = Vec::new();
+        releases[2].commits = Vec::new();
+        releases[2].previous = Some(Box::new(releases[0].clone()));
+        let changelog = Changelog::new(releases, &config, None)?;
+        let mut out = Vec::new();
+        changelog.generate(&mut out)?;
+        assert_eq!(
+            String::from(
+                r#"# Changelog
 
 			## Unreleased
 
@@ -1386,78 +1321,78 @@ mod test {
 			- -578 day(s) passed between releases.
 			-- total releases: 1 --
 			"#
-			)
-			.replace("			", ""),
-			str::from_utf8(&out).unwrap_or_default()
-		);
+            )
+            .replace("			", ""),
+            str::from_utf8(&out).unwrap_or_default()
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn changelog_generator_split_commits() -> Result<()> {
-		let (mut config, mut releases) = get_test_data();
-		config.git.split_commits = true;
-		config.git.filter_unconventional = false;
-		config.git.protect_breaking_commits = true;
-		for parser in config
-			.git
-			.commit_parsers
-			.iter_mut()
-			.filter(|p| p.footer.is_some())
-		{
-			parser.skip = Some(true);
-		}
+    #[test]
+    fn changelog_generator_split_commits() -> Result<()> {
+        let (mut config, mut releases) = get_test_data();
+        config.git.split_commits = true;
+        config.git.filter_unconventional = false;
+        config.git.protect_breaking_commits = true;
+        for parser in config
+            .git
+            .commit_parsers
+            .iter_mut()
+            .filter(|p| p.footer.is_some())
+        {
+            parser.skip = Some(true);
+        }
 
-		releases[0].commits.push(Commit {
-			id: String::from("0bc123"),
-			message: String::from(
-				"feat(app): add some more cool features
+        releases[0].commits.push(Commit {
+            id: String::from("0bc123"),
+            message: String::from(
+                "feat(app): add some more cool features
 feat(app): even more features
 feat(app): feature #3
 ",
-			),
-			committer: Signature {
-				timestamp: 49827200,
-				..Default::default()
-			},
-			..Default::default()
-		});
-		releases[0].commits.push(Commit {
-			id: String::from("003934"),
-			message: String::from(
-				"feat: add awesome stuff
+            ),
+            committer: Signature {
+                timestamp: 49827200,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        releases[0].commits.push(Commit {
+            id: String::from("003934"),
+            message: String::from(
+                "feat: add awesome stuff
 fix(backend): fix awesome stuff
 style: make awesome stuff look better
 ",
-			),
-			committer: Signature {
-				timestamp: 49740800,
-				..Default::default()
-			},
-			..Default::default()
-		});
-		releases[2].commits.push(Commit {
-			id: String::from("123abc"),
-			message: String::from(
-				"chore(deps): bump some deps
+            ),
+            committer: Signature {
+                timestamp: 49740800,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        releases[2].commits.push(Commit {
+            id: String::from("123abc"),
+            message: String::from(
+                "chore(deps): bump some deps
 
 chore(deps): bump some more deps
 chore(deps): fix broken deps
 ",
-			),
-			committer: Signature {
-				timestamp: 49308800,
-				..Default::default()
-			},
-			..Default::default()
-		});
-		let changelog = Changelog::new(releases, &config, None)?;
-		let mut out = Vec::new();
-		changelog.generate(&mut out)?;
-		assert_eq!(
-			String::from(
-				r#"# Changelog
+            ),
+            committer: Signature {
+                timestamp: 49308800,
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let changelog = Changelog::new(releases, &config, None)?;
+        let mut out = Vec::new();
+        changelog.generate(&mut out)?;
+        assert_eq!(
+            String::from(
+                r#"# Changelog
 
 			## Unreleased
 
@@ -1550,19 +1485,19 @@ chore(deps): fix broken deps
 			  - [#3](https://github.com/3) (referenced 1 time(s))
 			-- total releases: 2 --
 			"#
-			)
-			.replace("			", ""),
-			str::from_utf8(&out).unwrap_or_default()
-		);
+            )
+            .replace("			", ""),
+            str::from_utf8(&out).unwrap_or_default()
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn changelog_adds_additional_context() -> Result<()> {
-		let (mut config, releases) = get_test_data();
-		// add `{{ custom_field }}` to the template
-		config.changelog.body = r#"{% if version %}
+    #[test]
+    fn changelog_adds_additional_context() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        // add `{{ custom_field }}` to the template
+        config.changelog.body = r#"{% if version %}
 				## {{ custom_field }} [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 				{% if commit_id %}({{ commit_id }}){% endif %}{% else %}
 				## Unreleased{% endif %}
@@ -1571,12 +1506,12 @@ chore(deps): fix broken deps
 				#### {{ group }}{% for commit in commits %}
 				- {{ commit.message }}{% endfor %}
 				{% endfor %}{% endfor %}"#
-			.to_string();
-		let mut changelog = Changelog::new(releases, &config, None)?;
-		changelog.add_context("custom_field", "Hello")?;
-		let mut out = Vec::new();
-		changelog.generate(&mut out)?;
-		expect_test::expect![[r#"
+            .to_string();
+        let mut changelog = Changelog::new(releases, &config, None)?;
+        changelog.add_context("custom_field", "Hello")?;
+        let mut out = Vec::new();
+        changelog.generate(&mut out)?;
+        expect_test::expect![[r#"
     # Changelog
 
     ## Unreleased
@@ -1640,7 +1575,7 @@ chore(deps): fix broken deps
     - make good stuff
     -- total releases: 2 --
 "#]]
-		.assert_eq(str::from_utf8(&out).unwrap_or_default());
-		Ok(())
-	}
+        .assert_eq(str::from_utf8(&out).unwrap_or_default());
+        Ok(())
+    }
 }

--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -8,78 +8,71 @@ use crate::error::Result;
 ///
 /// Use `input` parameter to specify a text to write to stdin.
 /// Environment variables are set accordingly to `envs`.
-pub fn run(
-	command: &str,
-	input: Option<String>,
-	envs: Vec<(&str, &str)>,
-) -> Result<String> {
-	log::trace!("Running command: {:?}", command);
-	let mut child = if cfg!(target_os = "windows") {
-		Command::new("cmd")
-			.envs(envs)
-			.args(["/C", command])
-			.stdin(Stdio::piped())
-			.stdout(Stdio::piped())
-			.current_dir(env::current_dir()?)
-			.spawn()
-	} else {
-		Command::new("sh")
-			.envs(envs)
-			.args(["-c", command])
-			.stdin(Stdio::piped())
-			.stdout(Stdio::piped())
-			.current_dir(env::current_dir()?)
-			.spawn()
-	}?;
-	if let Some(input) = input {
-		let mut stdin = child
-			.stdin
-			.take()
-			.ok_or_else(|| IoError::other("stdin is not captured"))?;
-		thread::spawn(move || {
-			stdin
-				.write_all(input.as_bytes())
-				.expect("Failed to write to stdin");
-		});
-	}
-	let output = child.wait_with_output()?;
-	if output.status.success() {
-		Ok(str::from_utf8(&output.stdout)?.to_string())
-	} else {
-		for output in [output.stdout, output.stderr] {
-			let output = str::from_utf8(&output)?.to_string();
-			if !output.is_empty() {
-				log::error!("{}", output);
-			}
-		}
-		Err(
-			IoError::other(format!("command exited with {:?}", output.status))
-				.into(),
-		)
-	}
+pub fn run(command: &str, input: Option<String>, envs: Vec<(&str, &str)>) -> Result<String> {
+    log::trace!("Running command: {:?}", command);
+    let mut child = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .envs(envs)
+            .args(["/C", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .current_dir(env::current_dir()?)
+            .spawn()
+    } else {
+        Command::new("sh")
+            .envs(envs)
+            .args(["-c", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .current_dir(env::current_dir()?)
+            .spawn()
+    }?;
+    if let Some(input) = input {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| IoError::other("stdin is not captured"))?;
+        thread::spawn(move || {
+            stdin
+                .write_all(input.as_bytes())
+                .expect("Failed to write to stdin");
+        });
+    }
+    let output = child.wait_with_output()?;
+    if output.status.success() {
+        Ok(str::from_utf8(&output.stdout)?.to_string())
+    } else {
+        for output in [output.stdout, output.stderr] {
+            let output = str::from_utf8(&output)?.to_string();
+            if !output.is_empty() {
+                log::error!("{}", output);
+            }
+        }
+        Err(IoError::other(format!("command exited with {:?}", output.status)).into())
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
+    use super::*;
 
-	#[test]
-	#[cfg(target_family = "unix")]
-	fn run_os_command() -> Result<()> {
-		assert_eq!(
-			"eroc-ffilc-tig",
-			run("echo $APP_NAME | rev", None, vec![(
-				"APP_NAME",
-				env!("CARGO_PKG_NAME")
-			)])?
-			.trim()
-		);
-		assert_eq!(
-			"eroc-ffilc-tig",
-			run("rev", Some(env!("CARGO_PKG_NAME").to_string()), vec![])?.trim()
-		);
-		assert_eq!("testing", run("echo 'testing'", None, vec![])?.trim());
-		assert!(run("some_command", None, vec![]).is_err());
-		Ok(())
-	}
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn run_os_command() -> Result<()> {
+        assert_eq!(
+            "eroc-ffilc-tig",
+            run("echo $APP_NAME | rev", None, vec![(
+                "APP_NAME",
+                env!("CARGO_PKG_NAME")
+            )])?
+            .trim()
+        );
+        assert_eq!(
+            "eroc-ffilc-tig",
+            run("rev", Some(env!("CARGO_PKG_NAME").to_string()), vec![])?.trim()
+        );
+        assert_eq!("testing", run("echo 'testing'", None, vec![])?.trim());
+        assert!(run("some_command", None, vec![]).is_err());
+        Ok(())
+    }
 }

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -17,499 +17,474 @@ static SHA1_REGEX: Lazy<Regex> = lazy_regex!(r#"^\b([a-f0-9]{40})\b (.*)$"#);
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Link {
-	/// Text of the link.
-	pub text: String,
-	/// URL of the link
-	pub href: String,
+    /// Text of the link.
+    pub text: String,
+    /// URL of the link
+    pub href: String,
 }
 
 /// A conventional commit footer.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 struct Footer<'a> {
-	/// Token of the footer.
-	///
-	/// This is the part of the footer preceding the separator. For example, for
-	/// the `Signed-off-by: <user.name>` footer, this would be `Signed-off-by`.
-	token:     &'a str,
-	/// The separator between the footer token and its value.
-	///
-	/// This is typically either `:` or `#`.
-	separator: &'a str,
-	/// The value of the footer.
-	value:     &'a str,
-	/// A flag to signal that the footer describes a breaking change.
-	breaking:  bool,
+    /// Token of the footer.
+    ///
+    /// This is the part of the footer preceding the separator. For example, for
+    /// the `Signed-off-by: <user.name>` footer, this would be `Signed-off-by`.
+    token: &'a str,
+    /// The separator between the footer token and its value.
+    ///
+    /// This is typically either `:` or `#`.
+    separator: &'a str,
+    /// The value of the footer.
+    value: &'a str,
+    /// A flag to signal that the footer describes a breaking change.
+    breaking: bool,
 }
 
 impl<'a> From<&'a ConventionalFooter<'a>> for Footer<'a> {
-	fn from(footer: &'a ConventionalFooter<'a>) -> Self {
-		Self {
-			token:     footer.token().as_str(),
-			separator: footer.separator().as_str(),
-			value:     footer.value(),
-			breaking:  footer.breaking(),
-		}
-	}
+    fn from(footer: &'a ConventionalFooter<'a>) -> Self {
+        Self {
+            token: footer.token().as_str(),
+            separator: footer.separator().as_str(),
+            value: footer.value(),
+            breaking: footer.breaking(),
+        }
+    }
 }
 
 /// Commit signature that indicates authorship.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Signature {
-	/// Name on the signature.
-	pub name:      Option<String>,
-	/// Email on the signature.
-	pub email:     Option<String>,
-	/// Time of the signature.
-	pub timestamp: i64,
+    /// Name on the signature.
+    pub name: Option<String>,
+    /// Email on the signature.
+    pub email: Option<String>,
+    /// Time of the signature.
+    pub timestamp: i64,
 }
 
 #[cfg(feature = "repo")]
 impl<'a> From<CommitSignature<'a>> for Signature {
-	fn from(signature: CommitSignature<'a>) -> Self {
-		Self {
-			name:      signature.name().map(String::from),
-			email:     signature.email().map(String::from),
-			timestamp: signature.when().seconds(),
-		}
-	}
+    fn from(signature: CommitSignature<'a>) -> Self {
+        Self {
+            name: signature.name().map(String::from),
+            email: signature.email().map(String::from),
+            timestamp: signature.when().seconds(),
+        }
+    }
 }
 
 /// Commit range (from..to)
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Range {
-	/// Full commit SHA the range starts at
-	from: String,
-	/// Full commit SHA the range ends at
-	to:   String,
+    /// Full commit SHA the range starts at
+    from: String,
+    /// Full commit SHA the range ends at
+    to: String,
 }
 
 impl Range {
-	/// Creates a new [`Range`] from [`crate::commit::Commit`].
-	pub fn new(from: &Commit, to: &Commit) -> Self {
-		Self {
-			from: from.id.clone(),
-			to:   to.id.clone(),
-		}
-	}
+    /// Creates a new [`Range`] from [`crate::commit::Commit`].
+    pub fn new(from: &Commit, to: &Commit) -> Self {
+        Self {
+            from: from.id.clone(),
+            to: to.id.clone(),
+        }
+    }
 }
 
 /// Common commit object that is parsed from a repository.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Commit<'a> {
-	/// Commit ID.
-	pub id:            String,
-	/// Commit message including title, description and summary.
-	pub message:       String,
-	/// Conventional commit.
-	#[serde(skip_deserializing)]
-	pub conv:          Option<ConventionalCommit<'a>>,
-	/// Commit group based on a commit parser or its conventional type.
-	pub group:         Option<String>,
-	/// Default commit scope based on (inherited from) conventional type or a
-	/// commit parser.
-	pub default_scope: Option<String>,
-	/// Commit scope for overriding the default one.
-	pub scope:         Option<String>,
-	/// A list of links found in the commit
-	pub links:         Vec<Link>,
-	/// Commit author.
-	pub author:        Signature,
-	/// Committer.
-	pub committer:     Signature,
-	/// Whether if the commit has two or more parents.
-	pub merge_commit:  bool,
-	/// Arbitrary data to be used with the `--from-context` CLI option.
-	pub extra:         Option<Value>,
-	/// Remote metadata of the commit.
-	pub remote:        Option<crate::contributor::RemoteContributor>,
-	/// GitHub metadata of the commit.
-	#[cfg(feature = "github")]
-	#[deprecated(note = "Use `remote` field instead")]
-	pub github:        crate::contributor::RemoteContributor,
-	/// GitLab metadata of the commit.
-	#[cfg(feature = "gitlab")]
-	#[deprecated(note = "Use `remote` field instead")]
-	pub gitlab:        crate::contributor::RemoteContributor,
-	/// Gitea metadata of the commit.
-	#[cfg(feature = "gitea")]
-	#[deprecated(note = "Use `remote` field instead")]
-	pub gitea:         crate::contributor::RemoteContributor,
-	/// Bitbucket metadata of the commit.
-	#[cfg(feature = "bitbucket")]
-	#[deprecated(note = "Use `remote` field instead")]
-	pub bitbucket:     crate::contributor::RemoteContributor,
+    /// Commit ID.
+    pub id: String,
+    /// Commit message including title, description and summary.
+    pub message: String,
+    /// Conventional commit.
+    #[serde(skip_deserializing)]
+    pub conv: Option<ConventionalCommit<'a>>,
+    /// Commit group based on a commit parser or its conventional type.
+    pub group: Option<String>,
+    /// Default commit scope based on (inherited from) conventional type or a
+    /// commit parser.
+    pub default_scope: Option<String>,
+    /// Commit scope for overriding the default one.
+    pub scope: Option<String>,
+    /// A list of links found in the commit
+    pub links: Vec<Link>,
+    /// Commit author.
+    pub author: Signature,
+    /// Committer.
+    pub committer: Signature,
+    /// Whether if the commit has two or more parents.
+    pub merge_commit: bool,
+    /// Arbitrary data to be used with the `--from-context` CLI option.
+    pub extra: Option<Value>,
+    /// Remote metadata of the commit.
+    pub remote: Option<crate::contributor::RemoteContributor>,
+    /// GitHub metadata of the commit.
+    #[cfg(feature = "github")]
+    #[deprecated(note = "Use `remote` field instead")]
+    pub github: crate::contributor::RemoteContributor,
+    /// GitLab metadata of the commit.
+    #[cfg(feature = "gitlab")]
+    #[deprecated(note = "Use `remote` field instead")]
+    pub gitlab: crate::contributor::RemoteContributor,
+    /// Gitea metadata of the commit.
+    #[cfg(feature = "gitea")]
+    #[deprecated(note = "Use `remote` field instead")]
+    pub gitea: crate::contributor::RemoteContributor,
+    /// Bitbucket metadata of the commit.
+    #[cfg(feature = "bitbucket")]
+    #[deprecated(note = "Use `remote` field instead")]
+    pub bitbucket: crate::contributor::RemoteContributor,
 
-	/// Raw message of the normal commit, works as a placeholder for converting
-	/// normal commit into conventional commit.
-	///
-	/// Despite the name, it is not actually a raw message.
-	/// In fact, it is pre-processed by [`Commit::preprocess`], and only be
-	/// generated when serializing into `context` the first time.
-	pub raw_message: Option<String>,
+    /// Raw message of the normal commit, works as a placeholder for converting
+    /// normal commit into conventional commit.
+    ///
+    /// Despite the name, it is not actually a raw message.
+    /// In fact, it is pre-processed by [`Commit::preprocess`], and only be
+    /// generated when serializing into `context` the first time.
+    pub raw_message: Option<String>,
 }
 
 impl From<String> for Commit<'_> {
-	fn from(message: String) -> Self {
-		if let Some(captures) = SHA1_REGEX.captures(&message) {
-			if let (Some(id), Some(message)) = (
-				captures.get(1).map(|v| v.as_str()),
-				captures.get(2).map(|v| v.as_str()),
-			) {
-				return Commit {
-					id: id.to_string(),
-					message: message.to_string(),
-					..Default::default()
-				};
-			}
-		}
-		Commit {
-			id: String::new(),
-			message,
-			..Default::default()
-		}
-	}
+    fn from(message: String) -> Self {
+        if let Some(captures) = SHA1_REGEX.captures(&message) {
+            if let (Some(id), Some(message)) = (
+                captures.get(1).map(|v| v.as_str()),
+                captures.get(2).map(|v| v.as_str()),
+            ) {
+                return Commit {
+                    id: id.to_string(),
+                    message: message.to_string(),
+                    ..Default::default()
+                };
+            }
+        }
+        Commit {
+            id: String::new(),
+            message,
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(feature = "repo")]
 impl From<&GitCommit<'_>> for Commit<'_> {
-	fn from(commit: &GitCommit<'_>) -> Self {
-		Commit {
-			id: commit.id().to_string(),
-			message: commit.message().unwrap_or_default().trim_end().to_string(),
-			author: commit.author().into(),
-			committer: commit.committer().into(),
-			merge_commit: commit.parent_count() > 1,
-			..Default::default()
-		}
-	}
+    fn from(commit: &GitCommit<'_>) -> Self {
+        Commit {
+            id: commit.id().to_string(),
+            message: commit.message().unwrap_or_default().trim_end().to_string(),
+            author: commit.author().into(),
+            committer: commit.committer().into(),
+            merge_commit: commit.parent_count() > 1,
+            ..Default::default()
+        }
+    }
 }
 
 impl Commit<'_> {
-	/// Constructs a new instance.
-	pub fn new(id: String, message: String) -> Self {
-		Self {
-			id,
-			message,
-			..Default::default()
-		}
-	}
+    /// Constructs a new instance.
+    pub fn new(id: String, message: String) -> Self {
+        Self {
+            id,
+            message,
+            ..Default::default()
+        }
+    }
 
-	/// Get raw message for converting into conventional commit.
-	pub fn raw_message(&self) -> &str {
-		self.raw_message.as_deref().unwrap_or(&self.message)
-	}
+    /// Get raw message for converting into conventional commit.
+    pub fn raw_message(&self) -> &str {
+        self.raw_message.as_deref().unwrap_or(&self.message)
+    }
 
-	/// Processes the commit.
-	///
-	/// * converts commit to a conventional commit
-	/// * sets the group for the commit
-	/// * extracts links and generates URLs
-	pub fn process(&self, config: &GitConfig) -> Result<Self> {
-		let mut commit = self.clone();
-		commit = commit.preprocess(&config.commit_preprocessors)?;
-		if config.conventional_commits {
-			if !config.require_conventional &&
-				config.filter_unconventional &&
-				!config.split_commits
-			{
-				commit = commit.into_conventional()?;
-			} else if let Ok(conv_commit) = commit.clone().into_conventional() {
-				commit = conv_commit;
-			}
-		}
+    /// Processes the commit.
+    ///
+    /// * converts commit to a conventional commit
+    /// * sets the group for the commit
+    /// * extracts links and generates URLs
+    pub fn process(&self, config: &GitConfig) -> Result<Self> {
+        let mut commit = self.clone();
+        commit = commit.preprocess(&config.commit_preprocessors)?;
+        if config.conventional_commits {
+            if !config.require_conventional && config.filter_unconventional && !config.split_commits
+            {
+                commit = commit.into_conventional()?;
+            } else if let Ok(conv_commit) = commit.clone().into_conventional() {
+                commit = conv_commit;
+            }
+        }
 
-		commit = commit.parse(
-			&config.commit_parsers,
-			config.protect_breaking_commits,
-			config.filter_commits,
-		)?;
+        commit = commit.parse(
+            &config.commit_parsers,
+            config.protect_breaking_commits,
+            config.filter_commits,
+        )?;
 
-		commit = commit.parse_links(&config.link_parsers);
+        commit = commit.parse_links(&config.link_parsers);
 
-		Ok(commit)
-	}
+        Ok(commit)
+    }
 
-	/// Returns the commit with its conventional type set.
-	pub fn into_conventional(mut self) -> Result<Self> {
-		match ConventionalCommit::parse(Box::leak(
-			self.raw_message().to_string().into_boxed_str(),
-		)) {
-			Ok(conv) => {
-				self.conv = Some(conv);
-				Ok(self)
-			}
-			Err(e) => Err(AppError::ParseError(e)),
-		}
-	}
+    /// Returns the commit with its conventional type set.
+    pub fn into_conventional(mut self) -> Result<Self> {
+        match ConventionalCommit::parse(Box::leak(self.raw_message().to_string().into_boxed_str()))
+        {
+            Ok(conv) => {
+                self.conv = Some(conv);
+                Ok(self)
+            }
+            Err(e) => Err(AppError::ParseError(e)),
+        }
+    }
 
-	/// Preprocesses the commit using [`TextProcessor`]s.
-	///
-	/// Modifies the commit [`message`] using regex or custom OS command.
-	///
-	/// [`message`]: Commit::message
-	pub fn preprocess(mut self, preprocessors: &[TextProcessor]) -> Result<Self> {
-		preprocessors.iter().try_for_each(|preprocessor| {
-			preprocessor
-				.replace(&mut self.message, vec![("COMMIT_SHA", &self.id)])?;
-			Ok::<(), AppError>(())
-		})?;
-		Ok(self)
-	}
+    /// Preprocesses the commit using [`TextProcessor`]s.
+    ///
+    /// Modifies the commit [`message`] using regex or custom OS command.
+    ///
+    /// [`message`]: Commit::message
+    pub fn preprocess(mut self, preprocessors: &[TextProcessor]) -> Result<Self> {
+        preprocessors.iter().try_for_each(|preprocessor| {
+            preprocessor.replace(&mut self.message, vec![("COMMIT_SHA", &self.id)])?;
+            Ok::<(), AppError>(())
+        })?;
+        Ok(self)
+    }
 
-	/// States if the commit is skipped in the provided `CommitParser`.
-	///
-	/// Returns `false` if `protect_breaking_commits` is enabled in the config
-	/// and the commit is breaking, or the parser's `skip` field is None or
-	/// `false`. Returns `true` otherwise.
-	fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-		parser.skip.unwrap_or(false) &&
-			!(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) &&
-				protect_breaking)
-	}
+    /// States if the commit is skipped in the provided `CommitParser`.
+    ///
+    /// Returns `false` if `protect_breaking_commits` is enabled in the config
+    /// and the commit is breaking, or the parser's `skip` field is None or
+    /// `false`. Returns `true` otherwise.
+    fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
+        parser.skip.unwrap_or(false) &&
+            !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
+    }
 
-	/// Parses the commit using [`CommitParser`]s.
-	///
-	/// Sets the [`group`] and [`scope`] of the commit.
-	///
-	/// [`group`]: Commit::group
-	/// [`scope`]: Commit::scope
-	pub fn parse(
-		mut self,
-		parsers: &[CommitParser],
-		protect_breaking: bool,
-		filter: bool,
-	) -> Result<Self> {
-		let lookup_context = serde_json::to_value(&self).map_err(|e| {
-			AppError::FieldError(format!(
-				"failed to convert context into value: {e}",
-			))
-		})?;
-		for parser in parsers {
-			let mut regex_checks = Vec::new();
-			if let Some(message_regex) = parser.message.as_ref() {
-				regex_checks.push((message_regex, self.message.to_string()));
-			}
-			let body = self
-				.conv
-				.as_ref()
-				.and_then(|v| v.body())
-				.map(|v| v.to_string());
-			if let Some(body_regex) = parser.body.as_ref() {
-				regex_checks.push((body_regex, body.clone().unwrap_or_default()));
-			}
-			if let (Some(footer_regex), Some(footers)) = (
-				parser.footer.as_ref(),
-				self.conv.as_ref().map(|v| v.footers()),
-			) {
-				regex_checks
-					.extend(footers.iter().map(|f| (footer_regex, f.to_string())));
-			}
-			if let (Some(field_name), Some(pattern_regex)) =
-				(parser.field.as_ref(), parser.pattern.as_ref())
-			{
-				let values = if field_name == "body" {
-					vec![body.clone()].into_iter().collect()
-				} else {
-					tera::dotted_pointer(&lookup_context, field_name).and_then(|v| {
-						match v {
-							Value::String(s) => Some(vec![s.clone()]),
-							Value::Number(_) | Value::Bool(_) | Value::Null => {
-								Some(vec![v.to_string()])
-							}
-							Value::Array(arr) => {
-								let mut values = Vec::new();
-								for item in arr {
-									match item {
-										Value::String(s) => values.push(s.clone()),
-										Value::Number(_) |
-										Value::Bool(_) |
-										Value::Null => values.push(item.to_string()),
-										_ => continue,
-									}
-								}
-								Some(values)
-							}
-							_ => None,
-						}
-					})
-				};
-				match values {
-					Some(values) => {
-						if values.is_empty() {
-							trace!("field '{field_name}' is present but empty");
-						} else {
-							for value in values {
-								regex_checks.push((pattern_regex, value));
-							}
-						}
-					}
-					None => {
-						return Err(AppError::FieldError(format!(
-							"field '{field_name}' is missing or has unsupported \
-							 type (expected a String, Number, Bool, or Null — or \
-							 an Array of these scalar values)",
-						)));
-					}
-				}
-			}
-			if parser.sha.clone().map(|v| v.to_lowercase()).as_deref() ==
-				Some(&self.id)
-			{
-				if self.skip_commit(parser, protect_breaking) {
-					return Err(AppError::GroupError(String::from(
-						"Skipping commit",
-					)));
-				} else {
-					self.group = parser.group.clone().or(self.group);
-					self.scope = parser.scope.clone().or(self.scope);
-					self.default_scope =
-						parser.default_scope.clone().or(self.default_scope);
-					return Ok(self);
-				}
-			}
-			for (regex, text) in regex_checks {
-				if regex.is_match(text.trim()) {
-					if self.skip_commit(parser, protect_breaking) {
-						return Err(AppError::GroupError(String::from(
-							"Skipping commit",
-						)));
-					} else {
-						let regex_replace = |mut value: String| {
-							for mat in regex.find_iter(&text) {
-								value =
-									regex.replace(mat.as_str(), value).to_string();
-							}
-							value
-						};
-						self.group = parser.group.clone().map(regex_replace);
-						self.scope = parser.scope.clone().map(regex_replace);
-						self.default_scope.clone_from(&parser.default_scope);
-						return Ok(self);
-					}
-				}
-			}
-		}
-		if filter {
-			Err(AppError::GroupError(String::from(
-				"Commit does not belong to any group",
-			)))
-		} else {
-			Ok(self)
-		}
-	}
+    /// Parses the commit using [`CommitParser`]s.
+    ///
+    /// Sets the [`group`] and [`scope`] of the commit.
+    ///
+    /// [`group`]: Commit::group
+    /// [`scope`]: Commit::scope
+    pub fn parse(
+        mut self,
+        parsers: &[CommitParser],
+        protect_breaking: bool,
+        filter: bool,
+    ) -> Result<Self> {
+        let lookup_context = serde_json::to_value(&self).map_err(|e| {
+            AppError::FieldError(format!("failed to convert context into value: {e}",))
+        })?;
+        for parser in parsers {
+            let mut regex_checks = Vec::new();
+            if let Some(message_regex) = parser.message.as_ref() {
+                regex_checks.push((message_regex, self.message.to_string()));
+            }
+            let body = self
+                .conv
+                .as_ref()
+                .and_then(|v| v.body())
+                .map(|v| v.to_string());
+            if let Some(body_regex) = parser.body.as_ref() {
+                regex_checks.push((body_regex, body.clone().unwrap_or_default()));
+            }
+            if let (Some(footer_regex), Some(footers)) = (
+                parser.footer.as_ref(),
+                self.conv.as_ref().map(|v| v.footers()),
+            ) {
+                regex_checks.extend(footers.iter().map(|f| (footer_regex, f.to_string())));
+            }
+            if let (Some(field_name), Some(pattern_regex)) =
+                (parser.field.as_ref(), parser.pattern.as_ref())
+            {
+                let values = if field_name == "body" {
+                    vec![body.clone()].into_iter().collect()
+                } else {
+                    tera::dotted_pointer(&lookup_context, field_name).and_then(|v| match v {
+                        Value::String(s) => Some(vec![s.clone()]),
+                        Value::Number(_) | Value::Bool(_) | Value::Null => {
+                            Some(vec![v.to_string()])
+                        }
+                        Value::Array(arr) => {
+                            let mut values = Vec::new();
+                            for item in arr {
+                                match item {
+                                    Value::String(s) => values.push(s.clone()),
+                                    Value::Number(_) | Value::Bool(_) | Value::Null => {
+                                        values.push(item.to_string())
+                                    }
+                                    _ => continue,
+                                }
+                            }
+                            Some(values)
+                        }
+                        _ => None,
+                    })
+                };
+                match values {
+                    Some(values) => {
+                        if values.is_empty() {
+                            trace!("field '{field_name}' is present but empty");
+                        } else {
+                            for value in values {
+                                regex_checks.push((pattern_regex, value));
+                            }
+                        }
+                    }
+                    None => {
+                        return Err(AppError::FieldError(format!(
+                            "field '{field_name}' is missing or has unsupported type (expected a \
+                             String, Number, Bool, or Null — or an Array of these scalar values)",
+                        )));
+                    }
+                }
+            }
+            if parser.sha.clone().map(|v| v.to_lowercase()).as_deref() == Some(&self.id) {
+                if self.skip_commit(parser, protect_breaking) {
+                    return Err(AppError::GroupError(String::from("Skipping commit")));
+                } else {
+                    self.group = parser.group.clone().or(self.group);
+                    self.scope = parser.scope.clone().or(self.scope);
+                    self.default_scope = parser.default_scope.clone().or(self.default_scope);
+                    return Ok(self);
+                }
+            }
+            for (regex, text) in regex_checks {
+                if regex.is_match(text.trim()) {
+                    if self.skip_commit(parser, protect_breaking) {
+                        return Err(AppError::GroupError(String::from("Skipping commit")));
+                    } else {
+                        let regex_replace = |mut value: String| {
+                            for mat in regex.find_iter(&text) {
+                                value = regex.replace(mat.as_str(), value).to_string();
+                            }
+                            value
+                        };
+                        self.group = parser.group.clone().map(regex_replace);
+                        self.scope = parser.scope.clone().map(regex_replace);
+                        self.default_scope.clone_from(&parser.default_scope);
+                        return Ok(self);
+                    }
+                }
+            }
+        }
+        if filter {
+            Err(AppError::GroupError(String::from(
+                "Commit does not belong to any group",
+            )))
+        } else {
+            Ok(self)
+        }
+    }
 
-	/// Parses the commit using [`LinkParser`]s.
-	///
-	/// Sets the [`links`] of the commit.
-	///
-	/// [`links`]: Commit::links
-	pub fn parse_links(mut self, parsers: &[LinkParser]) -> Self {
-		for parser in parsers {
-			let regex = &parser.pattern;
-			let replace = &parser.href;
-			for mat in regex.find_iter(&self.message) {
-				let m = mat.as_str();
-				let text = if let Some(text_replace) = &parser.text {
-					regex.replace(m, text_replace).to_string()
-				} else {
-					m.to_string()
-				};
-				let href = regex.replace(m, replace);
-				self.links.push(Link {
-					text,
-					href: href.to_string(),
-				});
-			}
-		}
-		self
-	}
+    /// Parses the commit using [`LinkParser`]s.
+    ///
+    /// Sets the [`links`] of the commit.
+    ///
+    /// [`links`]: Commit::links
+    pub fn parse_links(mut self, parsers: &[LinkParser]) -> Self {
+        for parser in parsers {
+            let regex = &parser.pattern;
+            let replace = &parser.href;
+            for mat in regex.find_iter(&self.message) {
+                let m = mat.as_str();
+                let text = if let Some(text_replace) = &parser.text {
+                    regex.replace(m, text_replace).to_string()
+                } else {
+                    m.to_string()
+                };
+                let href = regex.replace(m, replace);
+                self.links.push(Link {
+                    text,
+                    href: href.to_string(),
+                });
+            }
+        }
+        self
+    }
 
-	/// Returns an iterator over this commit's [`Footer`]s, if this is a
-	/// conventional commit.
-	///
-	/// If this commit is not conventional, the returned iterator will be empty.
-	fn footers(&self) -> impl Iterator<Item = Footer<'_>> {
-		self.conv
-			.iter()
-			.flat_map(|conv| conv.footers().iter().map(Footer::from))
-	}
+    /// Returns an iterator over this commit's [`Footer`]s, if this is a
+    /// conventional commit.
+    ///
+    /// If this commit is not conventional, the returned iterator will be empty.
+    fn footers(&self) -> impl Iterator<Item = Footer<'_>> {
+        self.conv
+            .iter()
+            .flat_map(|conv| conv.footers().iter().map(Footer::from))
+    }
 }
 
 impl Serialize for Commit<'_> {
-	#[allow(deprecated)]
-	fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-	where
-		S: Serializer,
-	{
-		/// A wrapper to serialize commit footers from an iterator using
-		/// `Serializer::collect_seq` without having to allocate in order to
-		/// `collect` the footers  into a new to `Vec`.
-		struct SerializeFooters<'a>(&'a Commit<'a>);
-		impl Serialize for SerializeFooters<'_> {
-			fn serialize<S>(
-				&self,
-				serializer: S,
-			) -> std::result::Result<S::Ok, S::Error>
-			where
-				S: Serializer,
-			{
-				serializer.collect_seq(self.0.footers())
-			}
-		}
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        /// A wrapper to serialize commit footers from an iterator using
+        /// `Serializer::collect_seq` without having to allocate in order to
+        /// `collect` the footers  into a new to `Vec`.
+        struct SerializeFooters<'a>(&'a Commit<'a>);
+        impl Serialize for SerializeFooters<'_> {
+            fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.collect_seq(self.0.footers())
+            }
+        }
 
-		let mut commit = serializer.serialize_struct("Commit", 20)?;
-		commit.serialize_field("id", &self.id)?;
-		if let Some(conv) = &self.conv {
-			commit.serialize_field("message", conv.description())?;
-			commit.serialize_field("body", &conv.body())?;
-			commit.serialize_field("footers", &SerializeFooters(self))?;
-			commit.serialize_field(
-				"group",
-				self.group.as_ref().unwrap_or(&conv.type_().to_string()),
-			)?;
-			commit.serialize_field(
-				"breaking_description",
-				&conv.breaking_description(),
-			)?;
-			commit.serialize_field("breaking", &conv.breaking())?;
-			commit.serialize_field(
-				"scope",
-				&self
-					.scope
-					.as_deref()
-					.or_else(|| conv.scope().map(|v| v.as_str()))
-					.or(self.default_scope.as_deref()),
-			)?;
-		} else {
-			commit.serialize_field("message", &self.message)?;
-			commit.serialize_field("group", &self.group)?;
-			commit.serialize_field(
-				"scope",
-				&self.scope.as_deref().or(self.default_scope.as_deref()),
-			)?;
-		}
+        let mut commit = serializer.serialize_struct("Commit", 20)?;
+        commit.serialize_field("id", &self.id)?;
+        if let Some(conv) = &self.conv {
+            commit.serialize_field("message", conv.description())?;
+            commit.serialize_field("body", &conv.body())?;
+            commit.serialize_field("footers", &SerializeFooters(self))?;
+            commit.serialize_field(
+                "group",
+                self.group.as_ref().unwrap_or(&conv.type_().to_string()),
+            )?;
+            commit.serialize_field("breaking_description", &conv.breaking_description())?;
+            commit.serialize_field("breaking", &conv.breaking())?;
+            commit.serialize_field(
+                "scope",
+                &self
+                    .scope
+                    .as_deref()
+                    .or_else(|| conv.scope().map(|v| v.as_str()))
+                    .or(self.default_scope.as_deref()),
+            )?;
+        } else {
+            commit.serialize_field("message", &self.message)?;
+            commit.serialize_field("group", &self.group)?;
+            commit.serialize_field(
+                "scope",
+                &self.scope.as_deref().or(self.default_scope.as_deref()),
+            )?;
+        }
 
-		commit.serialize_field("links", &self.links)?;
-		commit.serialize_field("author", &self.author)?;
-		commit.serialize_field("committer", &self.committer)?;
-		commit.serialize_field("conventional", &self.conv.is_some())?;
-		commit.serialize_field("merge_commit", &self.merge_commit)?;
-		commit.serialize_field("extra", &self.extra)?;
-		#[cfg(feature = "github")]
-		commit.serialize_field("github", &self.github)?;
-		#[cfg(feature = "gitlab")]
-		commit.serialize_field("gitlab", &self.gitlab)?;
-		#[cfg(feature = "gitea")]
-		commit.serialize_field("gitea", &self.gitea)?;
-		#[cfg(feature = "bitbucket")]
-		commit.serialize_field("bitbucket", &self.bitbucket)?;
-		if let Some(remote) = &self.remote {
-			commit.serialize_field("remote", remote)?;
-		}
-		commit.serialize_field("raw_message", &self.raw_message())?;
-		commit.end()
-	}
+        commit.serialize_field("links", &self.links)?;
+        commit.serialize_field("author", &self.author)?;
+        commit.serialize_field("committer", &self.committer)?;
+        commit.serialize_field("conventional", &self.conv.is_some())?;
+        commit.serialize_field("merge_commit", &self.merge_commit)?;
+        commit.serialize_field("extra", &self.extra)?;
+        #[cfg(feature = "github")]
+        commit.serialize_field("github", &self.github)?;
+        #[cfg(feature = "gitlab")]
+        commit.serialize_field("gitlab", &self.gitlab)?;
+        #[cfg(feature = "gitea")]
+        commit.serialize_field("gitea", &self.gitea)?;
+        #[cfg(feature = "bitbucket")]
+        commit.serialize_field("bitbucket", &self.bitbucket)?;
+        if let Some(remote) = &self.remote {
+            commit.serialize_field("remote", remote)?;
+        }
+        commit.serialize_field("raw_message", &self.raw_message())?;
+        commit.end()
+    }
 }
 
 /// Deserialize commits into conventional commits if they are convertible.
@@ -520,540 +495,528 @@ impl Serialize for Commit<'_> {
 ///
 /// This function is to be used only in [`crate::release::Release::commits`].
 pub(crate) fn commits_to_conventional_commits<'de, 'a, D: Deserializer<'de>>(
-	deserializer: D,
+    deserializer: D,
 ) -> std::result::Result<Vec<Commit<'a>>, D::Error> {
-	let commits = Vec::<Commit<'a>>::deserialize(deserializer)?;
-	let commits = commits
-		.into_iter()
-		.map(|commit| commit.clone().into_conventional().unwrap_or(commit))
-		.collect();
-	Ok(commits)
+    let commits = Vec::<Commit<'a>>::deserialize(deserializer)?;
+    let commits = commits
+        .into_iter()
+        .map(|commit| commit.clone().into_conventional().unwrap_or(commit))
+        .collect();
+    Ok(commits)
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
-	#[test]
-	fn conventional_commit() -> Result<()> {
-		let test_cases = vec![
-			(
-				Commit::new(
-					String::from("123123"),
-					String::from("test(commit): add test"),
-				),
-				true,
-			),
-			(
-				Commit::new(String::from("124124"), String::from("xyz")),
-				false,
-			),
-		];
+    use super::*;
+    #[test]
+    fn conventional_commit() -> Result<()> {
+        let test_cases = vec![
+            (
+                Commit::new(
+                    String::from("123123"),
+                    String::from("test(commit): add test"),
+                ),
+                true,
+            ),
+            (
+                Commit::new(String::from("124124"), String::from("xyz")),
+                false,
+            ),
+        ];
 
-		for (commit, is_conventional) in &test_cases {
-			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
-		}
+        for (commit, is_conventional) in &test_cases {
+            assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
+        }
 
-		let commit = test_cases[0].0.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       Regex::new("test*").ok(),
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("test_group")),
-				default_scope: Some(String::from("test_scope")),
-				scope:         None,
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("test_group")), commit.group);
-		assert_eq!(Some(String::from("test_scope")), commit.default_scope);
+        let commit = test_cases[0].0.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: Regex::new("test*").ok(),
+                body: None,
+                footer: None,
+                group: Some(String::from("test_group")),
+                default_scope: Some(String::from("test_scope")),
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("test_group")), commit.group);
+        assert_eq!(Some(String::from("test_scope")), commit.default_scope);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn conventional_footers() {
-		let cfg = crate::config::GitConfig {
-			conventional_commits: true,
-			..Default::default()
-		};
-		let test_cases = vec![
-			(
-				Commit::new(
-					String::from("123123"),
-					String::from(
-						"test(commit): add test\n\nSigned-off-by: Test User \
-						 <test@example.com>",
-					),
-				),
-				vec![Footer {
-					token:     "Signed-off-by",
-					separator: ":",
-					value:     "Test User <test@example.com>",
-					breaking:  false,
-				}],
-			),
-			(
-				Commit::new(
-					String::from("123124"),
-					String::from(
-						"fix(commit): break stuff\n\nBREAKING CHANGE: This commit \
-						 breaks stuff\nSigned-off-by: Test User <test@example.com>",
-					),
-				),
-				vec![
-					Footer {
-						token:     "BREAKING CHANGE",
-						separator: ":",
-						value:     "This commit breaks stuff",
-						breaking:  true,
-					},
-					Footer {
-						token:     "Signed-off-by",
-						separator: ":",
-						value:     "Test User <test@example.com>",
-						breaking:  false,
-					},
-				],
-			),
-		];
+    #[test]
+    fn conventional_footers() {
+        let cfg = crate::config::GitConfig {
+            conventional_commits: true,
+            ..Default::default()
+        };
+        let test_cases = vec![
+            (
+                Commit::new(
+                    String::from("123123"),
+                    String::from(
+                        "test(commit): add test\n\nSigned-off-by: Test User <test@example.com>",
+                    ),
+                ),
+                vec![Footer {
+                    token: "Signed-off-by",
+                    separator: ":",
+                    value: "Test User <test@example.com>",
+                    breaking: false,
+                }],
+            ),
+            (
+                Commit::new(
+                    String::from("123124"),
+                    String::from(
+                        "fix(commit): break stuff\n\nBREAKING CHANGE: This commit breaks \
+                         stuff\nSigned-off-by: Test User <test@example.com>",
+                    ),
+                ),
+                vec![
+                    Footer {
+                        token: "BREAKING CHANGE",
+                        separator: ":",
+                        value: "This commit breaks stuff",
+                        breaking: true,
+                    },
+                    Footer {
+                        token: "Signed-off-by",
+                        separator: ":",
+                        value: "Test User <test@example.com>",
+                        breaking: false,
+                    },
+                ],
+            ),
+        ];
 
-		for (commit, footers) in &test_cases {
-			let commit = commit.process(&cfg).expect("commit should process");
-			assert_eq!(&commit.footers().collect::<Vec<_>>(), footers);
-		}
-	}
+        for (commit, footers) in &test_cases {
+            let commit = commit.process(&cfg).expect("commit should process");
+            assert_eq!(&commit.footers().collect::<Vec<_>>(), footers);
+        }
+    }
 
-	#[test]
-	fn parse_link() -> Result<()> {
-		let test_cases = vec![
-			(
-				Commit::new(
-					String::from("123123"),
-					String::from("test(commit): add test\n\nBody with issue #123"),
-				),
-				true,
-			),
-			(
-				Commit::new(
-					String::from("123123"),
-					String::from(
-						"test(commit): add test\n\nImlement RFC456\n\nFixes: #456",
-					),
-				),
-				true,
-			),
-		];
+    #[test]
+    fn parse_link() -> Result<()> {
+        let test_cases = vec![
+            (
+                Commit::new(
+                    String::from("123123"),
+                    String::from("test(commit): add test\n\nBody with issue #123"),
+                ),
+                true,
+            ),
+            (
+                Commit::new(
+                    String::from("123123"),
+                    String::from("test(commit): add test\n\nImlement RFC456\n\nFixes: #456"),
+                ),
+                true,
+            ),
+        ];
 
-		for (commit, is_conventional) in &test_cases {
-			assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
-		}
+        for (commit, is_conventional) in &test_cases {
+            assert_eq!(is_conventional, &commit.clone().into_conventional().is_ok());
+        }
 
-		let commit = Commit::new(
-			String::from("123123"),
-			String::from("test(commit): add test\n\nImlement RFC456\n\nFixes: #455"),
-		);
+        let commit = Commit::new(
+            String::from("123123"),
+            String::from("test(commit): add test\n\nImlement RFC456\n\nFixes: #455"),
+        );
 
-		let commit = commit.parse_links(&[
-			LinkParser {
-				pattern: Regex::new("RFC(\\d+)")?,
-				href:    String::from("rfc://$1"),
-				text:    None,
-			},
-			LinkParser {
-				pattern: Regex::new("#(\\d+)")?,
-				href:    String::from("https://github.com/$1"),
-				text:    None,
-			},
-		]);
-		assert_eq!(
-			vec![
-				Link {
-					text: String::from("RFC456"),
-					href: String::from("rfc://456"),
-				},
-				Link {
-					text: String::from("#455"),
-					href: String::from("https://github.com/455"),
-				}
-			],
-			commit.links
-		);
+        let commit = commit.parse_links(&[
+            LinkParser {
+                pattern: Regex::new("RFC(\\d+)")?,
+                href: String::from("rfc://$1"),
+                text: None,
+            },
+            LinkParser {
+                pattern: Regex::new("#(\\d+)")?,
+                href: String::from("https://github.com/$1"),
+                text: None,
+            },
+        ]);
+        assert_eq!(
+            vec![
+                Link {
+                    text: String::from("RFC456"),
+                    href: String::from("rfc://456"),
+                },
+                Link {
+                    text: String::from("#455"),
+                    href: String::from("https://github.com/455"),
+                }
+            ],
+            commit.links
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn parse_commit() {
-		assert_eq!(
-			Commit::new(String::new(), String::from("test: no sha1 given")),
-			Commit::from(String::from("test: no sha1 given"))
-		);
+    #[test]
+    fn parse_commit() {
+        assert_eq!(
+            Commit::new(String::new(), String::from("test: no sha1 given")),
+            Commit::from(String::from("test: no sha1 given"))
+        );
 
-		assert_eq!(
-			Commit::new(
-				String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-				String::from("feat: do something")
-			),
-			Commit::from(String::from(
-				"8f55e69eba6e6ce811ace32bd84cc82215673cb6 feat: do something"
-			))
-		);
+        assert_eq!(
+            Commit::new(
+                String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+                String::from("feat: do something")
+            ),
+            Commit::from(String::from(
+                "8f55e69eba6e6ce811ace32bd84cc82215673cb6 feat: do something"
+            ))
+        );
 
-		assert_eq!(
-			Commit::new(
-				String::from("3bdd0e690c4cd5bd00e5201cc8ef3ce3fb235853"),
-				String::from("chore: do something")
-			),
-			Commit::from(String::from(
-				"3bdd0e690c4cd5bd00e5201cc8ef3ce3fb235853 chore: do something"
-			))
-		);
+        assert_eq!(
+            Commit::new(
+                String::from("3bdd0e690c4cd5bd00e5201cc8ef3ce3fb235853"),
+                String::from("chore: do something")
+            ),
+            Commit::from(String::from(
+                "3bdd0e690c4cd5bd00e5201cc8ef3ce3fb235853 chore: do something"
+            ))
+        );
 
-		assert_eq!(
-			Commit::new(
-				String::new(),
-				String::from("thisisinvalidsha1 style: add formatting")
-			),
-			Commit::from(String::from("thisisinvalidsha1 style: add formatting"))
-		);
-	}
+        assert_eq!(
+            Commit::new(
+                String::new(),
+                String::from("thisisinvalidsha1 style: add formatting")
+            ),
+            Commit::from(String::from("thisisinvalidsha1 style: add formatting"))
+        );
+    }
 
-	#[test]
-	fn parse_body() -> Result<()> {
-		let mut commit = Commit::new(
-			String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-			String::from(
-				"fix: do something
+    #[test]
+    fn parse_body() -> Result<()> {
+        let mut commit = Commit::new(
+            String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+            String::from(
+                "fix: do something
 
 Introduce something great
 
 BREAKING CHANGE: drop support for something else
 Refs: #123
 ",
-			),
-		);
-		commit.author = Signature {
-			name:      Some("John Doe".to_string()),
-			email:     None,
-			timestamp: 0x0,
-		};
-		commit.remote = Some(crate::contributor::RemoteContributor {
-			username:      None,
-			pr_title:      Some("feat: do something".to_string()),
-			pr_number:     None,
-			pr_labels:     vec![
-				String::from("feature"),
-				String::from("deprecation"),
-			],
-			is_first_time: true,
-		});
-		let commit = commit.into_conventional()?;
-		let commit = commit.parse_links(&[
-			LinkParser {
-				pattern: Regex::new("RFC(\\d+)")?,
-				href:    String::from("rfc://$1"),
-				text:    None,
-			},
-			LinkParser {
-				pattern: Regex::new("#(\\d+)")?,
-				href:    String::from("https://github.com/$1"),
-				text:    None,
-			},
-		]);
+            ),
+        );
+        commit.author = Signature {
+            name: Some("John Doe".to_string()),
+            email: None,
+            timestamp: 0x0,
+        };
+        commit.remote = Some(crate::contributor::RemoteContributor {
+            username: None,
+            pr_title: Some("feat: do something".to_string()),
+            pr_number: None,
+            pr_labels: vec![String::from("feature"), String::from("deprecation")],
+            is_first_time: true,
+        });
+        let commit = commit.into_conventional()?;
+        let commit = commit.parse_links(&[
+            LinkParser {
+                pattern: Regex::new("RFC(\\d+)")?,
+                href: String::from("rfc://$1"),
+                text: None,
+            },
+            LinkParser {
+                pattern: Regex::new("#(\\d+)")?,
+                href: String::from("https://github.com/$1"),
+                text: None,
+            },
+        ]);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          Regex::new("something great").ok(),
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: Regex::new("something great").ok(),
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn parse_commit_field() -> Result<()> {
-		let mut commit = Commit::new(
-			String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-			String::from(
-				"fix: do something
+    #[test]
+    fn parse_commit_field() -> Result<()> {
+        let mut commit = Commit::new(
+            String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+            String::from(
+                "fix: do something
 
 Introduce something great
 
 BREAKING CHANGE: drop support for something else
 Refs: #123
 ",
-			),
-		);
-		commit.author = Signature {
-			name:      Some("John Doe".to_string()),
-			email:     None,
-			timestamp: 0x0,
-		};
-		commit.remote = Some(crate::contributor::RemoteContributor {
-			username:      None,
-			pr_title:      Some("feat: do something".to_string()),
-			pr_number:     None,
-			pr_labels:     vec![
-				String::from("feature"),
-				String::from("deprecation"),
-			],
-			is_first_time: true,
-		});
-		let commit = commit.into_conventional()?;
-		let commit = commit.parse_links(&[
-			LinkParser {
-				pattern: Regex::new("RFC(\\d+)")?,
-				href:    String::from("rfc://$1"),
-				text:    None,
-			},
-			LinkParser {
-				pattern: Regex::new("#(\\d+)")?,
-				href:    String::from("https://github.com/$1"),
-				text:    None,
-			},
-		]);
+            ),
+        );
+        commit.author = Signature {
+            name: Some("John Doe".to_string()),
+            email: None,
+            timestamp: 0x0,
+        };
+        commit.remote = Some(crate::contributor::RemoteContributor {
+            username: None,
+            pr_title: Some("feat: do something".to_string()),
+            pr_number: None,
+            pr_labels: vec![String::from("feature"), String::from("deprecation")],
+            is_first_time: true,
+        });
+        let commit = commit.into_conventional()?;
+        let commit = commit.parse_links(&[
+            LinkParser {
+                pattern: Regex::new("RFC(\\d+)")?,
+                href: String::from("rfc://$1"),
+                text: None,
+            },
+            LinkParser {
+                pattern: Regex::new("#(\\d+)")?,
+                href: String::from("https://github.com/$1"),
+                text: None,
+            },
+        ]);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("author.name")),
-				pattern:       Regex::new("John Doe").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("author.name")),
+                pattern: Regex::new("John Doe").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("remote.pr_title")),
-				pattern:       Regex::new("feat: do something").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("remote.pr_title")),
+                pattern: Regex::new("feat: do something").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("body")),
-				pattern:       Regex::new("something great").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("body")),
+                pattern: Regex::new("something great").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("remote.pr_labels")),
-				pattern:       Regex::new("feature|deprecation").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("remote.pr_labels")),
+                pattern: Regex::new("feature|deprecation").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("links")),
-				pattern:       Regex::new(".*").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(None, parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("links")),
+                pattern: Regex::new(".*").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(None, parsed_commit.group);
 
-		let parse_result = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("remote")),
-				pattern:       Regex::new(".*").ok(),
-			}],
-			false,
-			false,
-		);
-		assert!(
-			parse_result.is_err(),
-			"Expected error when using unsupported field `remote`, but got Ok"
-		);
+        let parse_result = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("remote")),
+                pattern: Regex::new(".*").ok(),
+            }],
+            false,
+            false,
+        );
+        assert!(
+            parse_result.is_err(),
+            "Expected error when using unsupported field `remote`, but got Ok"
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn commit_sha() -> Result<()> {
-		let commit = Commit::new(
-			String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-			String::from("feat: do something"),
-		);
+    #[test]
+    fn commit_sha() -> Result<()> {
+        let commit = Commit::new(
+            String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+            String::from("feat: do something"),
+        );
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           Some(String::from(
-					"8f55e69eba6e6ce811ace32bd84cc82215673cb6",
-				)),
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         None,
-				default_scope: None,
-				scope:         None,
-				skip:          Some(true),
-				field:         None,
-				pattern:       None,
-			}],
-			false,
-			false,
-		);
-		assert!(
-			parsed_commit.is_err(),
-			"Expected error when parsing with `skip: Some(true)`, but got Ok"
-		);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: Some(String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6")),
+                message: None,
+                body: None,
+                footer: None,
+                group: None,
+                default_scope: None,
+                scope: None,
+                skip: Some(true),
+                field: None,
+                pattern: None,
+            }],
+            false,
+            false,
+        );
+        assert!(
+            parsed_commit.is_err(),
+            "Expected error when parsing with `skip: Some(true)`, but got Ok"
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn field_name_regex() -> Result<()> {
-		let mut commit = Commit::new(
-			String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
-			String::from("feat: do something"),
-		);
-		commit.author = Signature {
-			name:      Some("John Doe".to_string()),
-			email:     None,
-			timestamp: 0x0,
-		};
-		commit.remote = Some(crate::contributor::RemoteContributor {
-			username:      None,
-			pr_title:      Some("feat: do something".to_string()),
-			pr_number:     None,
-			pr_labels:     Vec::new(),
-			is_first_time: true,
-		});
+    #[test]
+    fn field_name_regex() -> Result<()> {
+        let mut commit = Commit::new(
+            String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+            String::from("feat: do something"),
+        );
+        commit.author = Signature {
+            name: Some("John Doe".to_string()),
+            email: None,
+            timestamp: 0x0,
+        };
+        commit.remote = Some(crate::contributor::RemoteContributor {
+            username: None,
+            pr_title: Some("feat: do something".to_string()),
+            pr_number: None,
+            pr_labels: Vec::new(),
+            is_first_time: true,
+        });
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("author.name")),
-				pattern:       Regex::new("^John Doe$").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("author.name")),
+                pattern: Regex::new("^John Doe$").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parsed_commit = commit.clone().parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("remote.pr_title")),
-				pattern:       Regex::new("^feat(\\([^)]+\\))?").ok(),
-			}],
-			false,
-			false,
-		)?;
-		assert_eq!(Some(String::from("Test group")), parsed_commit.group);
+        let parsed_commit = commit.clone().parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("remote.pr_title")),
+                pattern: Regex::new("^feat(\\([^)]+\\))?").ok(),
+            }],
+            false,
+            false,
+        )?;
+        assert_eq!(Some(String::from("Test group")), parsed_commit.group);
 
-		let parse_result = commit.parse(
-			&[CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("Test group")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("author.name")),
-				pattern:       Regex::new("Something else").ok(),
-			}],
-			false,
-			true,
-		);
-		assert!(
-			parse_result.is_err(),
-			"Expected error because `author.name` did not match the given pattern, \
-			 but got Ok"
-		);
+        let parse_result = commit.parse(
+            &[CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Test group")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("author.name")),
+                pattern: Regex::new("Something else").ok(),
+            }],
+            false,
+            true,
+        );
+        assert!(
+            parse_result.is_err(),
+            "Expected error because `author.name` did not match the given pattern, but got Ok"
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 }

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -17,556 +17,537 @@ const DEFAULT_INITIAL_TAG: &str = "0.1.0";
 /// Manifest file information and regex for matching contents.
 #[derive(Debug)]
 struct ManifestInfo {
-	/// Path of the manifest.
-	path:  PathBuf,
-	/// Regular expression for matching metadata in the manifest.
-	regex: Regex,
+    /// Path of the manifest.
+    path: PathBuf,
+    /// Regular expression for matching metadata in the manifest.
+    regex: Regex,
 }
 
 lazy_static::lazy_static! {
-	/// Array containing manifest information for Rust and Python projects.
-	static ref MANIFEST_INFO: Vec<ManifestInfo> = vec![
-		ManifestInfo {
-			path: PathBuf::from("Cargo.toml"),
-			regex: RegexBuilder::new(
-				r"^\[(?:workspace|package)\.metadata\.git\-cliff\.",
-			)
-			.multi_line(true)
-			.build()
-			.expect("failed to build regex"),
-		},
-		ManifestInfo {
-			path: PathBuf::from("pyproject.toml"),
-			regex: RegexBuilder::new(r"^\[(?:tool)\.git\-cliff\.")
-				.multi_line(true)
-				.build()
-				.expect("failed to build regex"),
-		},
-	];
+    /// Array containing manifest information for Rust and Python projects.
+    static ref MANIFEST_INFO: Vec<ManifestInfo> = vec![
+        ManifestInfo {
+            path: PathBuf::from("Cargo.toml"),
+            regex: RegexBuilder::new(
+                r"^\[(?:workspace|package)\.metadata\.git\-cliff\.",
+            )
+            .multi_line(true)
+            .build()
+            .expect("failed to build regex"),
+        },
+        ManifestInfo {
+            path: PathBuf::from("pyproject.toml"),
+            regex: RegexBuilder::new(r"^\[(?:tool)\.git\-cliff\.")
+                .multi_line(true)
+                .build()
+                .expect("failed to build regex"),
+        },
+    ];
 
 }
 
 /// Configuration values.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-	/// Configuration values about changelog generation.
-	#[serde(default)]
-	pub changelog: ChangelogConfig,
-	/// Configuration values about git.
-	#[serde(default)]
-	pub git:       GitConfig,
-	/// Configuration values about remote.
-	#[serde(default)]
-	pub remote:    RemoteConfig,
-	/// Configuration values about bump version.
-	#[serde(default)]
-	pub bump:      Bump,
+    /// Configuration values about changelog generation.
+    #[serde(default)]
+    pub changelog: ChangelogConfig,
+    /// Configuration values about git.
+    #[serde(default)]
+    pub git: GitConfig,
+    /// Configuration values about remote.
+    #[serde(default)]
+    pub remote: RemoteConfig,
+    /// Configuration values about bump version.
+    #[serde(default)]
+    pub bump: Bump,
 }
 
 /// Changelog configuration.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ChangelogConfig {
-	/// Changelog header.
-	pub header:         Option<String>,
-	/// Changelog body, template.
-	pub body:           String,
-	/// Changelog footer.
-	pub footer:         Option<String>,
-	/// Trim the template.
-	pub trim:           bool,
-	/// Always render the body template.
-	pub render_always:  bool,
-	/// Changelog postprocessors.
-	pub postprocessors: Vec<TextProcessor>,
-	/// Output file path.
-	pub output:         Option<PathBuf>,
+    /// Changelog header.
+    pub header: Option<String>,
+    /// Changelog body, template.
+    pub body: String,
+    /// Changelog footer.
+    pub footer: Option<String>,
+    /// Trim the template.
+    pub trim: bool,
+    /// Always render the body template.
+    pub render_always: bool,
+    /// Changelog postprocessors.
+    pub postprocessors: Vec<TextProcessor>,
+    /// Output file path.
+    pub output: Option<PathBuf>,
 }
 
 /// Git configuration
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
-	/// Parse commits according to the conventional commits specification.
-	pub conventional_commits:  bool,
-	/// Require all commits to be conventional.
-	/// Takes precedence over filter_unconventional.
-	pub require_conventional:  bool,
-	/// Exclude commits that do not match the conventional commits specification
-	/// from the changelog.
-	pub filter_unconventional: bool,
-	/// Split commits on newlines, treating each line as an individual commit.
-	pub split_commits:         bool,
+    /// Parse commits according to the conventional commits specification.
+    pub conventional_commits: bool,
+    /// Require all commits to be conventional.
+    /// Takes precedence over filter_unconventional.
+    pub require_conventional: bool,
+    /// Exclude commits that do not match the conventional commits specification
+    /// from the changelog.
+    pub filter_unconventional: bool,
+    /// Split commits on newlines, treating each line as an individual commit.
+    pub split_commits: bool,
 
-	/// An array of regex based parsers to modify commit messages prior to
-	/// further processing.
-	pub commit_preprocessors:     Vec<TextProcessor>,
-	/// An array of regex based parsers for extracting data from the commit
-	/// message.
-	pub commit_parsers:           Vec<CommitParser>,
-	/// Prevent commits having the `BREAKING CHANGE:` footer from being excluded
-	/// by commit parsers.
-	pub protect_breaking_commits: bool,
-	/// An array of regex based parsers to extract links from the commit message
-	/// and add them to the commit's context.
-	pub link_parsers:             Vec<LinkParser>,
-	/// Exclude commits that are not matched by any commit parser.
-	pub filter_commits:           bool,
-	/// Regex to select git tags that represent releases.
-	#[serde(with = "serde_regex", default)]
-	pub tag_pattern:              Option<Regex>,
-	/// Regex to select git tags that do not represent proper releases.
-	#[serde(with = "serde_regex", default)]
-	pub skip_tags:                Option<Regex>,
-	/// Regex to exclude git tags after applying the tag_pattern.
-	#[serde(with = "serde_regex", default)]
-	pub ignore_tags:              Option<Regex>,
-	/// Regex to count matched tags.
-	#[serde(with = "serde_regex", default)]
-	pub count_tags:               Option<Regex>,
-	/// Include only the tags that belong to the current branch.
-	pub use_branch_tags:          bool,
-	/// Order releases topologically instead of chronologically.
-	pub topo_order:               bool,
-	/// Order commits chronologically instead of topologically.
-	pub topo_order_commits:       bool,
-	/// How to order commits in each group/release within the changelog.
-	pub sort_commits:             String,
-	/// Limit the total number of commits included in the changelog.
-	pub limit_commits:            Option<usize>,
-	/// Read submodule commits.
-	pub recurse_submodules:       Option<bool>,
-	/// Include related commits with changes at the specified paths.
-	#[serde(with = "serde_pattern", default)]
-	pub include_paths:            Vec<Pattern>,
-	/// Exclude unrelated commits with changes at the specified paths.
-	#[serde(with = "serde_pattern", default)]
-	pub exclude_paths:            Vec<Pattern>,
+    /// An array of regex based parsers to modify commit messages prior to
+    /// further processing.
+    pub commit_preprocessors: Vec<TextProcessor>,
+    /// An array of regex based parsers for extracting data from the commit
+    /// message.
+    pub commit_parsers: Vec<CommitParser>,
+    /// Prevent commits having the `BREAKING CHANGE:` footer from being excluded
+    /// by commit parsers.
+    pub protect_breaking_commits: bool,
+    /// An array of regex based parsers to extract links from the commit message
+    /// and add them to the commit's context.
+    pub link_parsers: Vec<LinkParser>,
+    /// Exclude commits that are not matched by any commit parser.
+    pub filter_commits: bool,
+    /// Regex to select git tags that represent releases.
+    #[serde(with = "serde_regex", default)]
+    pub tag_pattern: Option<Regex>,
+    /// Regex to select git tags that do not represent proper releases.
+    #[serde(with = "serde_regex", default)]
+    pub skip_tags: Option<Regex>,
+    /// Regex to exclude git tags after applying the tag_pattern.
+    #[serde(with = "serde_regex", default)]
+    pub ignore_tags: Option<Regex>,
+    /// Regex to count matched tags.
+    #[serde(with = "serde_regex", default)]
+    pub count_tags: Option<Regex>,
+    /// Include only the tags that belong to the current branch.
+    pub use_branch_tags: bool,
+    /// Order releases topologically instead of chronologically.
+    pub topo_order: bool,
+    /// Order commits chronologically instead of topologically.
+    pub topo_order_commits: bool,
+    /// How to order commits in each group/release within the changelog.
+    pub sort_commits: String,
+    /// Limit the total number of commits included in the changelog.
+    pub limit_commits: Option<usize>,
+    /// Read submodule commits.
+    pub recurse_submodules: Option<bool>,
+    /// Include related commits with changes at the specified paths.
+    #[serde(with = "serde_pattern", default)]
+    pub include_paths: Vec<Pattern>,
+    /// Exclude unrelated commits with changes at the specified paths.
+    #[serde(with = "serde_pattern", default)]
+    pub exclude_paths: Vec<Pattern>,
 }
 
 /// Serialize and deserialize implementation for [`glob::Pattern`].
 mod serde_pattern {
-	use glob::Pattern;
-	use serde::Deserialize;
-	use serde::de::Error;
-	use serde::ser::SerializeSeq;
+    use glob::Pattern;
+    use serde::Deserialize;
+    use serde::de::Error;
+    use serde::ser::SerializeSeq;
 
-	pub fn serialize<S>(
-		patterns: &[Pattern],
-		serializer: S,
-	) -> Result<S::Ok, S::Error>
-	where
-		S: serde::Serializer,
-	{
-		let mut seq = serializer.serialize_seq(Some(patterns.len()))?;
-		for pattern in patterns {
-			seq.serialize_element(pattern.as_str())?;
-		}
-		seq.end()
-	}
+    pub fn serialize<S>(patterns: &[Pattern], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(patterns.len()))?;
+        for pattern in patterns {
+            seq.serialize_element(pattern.as_str())?;
+        }
+        seq.end()
+    }
 
-	pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Pattern>, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		let patterns = Vec::<String>::deserialize(deserializer)?;
-		patterns
-			.into_iter()
-			.map(|pattern| pattern.parse().map_err(D::Error::custom))
-			.collect()
-	}
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Pattern>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let patterns = Vec::<String>::deserialize(deserializer)?;
+        patterns
+            .into_iter()
+            .map(|pattern| pattern.parse().map_err(D::Error::custom))
+            .collect()
+    }
 }
 
 /// Remote configuration.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RemoteConfig {
-	/// GitHub remote.
-	#[serde(default)]
-	pub github:    Remote,
-	/// GitLab remote.
-	#[serde(default)]
-	pub gitlab:    Remote,
-	/// Gitea remote.
-	#[serde(default)]
-	pub gitea:     Remote,
-	/// Bitbucket remote.
-	#[serde(default)]
-	pub bitbucket: Remote,
+    /// GitHub remote.
+    #[serde(default)]
+    pub github: Remote,
+    /// GitLab remote.
+    #[serde(default)]
+    pub gitlab: Remote,
+    /// Gitea remote.
+    #[serde(default)]
+    pub gitea: Remote,
+    /// Bitbucket remote.
+    #[serde(default)]
+    pub bitbucket: Remote,
 }
 
 impl RemoteConfig {
-	/// Returns `true` if any remote is set.
-	pub fn is_any_set(&self) -> bool {
-		#[cfg(feature = "github")]
-		if self.github.is_set() {
-			return true;
-		}
-		#[cfg(feature = "gitlab")]
-		if self.gitlab.is_set() {
-			return true;
-		}
-		#[cfg(feature = "gitea")]
-		if self.gitea.is_set() {
-			return true;
-		}
-		#[cfg(feature = "bitbucket")]
-		if self.bitbucket.is_set() {
-			return true;
-		}
-		false
-	}
+    /// Returns `true` if any remote is set.
+    pub fn is_any_set(&self) -> bool {
+        #[cfg(feature = "github")]
+        if self.github.is_set() {
+            return true;
+        }
+        #[cfg(feature = "gitlab")]
+        if self.gitlab.is_set() {
+            return true;
+        }
+        #[cfg(feature = "gitea")]
+        if self.gitea.is_set() {
+            return true;
+        }
+        #[cfg(feature = "bitbucket")]
+        if self.bitbucket.is_set() {
+            return true;
+        }
+        false
+    }
 
-	/// Enables the native TLS for all remotes.
-	pub fn enable_native_tls(&mut self) {
-		#[cfg(feature = "github")]
-		{
-			self.github.native_tls = Some(true);
-		}
-		#[cfg(feature = "gitlab")]
-		{
-			self.gitlab.native_tls = Some(true);
-		}
-		#[cfg(feature = "gitea")]
-		{
-			self.gitea.native_tls = Some(true);
-		}
-		#[cfg(feature = "bitbucket")]
-		{
-			self.bitbucket.native_tls = Some(true);
-		}
-	}
+    /// Enables the native TLS for all remotes.
+    pub fn enable_native_tls(&mut self) {
+        #[cfg(feature = "github")]
+        {
+            self.github.native_tls = Some(true);
+        }
+        #[cfg(feature = "gitlab")]
+        {
+            self.gitlab.native_tls = Some(true);
+        }
+        #[cfg(feature = "gitea")]
+        {
+            self.gitea.native_tls = Some(true);
+        }
+        #[cfg(feature = "bitbucket")]
+        {
+            self.bitbucket.native_tls = Some(true);
+        }
+    }
 }
 
 /// A single remote.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Remote {
-	/// Owner of the remote.
-	pub owner:      String,
-	/// Repository name.
-	pub repo:       String,
-	/// Access token.
-	#[serde(skip_serializing)]
-	pub token:      Option<SecretString>,
-	/// Whether if the remote is set manually.
-	#[serde(skip_deserializing, default = "default_true")]
-	pub is_custom:  bool,
-	/// Remote API URL.
-	pub api_url:    Option<String>,
-	/// Whether to use native TLS.
-	pub native_tls: Option<bool>,
+    /// Owner of the remote.
+    pub owner: String,
+    /// Repository name.
+    pub repo: String,
+    /// Access token.
+    #[serde(skip_serializing)]
+    pub token: Option<SecretString>,
+    /// Whether if the remote is set manually.
+    #[serde(skip_deserializing, default = "default_true")]
+    pub is_custom: bool,
+    /// Remote API URL.
+    pub api_url: Option<String>,
+    /// Whether to use native TLS.
+    pub native_tls: Option<bool>,
 }
 
 /// Returns `true` for serde's `default` attribute.
 fn default_true() -> bool {
-	true
+    true
 }
 
 impl fmt::Display for Remote {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}/{}", self.owner, self.repo)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)
+    }
 }
 
 impl PartialEq for Remote {
-	fn eq(&self, other: &Self) -> bool {
-		self.to_string() == other.to_string()
-	}
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
 }
 
 impl Remote {
-	/// Constructs a new instance.
-	pub fn new<S: Into<String>>(owner: S, repo: S) -> Self {
-		Self {
-			owner:      owner.into(),
-			repo:       repo.into(),
-			token:      None,
-			is_custom:  false,
-			api_url:    None,
-			native_tls: None,
-		}
-	}
+    /// Constructs a new instance.
+    pub fn new<S: Into<String>>(owner: S, repo: S) -> Self {
+        Self {
+            owner: owner.into(),
+            repo: repo.into(),
+            token: None,
+            is_custom: false,
+            api_url: None,
+            native_tls: None,
+        }
+    }
 
-	/// Returns `true` if the remote has an owner and repo.
-	pub fn is_set(&self) -> bool {
-		!self.owner.is_empty() && !self.repo.is_empty()
-	}
+    /// Returns `true` if the remote has an owner and repo.
+    pub fn is_set(&self) -> bool {
+        !self.owner.is_empty() && !self.repo.is_empty()
+    }
 }
 
 /// Version bump type.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum BumpType {
-	/// Bump major version.
-	Major,
-	/// Bump minor version.
-	Minor,
-	/// Bump patch version.
-	Patch,
+    /// Bump major version.
+    Major,
+    /// Bump minor version.
+    Minor,
+    /// Bump patch version.
+    Patch,
 }
 
 /// Bump version configuration.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Bump {
-	/// Configures automatic minor version increments for feature changes.
-	///
-	/// When `true`, a feature will always trigger a minor version update.
-	/// When `false`, a feature will trigger:
-	///
-	/// - A patch version update if the major version is 0.
-	/// - A minor version update otherwise.
-	pub features_always_bump_minor: Option<bool>,
+    /// Configures automatic minor version increments for feature changes.
+    ///
+    /// When `true`, a feature will always trigger a minor version update.
+    /// When `false`, a feature will trigger:
+    ///
+    /// - A patch version update if the major version is 0.
+    /// - A minor version update otherwise.
+    pub features_always_bump_minor: Option<bool>,
 
-	/// Configures 0 -> 1 major version increments for breaking changes.
-	///
-	/// When `true`, a breaking change commit will always trigger a major
-	/// version update (including the transition from version 0 to 1)
-	/// When `false`, a breaking change commit will trigger:
-	///
-	/// - A minor version update if the major version is 0.
-	/// - A major version update otherwise.
-	pub breaking_always_bump_major: Option<bool>,
+    /// Configures 0 -> 1 major version increments for breaking changes.
+    ///
+    /// When `true`, a breaking change commit will always trigger a major
+    /// version update (including the transition from version 0 to 1)
+    /// When `false`, a breaking change commit will trigger:
+    ///
+    /// - A minor version update if the major version is 0.
+    /// - A major version update otherwise.
+    pub breaking_always_bump_major: Option<bool>,
 
-	/// Configures the initial version of the project.
-	///
-	/// When set, the version will be set to this value if no tags are found.
-	pub initial_tag: Option<String>,
+    /// Configures the initial version of the project.
+    ///
+    /// When set, the version will be set to this value if no tags are found.
+    pub initial_tag: Option<String>,
 
-	/// Configure a custom regex pattern for major version increments.
-	///
-	/// This will check only the type of the commit against the given pattern.
-	///
-	/// ### Note
-	///
-	/// `commit type` according to the spec is only `[a-zA-Z]+`
-	pub custom_major_increment_regex: Option<String>,
+    /// Configure a custom regex pattern for major version increments.
+    ///
+    /// This will check only the type of the commit against the given pattern.
+    ///
+    /// ### Note
+    ///
+    /// `commit type` according to the spec is only `[a-zA-Z]+`
+    pub custom_major_increment_regex: Option<String>,
 
-	/// Configure a custom regex pattern for minor version increments.
-	///
-	/// This will check only the type of the commit against the given pattern.
-	///
-	/// ### Note
-	///
-	/// `commit type` according to the spec is only `[a-zA-Z]+`
-	pub custom_minor_increment_regex: Option<String>,
+    /// Configure a custom regex pattern for minor version increments.
+    ///
+    /// This will check only the type of the commit against the given pattern.
+    ///
+    /// ### Note
+    ///
+    /// `commit type` according to the spec is only `[a-zA-Z]+`
+    pub custom_minor_increment_regex: Option<String>,
 
-	/// Force to always bump in major, minor or patch.
-	pub bump_type: Option<BumpType>,
+    /// Force to always bump in major, minor or patch.
+    pub bump_type: Option<BumpType>,
 }
 
 impl Bump {
-	/// Returns the initial tag.
-	///
-	/// This function also logs the returned value.
-	pub fn get_initial_tag(&self) -> String {
-		if let Some(tag) = self.initial_tag.clone() {
-			warn!(
-				"No releases found, using initial tag '{tag}' as the next version."
-			);
-			tag
-		} else {
-			warn!(
-				"No releases found, using {DEFAULT_INITIAL_TAG} as the next \
-				 version."
-			);
-			DEFAULT_INITIAL_TAG.into()
-		}
-	}
+    /// Returns the initial tag.
+    ///
+    /// This function also logs the returned value.
+    pub fn get_initial_tag(&self) -> String {
+        if let Some(tag) = self.initial_tag.clone() {
+            warn!("No releases found, using initial tag '{tag}' as the next version.");
+            tag
+        } else {
+            warn!("No releases found, using {DEFAULT_INITIAL_TAG} as the next version.");
+            DEFAULT_INITIAL_TAG.into()
+        }
+    }
 }
 
 /// Parser for grouping commits.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct CommitParser {
-	/// SHA1 of the commit.
-	pub sha:           Option<String>,
-	/// Regex for matching the commit message.
-	#[serde(with = "serde_regex", default)]
-	pub message:       Option<Regex>,
-	/// Regex for matching the commit body.
-	#[serde(with = "serde_regex", default)]
-	pub body:          Option<Regex>,
-	/// Regex for matching the commit footer.
-	#[serde(with = "serde_regex", default)]
-	pub footer:        Option<Regex>,
-	/// Group of the commit.
-	pub group:         Option<String>,
-	/// Default scope of the commit.
-	pub default_scope: Option<String>,
-	/// Commit scope for overriding the default scope.
-	pub scope:         Option<String>,
-	/// Whether to skip this commit group.
-	pub skip:          Option<bool>,
-	/// Field name of the commit to match the regex against.
-	pub field:         Option<String>,
-	/// Regex for matching the field value.
-	#[serde(with = "serde_regex", default)]
-	pub pattern:       Option<Regex>,
+    /// SHA1 of the commit.
+    pub sha: Option<String>,
+    /// Regex for matching the commit message.
+    #[serde(with = "serde_regex", default)]
+    pub message: Option<Regex>,
+    /// Regex for matching the commit body.
+    #[serde(with = "serde_regex", default)]
+    pub body: Option<Regex>,
+    /// Regex for matching the commit footer.
+    #[serde(with = "serde_regex", default)]
+    pub footer: Option<Regex>,
+    /// Group of the commit.
+    pub group: Option<String>,
+    /// Default scope of the commit.
+    pub default_scope: Option<String>,
+    /// Commit scope for overriding the default scope.
+    pub scope: Option<String>,
+    /// Whether to skip this commit group.
+    pub skip: Option<bool>,
+    /// Field name of the commit to match the regex against.
+    pub field: Option<String>,
+    /// Regex for matching the field value.
+    #[serde(with = "serde_regex", default)]
+    pub pattern: Option<Regex>,
 }
 
 /// `TextProcessor`, e.g. for modifying commit messages.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextProcessor {
-	/// Regex for matching a text to replace.
-	#[serde(with = "serde_regex")]
-	pub pattern:         Regex,
-	/// Replacement text.
-	pub replace:         Option<String>,
-	/// Command that will be run for replacing the commit message.
-	pub replace_command: Option<String>,
+    /// Regex for matching a text to replace.
+    #[serde(with = "serde_regex")]
+    pub pattern: Regex,
+    /// Replacement text.
+    pub replace: Option<String>,
+    /// Command that will be run for replacing the commit message.
+    pub replace_command: Option<String>,
 }
 
 impl TextProcessor {
-	/// Replaces the text with using the given pattern or the command output.
-	pub fn replace(
-		&self,
-		rendered: &mut String,
-		command_envs: Vec<(&str, &str)>,
-	) -> Result<()> {
-		if let Some(text) = &self.replace {
-			*rendered = self.pattern.replace_all(rendered, text).to_string();
-		} else if let Some(command) = &self.replace_command {
-			if self.pattern.is_match(rendered) {
-				*rendered =
-					command::run(command, Some(rendered.to_string()), command_envs)?;
-			}
-		}
-		Ok(())
-	}
+    /// Replaces the text with using the given pattern or the command output.
+    pub fn replace(&self, rendered: &mut String, command_envs: Vec<(&str, &str)>) -> Result<()> {
+        if let Some(text) = &self.replace {
+            *rendered = self.pattern.replace_all(rendered, text).to_string();
+        } else if let Some(command) = &self.replace_command {
+            if self.pattern.is_match(rendered) {
+                *rendered = command::run(command, Some(rendered.to_string()), command_envs)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Parser for extracting links in commits.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LinkParser {
-	/// Regex for finding links in the commit message.
-	#[serde(with = "serde_regex")]
-	pub pattern: Regex,
-	/// The string used to generate the link URL.
-	pub href:    String,
-	/// The string used to generate the link text.
-	pub text:    Option<String>,
+    /// Regex for finding links in the commit message.
+    #[serde(with = "serde_regex")]
+    pub pattern: Regex,
+    /// The string used to generate the link URL.
+    pub href: String,
+    /// The string used to generate the link text.
+    pub text: Option<String>,
 }
 
 impl Config {
-	/// Reads the config file contents from project manifest (e.g. Cargo.toml,
-	/// pyproject.toml)
-	pub fn read_from_manifest() -> Result<Option<String>> {
-		for info in &(*MANIFEST_INFO) {
-			if info.path.exists() {
-				let contents = fs::read_to_string(&info.path)?;
-				if info.regex.is_match(&contents) {
-					return Ok(Some(
-						info.regex.replace_all(&contents, "[").to_string(),
-					));
-				}
-			}
-		}
-		Ok(None)
-	}
+    /// Reads the config file contents from project manifest (e.g. Cargo.toml,
+    /// pyproject.toml)
+    pub fn read_from_manifest() -> Result<Option<String>> {
+        for info in &(*MANIFEST_INFO) {
+            if info.path.exists() {
+                let contents = fs::read_to_string(&info.path)?;
+                if info.regex.is_match(&contents) {
+                    return Ok(Some(info.regex.replace_all(&contents, "[").to_string()));
+                }
+            }
+        }
+        Ok(None)
+    }
 
-	/// Parses the config file and returns the values.
-	pub fn load(path: &Path) -> Result<Config> {
-		if MANIFEST_INFO
-			.iter()
-			.any(|v| path.file_name() == v.path.file_name())
-		{
-			if let Some(contents) = Self::read_from_manifest()? {
-				return contents.parse();
-			}
-		}
+    /// Parses the config file and returns the values.
+    pub fn load(path: &Path) -> Result<Config> {
+        if MANIFEST_INFO
+            .iter()
+            .any(|v| path.file_name() == v.path.file_name())
+        {
+            if let Some(contents) = Self::read_from_manifest()? {
+                return contents.parse();
+            }
+        }
 
-		// Adding sources one after another overwrites the previous values.
-		// Thus adding the default config initializes the config with default values.
-		let default_config_str = EmbeddedConfig::get_config()?;
-		Ok(config::Config::builder()
-			.add_source(config::File::from_str(
-				&default_config_str,
-				config::FileFormat::Toml,
-			))
-			.add_source(config::File::from(path))
-			.add_source(
-				config::Environment::with_prefix("GIT_CLIFF").separator("__"),
-			)
-			.build()?
-			.try_deserialize()?)
-	}
+        // Adding sources one after another overwrites the previous values.
+        // Thus adding the default config initializes the config with default values.
+        let default_config_str = EmbeddedConfig::get_config()?;
+        Ok(config::Config::builder()
+            .add_source(config::File::from_str(
+                &default_config_str,
+                config::FileFormat::Toml,
+            ))
+            .add_source(config::File::from(path))
+            .add_source(config::Environment::with_prefix("GIT_CLIFF").separator("__"))
+            .build()?
+            .try_deserialize()?)
+    }
 }
 
 impl FromStr for Config {
-	type Err = error::Error;
+    type Err = error::Error;
 
-	/// Parses the config file from string and returns the values.
-	fn from_str(contents: &str) -> Result<Self> {
-		// Adding sources one after another overwrites the previous values.
-		// Thus adding the default config initializes the config with default
-		// values.
-		let default_config_str = EmbeddedConfig::get_config()?;
+    /// Parses the config file from string and returns the values.
+    fn from_str(contents: &str) -> Result<Self> {
+        // Adding sources one after another overwrites the previous values.
+        // Thus adding the default config initializes the config with default
+        // values.
+        let default_config_str = EmbeddedConfig::get_config()?;
 
-		Ok(config::Config::builder()
-			.add_source(config::File::from_str(
-				&default_config_str,
-				config::FileFormat::Toml,
-			))
-			.add_source(config::File::from_str(contents, config::FileFormat::Toml))
-			.add_source(
-				config::Environment::with_prefix("GIT_CLIFF").separator("__"),
-			)
-			.build()?
-			.try_deserialize()?)
-	}
+        Ok(config::Config::builder()
+            .add_source(config::File::from_str(
+                &default_config_str,
+                config::FileFormat::Toml,
+            ))
+            .add_source(config::File::from_str(contents, config::FileFormat::Toml))
+            .add_source(config::Environment::with_prefix("GIT_CLIFF").separator("__"))
+            .build()?
+            .try_deserialize()?)
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use std::env;
+    use std::env;
 
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	#[test]
-	fn load() -> Result<()> {
-		let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-			.parent()
-			.expect("parent directory not found")
-			.to_path_buf()
-			.join("config")
-			.join(crate::DEFAULT_CONFIG);
+    use super::*;
+    #[test]
+    fn load() -> Result<()> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("parent directory not found")
+            .to_path_buf()
+            .join("config")
+            .join(crate::DEFAULT_CONFIG);
 
-		const FOOTER_VALUE: &str = "test";
-		const TAG_PATTERN_VALUE: &str = ".*[0-9].*";
-		const IGNORE_TAGS_VALUE: &str = "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+";
+        const FOOTER_VALUE: &str = "test";
+        const TAG_PATTERN_VALUE: &str = ".*[0-9].*";
+        const IGNORE_TAGS_VALUE: &str = "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+";
 
-		unsafe {
-			env::set_var("GIT_CLIFF__CHANGELOG__FOOTER", FOOTER_VALUE);
-			env::set_var("GIT_CLIFF__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
-			env::set_var("GIT_CLIFF__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
-		};
+        unsafe {
+            env::set_var("GIT_CLIFF__CHANGELOG__FOOTER", FOOTER_VALUE);
+            env::set_var("GIT_CLIFF__GIT__TAG_PATTERN", TAG_PATTERN_VALUE);
+            env::set_var("GIT_CLIFF__GIT__IGNORE_TAGS", IGNORE_TAGS_VALUE);
+        };
 
-		let config = Config::load(&path)?;
+        let config = Config::load(&path)?;
 
-		assert_eq!(Some(String::from(FOOTER_VALUE)), config.changelog.footer);
-		assert_eq!(
-			Some(String::from(TAG_PATTERN_VALUE)),
-			config
-				.git
-				.tag_pattern
-				.map(|tag_pattern| tag_pattern.to_string())
-		);
-		assert_eq!(
-			Some(String::from(IGNORE_TAGS_VALUE)),
-			config
-				.git
-				.ignore_tags
-				.map(|ignore_tags| ignore_tags.to_string())
-		);
-		Ok(())
-	}
+        assert_eq!(Some(String::from(FOOTER_VALUE)), config.changelog.footer);
+        assert_eq!(
+            Some(String::from(TAG_PATTERN_VALUE)),
+            config
+                .git
+                .tag_pattern
+                .map(|tag_pattern| tag_pattern.to_string())
+        );
+        assert_eq!(
+            Some(String::from(IGNORE_TAGS_VALUE)),
+            config
+                .git
+                .ignore_tags
+                .map(|ignore_tags| ignore_tags.to_string())
+        );
+        Ok(())
+    }
 
-	#[test]
-	fn remote_config() {
-		let remote1 = Remote::new("abc", "xyz1");
-		let remote2 = Remote::new("abc", "xyz2");
-		assert!(!remote1.eq(&remote2));
-		assert_eq!("abc/xyz1", remote1.to_string());
-		assert!(remote1.is_set());
-		assert!(!Remote::new("", "test").is_set());
-		assert!(!Remote::new("test", "").is_set());
-		assert!(!Remote::new("", "").is_set());
-	}
+    #[test]
+    fn remote_config() {
+        let remote1 = Remote::new("abc", "xyz1");
+        let remote2 = Remote::new("abc", "xyz2");
+        assert!(!remote1.eq(&remote2));
+        assert_eq!("abc/xyz1", remote1.to_string());
+        assert!(remote1.is_set());
+        assert!(!Remote::new("", "test").is_set());
+        assert!(!Remote::new("test", "").is_set());
+        assert!(!Remote::new("", "").is_set());
+    }
 }

--- a/git-cliff-core/src/contributor.rs
+++ b/git-cliff-core/src/contributor.rs
@@ -5,20 +5,20 @@ use serde::{Deserialize, Serialize};
 /// Representation of a remote contributor.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RemoteContributor {
-	/// Username.
-	pub username:      Option<String>,
-	/// Title of the pull request.
-	pub pr_title:      Option<String>,
-	/// The pull request that the user created.
-	pub pr_number:     Option<i64>,
-	/// Labels of the pull request.
-	pub pr_labels:     Vec<String>,
-	/// Whether if the user contributed for the first time.
-	pub is_first_time: bool,
+    /// Username.
+    pub username: Option<String>,
+    /// Title of the pull request.
+    pub pr_title: Option<String>,
+    /// The pull request that the user created.
+    pub pr_number: Option<i64>,
+    /// Labels of the pull request.
+    pub pr_labels: Vec<String>,
+    /// Whether if the user contributed for the first time.
+    pub is_first_time: bool,
 }
 
 impl Hash for RemoteContributor {
-	fn hash<H: Hasher>(&self, state: &mut H) {
-		self.username.hash(state);
-	}
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.username.hash(state);
+    }
 }

--- a/git-cliff-core/src/embed.rs
+++ b/git-cliff-core/src/embed.rs
@@ -16,22 +16,22 @@ use crate::error::{Error, Result};
 pub struct EmbeddedConfig;
 
 impl EmbeddedConfig {
-	/// Extracts the embedded content.
-	pub fn get_config() -> Result<String> {
-		match Self::get(crate::DEFAULT_CONFIG) {
-			Some(v) => Ok(str::from_utf8(&v.data)?.to_string()),
-			None => Err(Error::EmbeddedError(String::from(
-				"Embedded config not found",
-			))),
-		}
-	}
+    /// Extracts the embedded content.
+    pub fn get_config() -> Result<String> {
+        match Self::get(crate::DEFAULT_CONFIG) {
+            Some(v) => Ok(str::from_utf8(&v.data)?.to_string()),
+            None => Err(Error::EmbeddedError(String::from(
+                "Embedded config not found",
+            ))),
+        }
+    }
 
-	/// Parses the extracted content into [`Config`].
-	///
-	/// [`Config`]: Config
-	pub fn parse() -> Result<Config> {
-		Self::get_config()?.parse()
-	}
+    /// Parses the extracted content into [`Config`].
+    ///
+    /// [`Config`]: Config
+    pub fn parse() -> Result<Config> {
+        Self::get_config()?.parse()
+    }
 }
 
 /// Built-in configuration file embedder/extractor.
@@ -42,26 +42,26 @@ impl EmbeddedConfig {
 pub struct BuiltinConfig;
 
 impl BuiltinConfig {
-	/// Extracts the embedded content.
-	pub fn get_config(mut name: String) -> Result<String> {
-		if !Path::new(&name)
-			.extension()
-			.is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
-		{
-			name = format!("{name}.toml");
-		}
-		let contents = match Self::get(&name) {
-			Some(v) => Ok(str::from_utf8(&v.data)?.to_string()),
-			None => Err(Error::EmbeddedError(format!("config {} not found", name,))),
-		}?;
-		Ok(contents)
-	}
+    /// Extracts the embedded content.
+    pub fn get_config(mut name: String) -> Result<String> {
+        if !Path::new(&name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("toml"))
+        {
+            name = format!("{name}.toml");
+        }
+        let contents = match Self::get(&name) {
+            Some(v) => Ok(str::from_utf8(&v.data)?.to_string()),
+            None => Err(Error::EmbeddedError(format!("config {} not found", name,))),
+        }?;
+        Ok(contents)
+    }
 
-	/// Parses the extracted content into [`Config`] along with the name.
-	///
-	/// [`Config`]: Config
-	pub fn parse(name: String) -> Result<(Config, String)> {
-		let parsed = Self::get_config(name.to_string())?.parse()?;
-		Ok((parsed, name))
-	}
+    /// Parses the extracted content into [`Config`] along with the name.
+    ///
+    /// [`Config`]: Config
+    pub fn parse(name: String) -> Result<(Config, String)> {
+        let parsed = Self::get_config(name.to_string())?.parse()?;
+        Ok((parsed, name))
+    }
 }

--- a/git-cliff-core/src/error.rs
+++ b/git-cliff-core/src/error.rs
@@ -3,121 +3,118 @@ use thiserror::Error as ThisError;
 /// Library related errors that we are exposing to the rest of the workspaces.
 #[derive(Debug, ThisError)]
 pub enum Error {
-	/// Error that may occur while I/O operations.
-	#[error("IO error: `{0}`")]
-	IoError(#[from] std::io::Error),
-	/// Error that may occur when attempting to interpret a sequence of u8 as a
-	/// string.
-	#[error("UTF-8 error: `{0}`")]
-	Utf8Error(#[from] std::str::Utf8Error),
-	/// Error variant that represents errors coming out of libgit2.
-	#[cfg(feature = "repo")]
-	#[error("Git error: `{0}`")]
-	GitError(#[from] git2::Error),
-	/// Error that may occur when failed to set a commit range.
-	#[cfg(feature = "repo")]
-	#[error(
-		"Failed to set the commit range: {1}
+    /// Error that may occur while I/O operations.
+    #[error("IO error: `{0}`")]
+    IoError(#[from] std::io::Error),
+    /// Error that may occur when attempting to interpret a sequence of u8 as a
+    /// string.
+    #[error("UTF-8 error: `{0}`")]
+    Utf8Error(#[from] std::str::Utf8Error),
+    /// Error variant that represents errors coming out of libgit2.
+    #[cfg(feature = "repo")]
+    #[error("Git error: `{0}`")]
+    GitError(#[from] git2::Error),
+    /// Error that may occur when failed to set a commit range.
+    #[cfg(feature = "repo")]
+    #[error(
+        "Failed to set the commit range: {1}
 {0:?} is not a valid commit range. Did you provide the correct arguments?"
-	)]
-	SetCommitRangeError(String, #[source] git2::Error),
-	/// Error variant that represents other repository related errors.
-	#[cfg(feature = "repo")]
-	#[error("Git repository error: `{0}`")]
-	RepoError(String),
-	/// Error that may occur while parsing the config file.
-	#[error("Cannot parse config: `{0}`")]
-	ConfigError(#[from] config::ConfigError),
-	/// A possible error while initializing the logger.
-	#[error("Logger error: `{0}`")]
-	LoggerError(String),
-	/// When commit's not follow the conventional commit structure we throw this
-	/// error.
-	#[error("Cannot parse the commit: `{0}`")]
-	ParseError(#[from] git_conventional::Error),
-	/// Error that may occur while grouping commits.
-	#[error("Grouping error: `{0}`")]
-	GroupError(String),
-	/// Error that may occur while generating changelog.
-	#[error("Changelog error: `{0}`")]
-	ChangelogError(String),
-	/// Error that may occur while parsing the template.
-	#[error("Template parse error:\n{0}")]
-	TemplateParseError(String),
-	/// Error that may occur while rendering the template.
-	#[error("Template render error:\n{0}")]
-	TemplateRenderError(String),
-	/// Error that may occur while rendering the template.
-	#[error("Template render error:\n{0}\n{1}")]
-	TemplateRenderDetailedError(String, String),
-	/// Error that may occur during more general template operations.
-	#[error("Template error: `{0}`")]
-	TemplateError(#[from] tera::Error),
-	/// Error that may occur while parsing the command line arguments.
-	#[error("Argument error: `{0}`")]
-	ArgumentError(String),
-	/// Error that may occur while extracting the embedded content.
-	#[error("Embedded error: `{0}`")]
-	EmbeddedError(String),
-	/// Errors that may occur when deserializing types from TOML format.
-	#[error("Cannot parse TOML: `{0}`")]
-	DeserializeError(#[from] toml::de::Error),
-	/// Errors that may occur while de/serializing JSON format.
-	#[error("Cannot de/serialize JSON: `{0}`")]
-	JsonError(#[from] serde_json::Error),
-	/// Errors that may occur during parsing or compiling a regular expression.
-	#[error("Cannot parse/compile regex: `{0}`")]
-	RegexError(#[from] regex::Error),
-	/// Error that may occur due to system time related anomalies.
-	#[error("System time error: `{0}`")]
-	SystemTimeError(#[from] std::time::SystemTimeError),
-	/// Error that may occur while parsing integers.
-	#[error("Failed to parse integer: `{0}`")]
-	IntParseError(#[from] std::num::TryFromIntError),
-	/// Error that may occur while processing parsers that define field and
-	/// value matchers.
-	#[error("Field error: `{0}`")]
-	FieldError(String),
-	/// Error that may occur while parsing a `SemVer` version or version
-	/// requirement.
-	#[error("Semver error: `{0}`")]
-	SemverError(#[from] semver::Error),
-	/// The errors that may occur when processing a HTTP request.
-	#[error("HTTP client error: `{0}`")]
-	#[cfg(feature = "remote")]
-	HttpClientError(#[from] reqwest::Error),
-	/// The errors that may occur while constructing the HTTP client with
-	/// middleware.
-	#[error("HTTP client with middleware error: `{0}`")]
-	#[cfg(feature = "remote")]
-	HttpClientMiddlewareError(#[from] reqwest_middleware::Error),
-	/// A possible error when converting a `HeaderValue` from a string or byte
-	/// slice.
-	#[error("HTTP header error: `{0}`")]
-	#[cfg(feature = "remote")]
-	HttpHeaderError(#[from] reqwest::header::InvalidHeaderValue),
-	/// Error that may occur during handling pages.
-	#[error("Pagination error: `{0}`")]
-	PaginationError(String),
-	/// The errors that may occur while parsing URLs.
-	#[error("URL parse error: `{0}`")]
-	UrlParseError(#[from] url::ParseError),
-	/// Error that may occur when a remote is not set.
-	#[error("Repository remote is not set.")]
-	RemoteNotSetError,
-	/// Error that may occur while handling location of directories.
-	#[error("Directory error: `{0}`")]
-	DirsError(String),
-	/// Error that may occur while constructing patterns.
-	#[error("Pattern error: `{0}`")]
-	PatternError(#[from] glob::PatternError),
-	/// Error that may occur when unconventional commits are found.
-	/// See `require_conventional` option for more information.
-	#[error(
-		"Requiring all commits be conventional but found {0} unconventional \
-		 commits."
-	)]
-	UnconventionalCommitsError(i32),
+    )]
+    SetCommitRangeError(String, #[source] git2::Error),
+    /// Error variant that represents other repository related errors.
+    #[cfg(feature = "repo")]
+    #[error("Git repository error: `{0}`")]
+    RepoError(String),
+    /// Error that may occur while parsing the config file.
+    #[error("Cannot parse config: `{0}`")]
+    ConfigError(#[from] config::ConfigError),
+    /// A possible error while initializing the logger.
+    #[error("Logger error: `{0}`")]
+    LoggerError(String),
+    /// When commit's not follow the conventional commit structure we throw this
+    /// error.
+    #[error("Cannot parse the commit: `{0}`")]
+    ParseError(#[from] git_conventional::Error),
+    /// Error that may occur while grouping commits.
+    #[error("Grouping error: `{0}`")]
+    GroupError(String),
+    /// Error that may occur while generating changelog.
+    #[error("Changelog error: `{0}`")]
+    ChangelogError(String),
+    /// Error that may occur while parsing the template.
+    #[error("Template parse error:\n{0}")]
+    TemplateParseError(String),
+    /// Error that may occur while rendering the template.
+    #[error("Template render error:\n{0}")]
+    TemplateRenderError(String),
+    /// Error that may occur while rendering the template.
+    #[error("Template render error:\n{0}\n{1}")]
+    TemplateRenderDetailedError(String, String),
+    /// Error that may occur during more general template operations.
+    #[error("Template error: `{0}`")]
+    TemplateError(#[from] tera::Error),
+    /// Error that may occur while parsing the command line arguments.
+    #[error("Argument error: `{0}`")]
+    ArgumentError(String),
+    /// Error that may occur while extracting the embedded content.
+    #[error("Embedded error: `{0}`")]
+    EmbeddedError(String),
+    /// Errors that may occur when deserializing types from TOML format.
+    #[error("Cannot parse TOML: `{0}`")]
+    DeserializeError(#[from] toml::de::Error),
+    /// Errors that may occur while de/serializing JSON format.
+    #[error("Cannot de/serialize JSON: `{0}`")]
+    JsonError(#[from] serde_json::Error),
+    /// Errors that may occur during parsing or compiling a regular expression.
+    #[error("Cannot parse/compile regex: `{0}`")]
+    RegexError(#[from] regex::Error),
+    /// Error that may occur due to system time related anomalies.
+    #[error("System time error: `{0}`")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
+    /// Error that may occur while parsing integers.
+    #[error("Failed to parse integer: `{0}`")]
+    IntParseError(#[from] std::num::TryFromIntError),
+    /// Error that may occur while processing parsers that define field and
+    /// value matchers.
+    #[error("Field error: `{0}`")]
+    FieldError(String),
+    /// Error that may occur while parsing a `SemVer` version or version
+    /// requirement.
+    #[error("Semver error: `{0}`")]
+    SemverError(#[from] semver::Error),
+    /// The errors that may occur when processing a HTTP request.
+    #[error("HTTP client error: `{0}`")]
+    #[cfg(feature = "remote")]
+    HttpClientError(#[from] reqwest::Error),
+    /// The errors that may occur while constructing the HTTP client with
+    /// middleware.
+    #[error("HTTP client with middleware error: `{0}`")]
+    #[cfg(feature = "remote")]
+    HttpClientMiddlewareError(#[from] reqwest_middleware::Error),
+    /// A possible error when converting a `HeaderValue` from a string or byte
+    /// slice.
+    #[error("HTTP header error: `{0}`")]
+    #[cfg(feature = "remote")]
+    HttpHeaderError(#[from] reqwest::header::InvalidHeaderValue),
+    /// Error that may occur during handling pages.
+    #[error("Pagination error: `{0}`")]
+    PaginationError(String),
+    /// The errors that may occur while parsing URLs.
+    #[error("URL parse error: `{0}`")]
+    UrlParseError(#[from] url::ParseError),
+    /// Error that may occur when a remote is not set.
+    #[error("Repository remote is not set.")]
+    RemoteNotSetError,
+    /// Error that may occur while handling location of directories.
+    #[error("Directory error: `{0}`")]
+    DirsError(String),
+    /// Error that may occur while constructing patterns.
+    #[error("Pattern error: `{0}`")]
+    PatternError(#[from] glob::PatternError),
+    /// Error that may occur when unconventional commits are found.
+    /// See `require_conventional` option for more information.
+    #[error("Requiring all commits be conventional but found {0} unconventional commits.")]
+    UnconventionalCommitsError(i32),
 }
 
 /// Result type of the core library.
@@ -125,24 +122,24 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 #[cfg(test)]
 mod test {
-	use git_conventional::{Commit, ErrorKind};
+    use git_conventional::{Commit, ErrorKind};
 
-	use super::*;
-	fn mock_function() -> super::Result<Commit<'static>> {
-		Ok(Commit::parse("test")?)
-	}
+    use super::*;
+    fn mock_function() -> super::Result<Commit<'static>> {
+        Ok(Commit::parse("test")?)
+    }
 
-	#[test]
-	fn throw_parse_error() {
-		let actual_error = mock_function().expect_err("expected error");
-		let expected_error_kind = ErrorKind::MissingType;
-		match actual_error {
-			Error::ParseError(e) => {
-				assert_eq!(expected_error_kind, e.kind());
-			}
-			_ => {
-				unreachable!()
-			}
-		}
-	}
+    #[test]
+    fn throw_parse_error() {
+        let actual_error = mock_function().expect_err("expected error");
+        let expected_error_kind = ErrorKind::MissingType;
+        match actual_error {
+            Error::ParseError(e) => {
+                assert_eq!(expected_error_kind, e.kind());
+            }
+            _ => {
+                unreachable!()
+            }
+        }
+    }
 }

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -8,8 +8,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, clippy::unwrap_used)]
 #![doc(
-	html_logo_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff.png",
-	html_favicon_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/favicon/favicon.ico"
+    html_logo_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff.png",
+    html_favicon_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/favicon/favicon.ico"
 )]
 
 /// Changelog generator.

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -11,54 +11,54 @@ use crate::error::Result;
 use crate::statistics::Statistics;
 #[cfg(feature = "remote")]
 use crate::{
-	contributor::RemoteContributor,
-	remote::{RemoteCommit, RemotePullRequest, RemoteReleaseMetadata},
+    contributor::RemoteContributor,
+    remote::{RemoteCommit, RemotePullRequest, RemoteReleaseMetadata},
 };
 
 /// Representation of a release.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Release<'a> {
-	/// Release version, git tag.
-	pub version:           Option<String>,
-	/// git tag's message.
-	pub message:           Option<String>,
-	/// Commits made for the release.
-	#[serde(deserialize_with = "commits_to_conventional_commits")]
-	pub commits:           Vec<Commit<'a>>,
-	/// Commit ID of the tag.
-	#[serde(rename = "commit_id")]
-	pub commit_id:         Option<String>,
-	/// Timestamp of the release in seconds, from epoch.
-	pub timestamp:         Option<i64>,
-	/// Previous release.
-	pub previous:          Option<Box<Release<'a>>>,
-	/// Repository path.
-	pub repository:        Option<String>,
-	/// Commit range.
-	#[serde(rename = "commit_range")]
-	pub commit_range:      Option<Range>,
-	/// Submodule commits.
-	///
-	/// Maps submodule path to a list of commits.
-	#[serde(rename = "submodule_commits")]
-	pub submodule_commits: HashMap<String, Vec<Commit<'a>>>,
-	/// Aggregated statistics computed from the release's commits.
-	pub statistics:        Option<Statistics>,
-	/// Arbitrary data to be used with the `--from-context` CLI option.
-	pub extra:             Option<Value>,
-	/// Contributors.
-	#[cfg(feature = "github")]
-	pub github:            RemoteReleaseMetadata,
-	/// Contributors.
-	#[cfg(feature = "gitlab")]
-	pub gitlab:            RemoteReleaseMetadata,
-	/// Contributors.
-	#[cfg(feature = "gitea")]
-	pub gitea:             RemoteReleaseMetadata,
-	/// Contributors.
-	#[cfg(feature = "bitbucket")]
-	pub bitbucket:         RemoteReleaseMetadata,
+    /// Release version, git tag.
+    pub version: Option<String>,
+    /// git tag's message.
+    pub message: Option<String>,
+    /// Commits made for the release.
+    #[serde(deserialize_with = "commits_to_conventional_commits")]
+    pub commits: Vec<Commit<'a>>,
+    /// Commit ID of the tag.
+    #[serde(rename = "commit_id")]
+    pub commit_id: Option<String>,
+    /// Timestamp of the release in seconds, from epoch.
+    pub timestamp: Option<i64>,
+    /// Previous release.
+    pub previous: Option<Box<Release<'a>>>,
+    /// Repository path.
+    pub repository: Option<String>,
+    /// Commit range.
+    #[serde(rename = "commit_range")]
+    pub commit_range: Option<Range>,
+    /// Submodule commits.
+    ///
+    /// Maps submodule path to a list of commits.
+    #[serde(rename = "submodule_commits")]
+    pub submodule_commits: HashMap<String, Vec<Commit<'a>>>,
+    /// Aggregated statistics computed from the release's commits.
+    pub statistics: Option<Statistics>,
+    /// Arbitrary data to be used with the `--from-context` CLI option.
+    pub extra: Option<Value>,
+    /// Contributors.
+    #[cfg(feature = "github")]
+    pub github: RemoteReleaseMetadata,
+    /// Contributors.
+    #[cfg(feature = "gitlab")]
+    pub gitlab: RemoteReleaseMetadata,
+    /// Contributors.
+    #[cfg(feature = "gitea")]
+    pub gitea: RemoteReleaseMetadata,
+    /// Contributors.
+    #[cfg(feature = "bitbucket")]
+    pub bitbucket: RemoteReleaseMetadata,
 }
 
 #[cfg(feature = "github")]
@@ -74,1747 +74,1690 @@ crate::update_release_metadata!(gitea, update_gitea_metadata);
 crate::update_release_metadata!(bitbucket, update_bitbucket_metadata);
 
 impl Release<'_> {
-	/// Calculates the next version based on the commits.
-	///
-	/// It uses the default bump version configuration to calculate the next
-	/// version.
-	pub fn calculate_next_version(&self) -> Result<String> {
-		self.calculate_next_version_with_config(&Bump::default())
-	}
+    /// Calculates the next version based on the commits.
+    ///
+    /// It uses the default bump version configuration to calculate the next
+    /// version.
+    pub fn calculate_next_version(&self) -> Result<String> {
+        self.calculate_next_version_with_config(&Bump::default())
+    }
 
-	/// Returns a new `Release` instance with aggregated statistics populated.
-	///
-	/// This method computes various statistics from the release data and sets
-	/// the `statistics` field. It does not modify the original release but
-	/// returns a new instance with the computed statistics included.
-	pub fn with_statistics(mut self) -> Self {
-		self.statistics = Some((&self).into());
-		self
-	}
+    /// Returns a new `Release` instance with aggregated statistics populated.
+    ///
+    /// This method computes various statistics from the release data and sets
+    /// the `statistics` field. It does not modify the original release but
+    /// returns a new instance with the computed statistics included.
+    pub fn with_statistics(mut self) -> Self {
+        self.statistics = Some((&self).into());
+        self
+    }
 
-	/// Calculates the next version based on the commits.
-	///
-	/// It uses the given bump version configuration to calculate the next
-	/// version.
-	pub(super) fn calculate_next_version_with_config(
-		&self,
-		config: &Bump,
-	) -> Result<String> {
-		match self
-			.previous
-			.as_ref()
-			.and_then(|release| release.version.clone())
-		{
-			Some(version) => {
-				let mut semver = Version::parse(&version);
-				let mut prefix = None;
-				if semver.is_err() && version.split('.').count() >= 2 {
-					let mut found_numeric = false;
-					for (i, c) in version.char_indices() {
-						if c.is_numeric() && !found_numeric {
-							found_numeric = true;
-							let version_prefix = version[..i].to_string();
-							let remaining = version[i..].to_string();
-							let version = Version::parse(&remaining);
-							if version.is_ok() {
-								semver = version;
-								prefix = Some(version_prefix);
-								break;
-							}
-						} else if !c.is_numeric() && found_numeric {
-							found_numeric = false;
-						}
-					}
-				}
-				let mut next_version = VersionUpdater::new()
-					.with_features_always_increment_minor(
-						config.features_always_bump_minor.unwrap_or(true),
-					)
-					.with_breaking_always_increment_major(
-						config.breaking_always_bump_major.unwrap_or(true),
-					);
-				if let Some(custom_major_increment_regex) =
-					&config.custom_major_increment_regex
-				{
-					next_version = next_version.with_custom_major_increment_regex(
-						custom_major_increment_regex,
-					)?;
-				}
-				if let Some(custom_minor_increment_regex) =
-					&config.custom_minor_increment_regex
-				{
-					next_version = next_version.with_custom_minor_increment_regex(
-						custom_minor_increment_regex,
-					)?;
-				}
-				let next_version = if let Some(bump_type) = &config.bump_type {
-					match bump_type {
-						BumpType::Major => semver?.increment_major().to_string(),
-						BumpType::Minor => semver?.increment_minor().to_string(),
-						BumpType::Patch => semver?.increment_patch().to_string(),
-					}
-				} else {
-					next_version
-						.increment(
-							&semver?,
-							self.commits
-								.iter()
-								.map(|commit| commit.message.trim_end().to_string())
-								.collect::<Vec<String>>(),
-						)
-						.to_string()
-				};
-				if let Some(prefix) = prefix {
-					Ok(format!("{prefix}{next_version}"))
-				} else {
-					Ok(next_version)
-				}
-			}
-			None => Ok(config.get_initial_tag()),
-		}
-	}
+    /// Calculates the next version based on the commits.
+    ///
+    /// It uses the given bump version configuration to calculate the next
+    /// version.
+    pub(super) fn calculate_next_version_with_config(&self, config: &Bump) -> Result<String> {
+        match self
+            .previous
+            .as_ref()
+            .and_then(|release| release.version.clone())
+        {
+            Some(version) => {
+                let mut semver = Version::parse(&version);
+                let mut prefix = None;
+                if semver.is_err() && version.split('.').count() >= 2 {
+                    let mut found_numeric = false;
+                    for (i, c) in version.char_indices() {
+                        if c.is_numeric() && !found_numeric {
+                            found_numeric = true;
+                            let version_prefix = version[..i].to_string();
+                            let remaining = version[i..].to_string();
+                            let version = Version::parse(&remaining);
+                            if version.is_ok() {
+                                semver = version;
+                                prefix = Some(version_prefix);
+                                break;
+                            }
+                        } else if !c.is_numeric() && found_numeric {
+                            found_numeric = false;
+                        }
+                    }
+                }
+                let mut next_version = VersionUpdater::new()
+                    .with_features_always_increment_minor(
+                        config.features_always_bump_minor.unwrap_or(true),
+                    )
+                    .with_breaking_always_increment_major(
+                        config.breaking_always_bump_major.unwrap_or(true),
+                    );
+                if let Some(custom_major_increment_regex) = &config.custom_major_increment_regex {
+                    next_version = next_version
+                        .with_custom_major_increment_regex(custom_major_increment_regex)?;
+                }
+                if let Some(custom_minor_increment_regex) = &config.custom_minor_increment_regex {
+                    next_version = next_version
+                        .with_custom_minor_increment_regex(custom_minor_increment_regex)?;
+                }
+                let next_version = if let Some(bump_type) = &config.bump_type {
+                    match bump_type {
+                        BumpType::Major => semver?.increment_major().to_string(),
+                        BumpType::Minor => semver?.increment_minor().to_string(),
+                        BumpType::Patch => semver?.increment_patch().to_string(),
+                    }
+                } else {
+                    next_version
+                        .increment(
+                            &semver?,
+                            self.commits
+                                .iter()
+                                .map(|commit| commit.message.trim_end().to_string())
+                                .collect::<Vec<String>>(),
+                        )
+                        .to_string()
+                };
+                if let Some(prefix) = prefix {
+                    Ok(format!("{prefix}{next_version}"))
+                } else {
+                    Ok(next_version)
+                }
+            }
+            None => Ok(config.get_initial_tag()),
+        }
+    }
 }
 
 /// Representation of a list of releases.
 #[derive(Serialize)]
 pub struct Releases<'a> {
-	/// Releases.
-	pub releases: &'a Vec<Release<'a>>,
+    /// Releases.
+    pub releases: &'a Vec<Release<'a>>,
 }
 
 impl Releases<'_> {
-	/// Returns the list of releases as JSON.
-	pub fn as_json(&self) -> Result<String> {
-		Ok(serde_json::to_string(self.releases)?)
-	}
+    /// Returns the list of releases as JSON.
+    pub fn as_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(self.releases)?)
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	#[test]
-	fn bump_version() -> Result<()> {
-		fn build_release<'a>(version: &str, commits: &'a [&str]) -> Release<'a> {
-			Release {
-				version: None,
-				message: None,
-				extra: None,
-				commits: commits
-					.iter()
-					.map(|v| Commit::from(v.to_string()))
-					.collect(),
-				commit_range: None,
-				commit_id: None,
-				timestamp: None,
-				previous: Some(Box::new(Release {
-					version: Some(String::from(version)),
-					..Default::default()
-				})),
-				repository: Some(String::from("/root/repo")),
-				submodule_commits: HashMap::new(),
-				statistics: None,
-				#[cfg(feature = "github")]
-				github: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "gitlab")]
-				gitlab: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "gitea")]
-				gitea: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-				#[cfg(feature = "bitbucket")]
-				bitbucket: crate::remote::RemoteReleaseMetadata {
-					contributors: vec![],
-				},
-			}
-		}
+    use super::*;
+    #[test]
+    fn bump_version() -> Result<()> {
+        fn build_release<'a>(version: &str, commits: &'a [&str]) -> Release<'a> {
+            Release {
+                version: None,
+                message: None,
+                extra: None,
+                commits: commits
+                    .iter()
+                    .map(|v| Commit::from(v.to_string()))
+                    .collect(),
+                commit_range: None,
+                commit_id: None,
+                timestamp: None,
+                previous: Some(Box::new(Release {
+                    version: Some(String::from(version)),
+                    ..Default::default()
+                })),
+                repository: Some(String::from("/root/repo")),
+                submodule_commits: HashMap::new(),
+                statistics: None,
+                #[cfg(feature = "github")]
+                github: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "gitlab")]
+                gitlab: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "gitea")]
+                gitea: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+                #[cfg(feature = "bitbucket")]
+                bitbucket: crate::remote::RemoteReleaseMetadata {
+                    contributors: vec![],
+                },
+            }
+        }
 
-		let test_shared = [
-			("1.0.0", "1.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
-			("1.0.0", "1.0.1", vec!["fix: add xyz", "fix: aaaaaa"]),
-			("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
-			("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
-			("2.0.0", "2.0.1", vec!["fix: something"]),
-			("foo/1.0.0", "foo/1.1.0", vec![
-				"feat: add xyz",
-				"fix: fix xyz",
-			]),
-			("bar/1.0.0", "bar/2.0.0", vec![
-				"fix: add xyz",
-				"fix!: aaaaaa",
-			]),
-			("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
-				"fix: aaaaaa",
-			]),
-			("v100.0.0", "v101.0.0", vec!["feat!: something"]),
-			("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-			("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
-				"feat: nice",
-			]),
-			("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
-			(
-				"rocket/rocket-v4.0.0-rc.1",
-				"rocket/rocket-v4.0.0-rc.2",
-				vec!["chore!: wow"],
-			),
-			(
-				"aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.419",
-				"aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.420",
-				vec!["feat: damn this is working"],
-			),
-		];
+        let test_shared = [
+            ("1.0.0", "1.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
+            ("1.0.0", "1.0.1", vec!["fix: add xyz", "fix: aaaaaa"]),
+            ("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
+            ("2.0.0", "2.0.1", vec!["fix: something"]),
+            ("foo/1.0.0", "foo/1.1.0", vec![
+                "feat: add xyz",
+                "fix: fix xyz",
+            ]),
+            ("bar/1.0.0", "bar/2.0.0", vec![
+                "fix: add xyz",
+                "fix!: aaaaaa",
+            ]),
+            ("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
+                "fix: aaaaaa",
+            ]),
+            ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
+            ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
+            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
+                "feat: nice",
+            ]),
+            ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
+            (
+                "rocket/rocket-v4.0.0-rc.1",
+                "rocket/rocket-v4.0.0-rc.2",
+                vec!["chore!: wow"],
+            ),
+            (
+                "aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.419",
+                "aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.420",
+                vec!["feat: damn this is working"],
+            ),
+        ];
 
-		for (version, expected_version, commits) in test_shared.iter().chain(
-			[
-				("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
-				("0.0.1", "0.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.0.1", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
-				("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
-				("0.1.0", "0.2.0", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.1.0", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
-			]
-			.iter(),
-		) {
-			let release = build_release(version, commits);
-			let next_version = release.calculate_next_version()?;
-			assert_eq!(expected_version, &next_version);
-			let next_version =
-				release.calculate_next_version_with_config(&Bump::default())?;
-			assert_eq!(expected_version, &next_version);
-		}
+        for (version, expected_version, commits) in test_shared.iter().chain(
+            [
+                ("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
+                ("0.0.1", "0.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.0.1", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+                ("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
+                ("0.1.0", "0.2.0", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.1.0", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ]
+            .iter(),
+        ) {
+            let release = build_release(version, commits);
+            let next_version = release.calculate_next_version()?;
+            assert_eq!(expected_version, &next_version);
+            let next_version = release.calculate_next_version_with_config(&Bump::default())?;
+            assert_eq!(expected_version, &next_version);
+        }
 
-		for (version, expected_version, commits) in test_shared.iter().chain(
-			[
-				("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
-				("0.0.1", "0.0.2", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.0.1", "0.0.2", vec!["feat!: add xyz", "feat: zzz"]),
-				("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
-				("0.1.0", "0.1.1", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.1.0", "0.2.0", vec!["feat!: add xyz", "feat: zzz"]),
-			]
-			.iter(),
-		) {
-			let release = build_release(version, commits);
-			let next_version =
-				release.calculate_next_version_with_config(&Bump {
-					features_always_bump_minor:   Some(false),
-					breaking_always_bump_major:   Some(false),
-					initial_tag:                  None,
-					custom_major_increment_regex: None,
-					custom_minor_increment_regex: None,
-					bump_type:                    None,
-				})?;
-			assert_eq!(expected_version, &next_version);
-		}
+        for (version, expected_version, commits) in test_shared.iter().chain(
+            [
+                ("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
+                ("0.0.1", "0.0.2", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.0.1", "0.0.2", vec!["feat!: add xyz", "feat: zzz"]),
+                ("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
+                ("0.1.0", "0.1.1", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.1.0", "0.2.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ]
+            .iter(),
+        ) {
+            let release = build_release(version, commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(false),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
 
-		for (version, expected_version, commits) in test_shared.iter().chain(
-			[
-				("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
-				("0.0.1", "0.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.0.1", "0.1.0", vec!["feat!: add xyz", "feat: zzz"]),
-				("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
-				("0.1.0", "0.2.0", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.1.0", "0.2.0", vec!["feat!: add xyz", "feat: zzz"]),
-			]
-			.iter(),
-		) {
-			let release = build_release(version, commits);
-			let next_version =
-				release.calculate_next_version_with_config(&Bump {
-					features_always_bump_minor:   Some(true),
-					breaking_always_bump_major:   Some(false),
-					initial_tag:                  None,
-					custom_major_increment_regex: None,
-					custom_minor_increment_regex: None,
-					bump_type:                    None,
-				})?;
-			assert_eq!(expected_version, &next_version);
-		}
+        for (version, expected_version, commits) in test_shared.iter().chain(
+            [
+                ("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
+                ("0.0.1", "0.1.0", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.0.1", "0.1.0", vec!["feat!: add xyz", "feat: zzz"]),
+                ("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
+                ("0.1.0", "0.2.0", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.1.0", "0.2.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ]
+            .iter(),
+        ) {
+            let release = build_release(version, commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
 
-		for (version, expected_version, commits) in test_shared.iter().chain(
-			[
-				("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
-				("0.0.1", "0.0.2", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.0.1", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
-				("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
-				("0.1.0", "0.1.1", vec!["feat: add xyz", "fix: fix xyz"]),
-				("0.1.0", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
-			]
-			.iter(),
-		) {
-			let release = build_release(version, commits);
-			let next_version =
-				release.calculate_next_version_with_config(&Bump {
-					features_always_bump_minor:   Some(false),
-					breaking_always_bump_major:   Some(true),
-					initial_tag:                  None,
-					custom_major_increment_regex: None,
-					custom_minor_increment_regex: None,
-					bump_type:                    None,
-				})?;
-			assert_eq!(expected_version, &next_version);
-		}
+        for (version, expected_version, commits) in test_shared.iter().chain(
+            [
+                ("0.0.1", "0.0.2", vec!["fix: fix xyz"]),
+                ("0.0.1", "0.0.2", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.0.1", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+                ("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
+                ("0.1.0", "0.1.1", vec!["feat: add xyz", "fix: fix xyz"]),
+                ("0.1.0", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+            ]
+            .iter(),
+        ) {
+            let release = build_release(version, commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(false),
+                breaking_always_bump_major: Some(true),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
 
-		let empty_release = Release {
-			previous: Some(Box::new(Release {
-				version: None,
-				..Default::default()
-			})),
-			..Default::default()
-		};
-		assert_eq!("0.1.0", empty_release.calculate_next_version()?);
-		for (features_always_bump_minor, breaking_always_bump_major) in
-			[(true, true), (true, false), (false, true), (false, false)]
-		{
-			assert_eq!(
-				"0.1.0",
-				empty_release.calculate_next_version_with_config(&Bump {
-					features_always_bump_minor:   Some(features_always_bump_minor),
-					breaking_always_bump_major:   Some(breaking_always_bump_major),
-					initial_tag:                  None,
-					custom_major_increment_regex: None,
-					custom_minor_increment_regex: None,
-					bump_type:                    None,
-				})?
-			);
-		}
-		Ok(())
-	}
+        let empty_release = Release {
+            previous: Some(Box::new(Release {
+                version: None,
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert_eq!("0.1.0", empty_release.calculate_next_version()?);
+        for (features_always_bump_minor, breaking_always_bump_major) in
+            [(true, true), (true, false), (false, true), (false, false)]
+        {
+            assert_eq!(
+                "0.1.0",
+                empty_release.calculate_next_version_with_config(&Bump {
+                    features_always_bump_minor: Some(features_always_bump_minor),
+                    breaking_always_bump_major: Some(breaking_always_bump_major),
+                    initial_tag: None,
+                    custom_major_increment_regex: None,
+                    custom_minor_increment_regex: None,
+                    bump_type: None,
+                })?
+            );
+        }
+        Ok(())
+    }
 
-	#[test]
-	fn with_statistics() -> Result<()> {
-		let release = Release {
-			commits: vec![],
-			timestamp: Some(1649373910),
-			previous: Some(Box::new(Release {
-				timestamp: Some(1649201110),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			..Default::default()
-		};
+    #[test]
+    fn with_statistics() -> Result<()> {
+        let release = Release {
+            commits: vec![],
+            timestamp: Some(1649373910),
+            previous: Some(Box::new(Release {
+                timestamp: Some(1649201110),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            ..Default::default()
+        };
 
-		assert!(release.statistics.is_none());
-		let release = release.with_statistics();
-		assert!(release.statistics.is_some());
+        assert!(release.statistics.is_none());
+        let release = release.with_statistics();
+        assert!(release.statistics.is_some());
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[cfg(feature = "github")]
-	#[test]
-	fn update_github_metadata() -> Result<()> {
-		use crate::remote::github::{
-			GitHubCommit, GitHubCommitAuthor, GitHubCommitDetails,
-			GitHubCommitDetailsAuthor, GitHubPullRequest, PullRequestLabel,
-		};
+    #[cfg(feature = "github")]
+    #[test]
+    fn update_github_metadata() -> Result<()> {
+        use crate::remote::github::{
+            GitHubCommit, GitHubCommitAuthor, GitHubCommitDetails, GitHubCommitDetailsAuthor,
+            GitHubPullRequest, PullRequestLabel,
+        };
 
-		let mut release = Release {
-			version: None,
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit::from(String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"21f6aa587fcb772de13f2fde0e92697c51f84162 fix github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
-				)),
-				Commit::from(String::from(
-					"4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
-				)),
-				Commit::from(String::from(
-					"5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
-				)),
-				Commit::from(String::from(
-					"6c34967147560ea09658776d4901709139b4ad66 should be fine",
-				)),
-			],
-			commit_range: None,
-			commit_id: None,
-			timestamp: None,
-			previous: Some(Box::new(Release {
-				version: Some(String::from("1.0.0")),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			github: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		};
-		release.update_github_metadata(
-			vec![
-				GitHubCommit {
-					sha:    String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:14:39+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:12:19+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("nuhro")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:07:23+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("awesome_contributor")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:05:10+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:03:30+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("6c34967147560ea09658776d4901709139b4ad66"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("someone")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:00:38+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("0c34967147560e809658776d4901709139b4ad68"),
-					author: Some(GitHubCommitAuthor {
-						login: Some(String::from("idk")),
-					}),
-					commit: Some(GitHubCommitDetails {
-						author: GitHubCommitDetailsAuthor {
-							date: String::from("2021-07-18T15:00:38+03:00"),
-						},
-					}),
-				},
-				GitHubCommit {
-					sha:    String::from("kk34967147560e809658776d4901709139b4ad68"),
-					author: None,
-					commit: None,
-				},
-				GitHubCommit {
-					sha:    String::new(),
-					author: None,
-					commit: None,
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect(),
-			vec![
-				GitHubPullRequest {
-					title:            Some(String::from("1")),
-					number:           42,
-					merge_commit_sha: Some(String::from(
-						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("rust"),
-					}],
-				},
-				GitHubPullRequest {
-					title:            Some(String::from("2")),
-					number:           66,
-					merge_commit_sha: Some(String::from(
-						"21f6aa587fcb772de13f2fde0e92697c51f84162",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("rust"),
-					}],
-				},
-				GitHubPullRequest {
-					title:            Some(String::from("3")),
-					number:           53,
-					merge_commit_sha: Some(String::from(
-						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("deps"),
-					}],
-				},
-				GitHubPullRequest {
-					title:            Some(String::from("4")),
-					number:           1000,
-					merge_commit_sha: Some(String::from(
-						"4d3ffe4753b923f4d7807c490e650e6624a12074",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("deps"),
-					}],
-				},
-				GitHubPullRequest {
-					title:            Some(String::from("5")),
-					number:           999999,
-					merge_commit_sha: Some(String::from(
-						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("github"),
-					}],
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect(),
-		)?;
-		#[allow(deprecated)]
-		let expected_commits = vec![
-			Commit {
-				id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-				message: String::from("add github integration"),
-				github: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-				message: String::from("fix github integration"),
-				github: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("2")),
-					pr_number:     Some(66),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("2")),
-					pr_number:     Some(66),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-				message: String::from("update metadata"),
-				github: RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-				message: String::from("do some stuff"),
-				github: RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-				message: String::from("alright"),
-				github: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("5")),
-					pr_number:     Some(999999),
-					pr_labels:     vec![String::from("github")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("5")),
-					pr_number:     Some(999999),
-					pr_labels:     vec![String::from("github")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
-				message: String::from("should be fine"),
-				github: RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-		];
-		assert_eq!(expected_commits, release.commits);
+        let mut release = Release {
+            version: None,
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit::from(String::from(
+                    "1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github integration",
+                )),
+                Commit::from(String::from(
+                    "21f6aa587fcb772de13f2fde0e92697c51f84162 fix github integration",
+                )),
+                Commit::from(String::from(
+                    "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
+                )),
+                Commit::from(String::from(
+                    "4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
+                )),
+                Commit::from(String::from(
+                    "5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
+                )),
+                Commit::from(String::from(
+                    "6c34967147560ea09658776d4901709139b4ad66 should be fine",
+                )),
+            ],
+            commit_range: None,
+            commit_id: None,
+            timestamp: None,
+            previous: Some(Box::new(Release {
+                version: Some(String::from("1.0.0")),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            github: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        };
+        release.update_github_metadata(
+            vec![
+                GitHubCommit {
+                    sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:14:39+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:12:19+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("nuhro")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:07:23+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("awesome_contributor")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:05:10+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:03:30+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("someone")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:00:38+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("0c34967147560e809658776d4901709139b4ad68"),
+                    author: Some(GitHubCommitAuthor {
+                        login: Some(String::from("idk")),
+                    }),
+                    commit: Some(GitHubCommitDetails {
+                        author: GitHubCommitDetailsAuthor {
+                            date: String::from("2021-07-18T15:00:38+03:00"),
+                        },
+                    }),
+                },
+                GitHubCommit {
+                    sha: String::from("kk34967147560e809658776d4901709139b4ad68"),
+                    author: None,
+                    commit: None,
+                },
+                GitHubCommit {
+                    sha: String::new(),
+                    author: None,
+                    commit: None,
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect(),
+            vec![
+                GitHubPullRequest {
+                    title: Some(String::from("1")),
+                    number: 42,
+                    merge_commit_sha: Some(String::from(
+                        "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("rust"),
+                    }],
+                },
+                GitHubPullRequest {
+                    title: Some(String::from("2")),
+                    number: 66,
+                    merge_commit_sha: Some(String::from(
+                        "21f6aa587fcb772de13f2fde0e92697c51f84162",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("rust"),
+                    }],
+                },
+                GitHubPullRequest {
+                    title: Some(String::from("3")),
+                    number: 53,
+                    merge_commit_sha: Some(String::from(
+                        "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("deps"),
+                    }],
+                },
+                GitHubPullRequest {
+                    title: Some(String::from("4")),
+                    number: 1000,
+                    merge_commit_sha: Some(String::from(
+                        "4d3ffe4753b923f4d7807c490e650e6624a12074",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("deps"),
+                    }],
+                },
+                GitHubPullRequest {
+                    title: Some(String::from("5")),
+                    number: 999999,
+                    merge_commit_sha: Some(String::from(
+                        "5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("github"),
+                    }],
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect(),
+        )?;
+        #[allow(deprecated)]
+        let expected_commits = vec![
+            Commit {
+                id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                message: String::from("add github integration"),
+                github: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                message: String::from("fix github integration"),
+                github: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("2")),
+                    pr_number: Some(66),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("2")),
+                    pr_number: Some(66),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                message: String::from("update metadata"),
+                github: RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                message: String::from("do some stuff"),
+                github: RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                message: String::from("alright"),
+                github: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("5")),
+                    pr_number: Some(999999),
+                    pr_labels: vec![String::from("github")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("5")),
+                    pr_number: Some(999999),
+                    pr_labels: vec![String::from("github")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                message: String::from("should be fine"),
+                github: RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(expected_commits, release.commits);
 
-		release
-			.github
-			.contributors
-			.sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+        release
+            .github
+            .contributors
+            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
-		let expected_metadata = RemoteReleaseMetadata {
-			contributors: vec![
-				RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: true,
-				},
-			],
-		};
-		assert_eq!(expected_metadata, release.github);
+        let expected_metadata = RemoteReleaseMetadata {
+            contributors: vec![
+                RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: true,
+                },
+            ],
+        };
+        assert_eq!(expected_metadata, release.github);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[cfg(feature = "gitlab")]
-	#[test]
-	fn update_gitlab_metadata() -> Result<()> {
-		use crate::remote::gitlab::{GitLabCommit, GitLabMergeRequest, GitLabUser};
+    #[cfg(feature = "gitlab")]
+    #[test]
+    fn update_gitlab_metadata() -> Result<()> {
+        use crate::remote::gitlab::{GitLabCommit, GitLabMergeRequest, GitLabUser};
 
-		let mut release = Release {
-			version: None,
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit::from(String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"21f6aa587fcb772de13f2fde0e92697c51f84162 fix github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
-				)),
-				Commit::from(String::from(
-					"4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
-				)),
-				Commit::from(String::from(
-					"5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
-				)),
-				Commit::from(String::from(
-					"6c34967147560ea09658776d4901709139b4ad66 should be fine",
-				)),
-			],
-			commit_range: None,
-			commit_id: None,
-			timestamp: None,
-			previous: Some(Box::new(Release {
-				version: Some(String::from("1.0.0")),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		};
-		release.update_gitlab_metadata(
-			vec![
-				GitLabCommit {
-					id:              String::from(
-						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-					),
-					author_name:     String::from("orhun"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"21f6aa587fcb772de13f2fde0e92697c51f84162",
-					),
-					author_name:     String::from("orhun"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
-					),
-					author_name:     String::from("nuhro"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"4d3ffe4753b923f4d7807c490e650e6624a12074",
-					),
-					author_name:     String::from("awesome_contributor"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
-					),
-					author_name:     String::from("orhun"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"6c34967147560ea09658776d4901709139b4ad66",
-					),
-					author_name:     String::from("someone"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"0c34967147560e809658776d4901709139b4ad68",
-					),
-					author_name:     String::from("idk"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-				GitLabCommit {
-					id:              String::from(
-						"kk34967147560e809658776d4901709139b4ad68",
-					),
-					author_name:     String::from("orhun"),
-					short_id:        String::from(""),
-					title:           String::from(""),
-					author_email:    String::from(""),
-					authored_date:   String::from(""),
-					committer_name:  String::from(""),
-					committer_email: String::from(""),
-					committed_date:  String::from(""),
-					created_at:      String::from(""),
-					message:         String::from(""),
-					parent_ids:      vec![],
-					web_url:         String::from(""),
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect(),
-			vec![Box::new(GitLabMergeRequest {
-				title:             String::from("1"),
-				merge_commit_sha:  Some(String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-				)),
-				id:                1,
-				iid:               1,
-				project_id:        1,
-				description:       String::from(""),
-				state:             String::from(""),
-				created_at:        String::from(""),
-				author:            GitLabUser {
-					id:         1,
-					name:       String::from("42"),
-					username:   String::from("42"),
-					state:      String::from("42"),
-					avatar_url: None,
-					web_url:    String::from("42"),
-				},
-				sha:               String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-				),
-				web_url:           String::from(""),
-				squash_commit_sha: None,
-				labels:            vec![String::from("rust")],
-			})],
-		)?;
-		#[allow(deprecated)]
-		let expected_commits = vec![
-			Commit {
-				id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-				message: String::from("add github integration"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-				message: String::from("fix github integration"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-				message: String::from("update metadata"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-				message: String::from("do some stuff"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-				message: String::from("alright"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
-				message: String::from("should be fine"),
-				gitlab: RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-		];
-		assert_eq!(expected_commits, release.commits);
+        let mut release = Release {
+            version: None,
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit::from(String::from(
+                    "1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github integration",
+                )),
+                Commit::from(String::from(
+                    "21f6aa587fcb772de13f2fde0e92697c51f84162 fix github integration",
+                )),
+                Commit::from(String::from(
+                    "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
+                )),
+                Commit::from(String::from(
+                    "4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
+                )),
+                Commit::from(String::from(
+                    "5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
+                )),
+                Commit::from(String::from(
+                    "6c34967147560ea09658776d4901709139b4ad66 should be fine",
+                )),
+            ],
+            commit_range: None,
+            commit_id: None,
+            timestamp: None,
+            previous: Some(Box::new(Release {
+                version: Some(String::from("1.0.0")),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        };
+        release.update_gitlab_metadata(
+            vec![
+                GitLabCommit {
+                    id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                    author_name: String::from("orhun"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                    author_name: String::from("orhun"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                    author_name: String::from("nuhro"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                    author_name: String::from("awesome_contributor"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                    author_name: String::from("orhun"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                    author_name: String::from("someone"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("0c34967147560e809658776d4901709139b4ad68"),
+                    author_name: String::from("idk"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+                GitLabCommit {
+                    id: String::from("kk34967147560e809658776d4901709139b4ad68"),
+                    author_name: String::from("orhun"),
+                    short_id: String::from(""),
+                    title: String::from(""),
+                    author_email: String::from(""),
+                    authored_date: String::from(""),
+                    committer_name: String::from(""),
+                    committer_email: String::from(""),
+                    committed_date: String::from(""),
+                    created_at: String::from(""),
+                    message: String::from(""),
+                    parent_ids: vec![],
+                    web_url: String::from(""),
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect(),
+            vec![Box::new(GitLabMergeRequest {
+                title: String::from("1"),
+                merge_commit_sha: Some(String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071")),
+                id: 1,
+                iid: 1,
+                project_id: 1,
+                description: String::from(""),
+                state: String::from(""),
+                created_at: String::from(""),
+                author: GitLabUser {
+                    id: 1,
+                    name: String::from("42"),
+                    username: String::from("42"),
+                    state: String::from("42"),
+                    avatar_url: None,
+                    web_url: String::from("42"),
+                },
+                sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                web_url: String::from(""),
+                squash_commit_sha: None,
+                labels: vec![String::from("rust")],
+            })],
+        )?;
+        #[allow(deprecated)]
+        let expected_commits = vec![
+            Commit {
+                id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                message: String::from("add github integration"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                message: String::from("fix github integration"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                message: String::from("update metadata"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                message: String::from("do some stuff"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                message: String::from("alright"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                message: String::from("should be fine"),
+                gitlab: RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(expected_commits, release.commits);
 
-		release
-			.github
-			.contributors
-			.sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+        release
+            .github
+            .contributors
+            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
-		let expected_metadata = RemoteReleaseMetadata {
-			contributors: vec![
-				RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-			],
-		};
-		assert_eq!(expected_metadata, release.gitlab);
+        let expected_metadata = RemoteReleaseMetadata {
+            contributors: vec![
+                RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+            ],
+        };
+        assert_eq!(expected_metadata, release.gitlab);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[cfg(feature = "gitea")]
-	#[test]
-	fn update_gitea_metadata() -> Result<()> {
-		use crate::remote::gitea::{
-			GiteaCommit, GiteaCommitAuthor, GiteaPullRequest, PullRequestLabel,
-		};
+    #[cfg(feature = "gitea")]
+    #[test]
+    fn update_gitea_metadata() -> Result<()> {
+        use crate::remote::gitea::{
+            GiteaCommit, GiteaCommitAuthor, GiteaPullRequest, PullRequestLabel,
+        };
 
-		let mut release = Release {
-			version: None,
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit::from(String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"21f6aa587fcb772de13f2fde0e92697c51f84162 fix github \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
-				)),
-				Commit::from(String::from(
-					"4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
-				)),
-				Commit::from(String::from(
-					"5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
-				)),
-				Commit::from(String::from(
-					"6c34967147560ea09658776d4901709139b4ad66 should be fine",
-				)),
-			],
-			commit_range: None,
-			commit_id: None,
-			timestamp: None,
-			previous: Some(Box::new(Release {
-				version: Some(String::from("1.0.0")),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		};
-		release.update_gitea_metadata(
-			vec![
-				GiteaCommit {
-					sha:     String::from(
-						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					created: String::from("2021-07-18T15:14:39+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"21f6aa587fcb772de13f2fde0e92697c51f84162",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					created: String::from("2021-07-18T15:12:19+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("nuhro")),
-					}),
-					created: String::from("2021-07-18T15:07:23+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"4d3ffe4753b923f4d7807c490e650e6624a12074",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("awesome_contributor")),
-					}),
-					created: String::from("2021-07-18T15:05:10+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					created: String::from("2021-07-18T15:03:30+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"6c34967147560ea09658776d4901709139b4ad66",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("someone")),
-					}),
-					created: String::from("2021-07-18T15:00:38+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"0c34967147560e809658776d4901709139b4ad68",
-					),
-					author:  Some(GiteaCommitAuthor {
-						login: Some(String::from("idk")),
-					}),
-					created: String::from("2021-07-18T15:00:38+03:00"),
-				},
-				GiteaCommit {
-					sha:     String::from(
-						"kk34967147560e809658776d4901709139b4ad68",
-					),
-					author:  None,
-					created: String::new(),
-				},
-				GiteaCommit {
-					sha:     String::new(),
-					author:  None,
-					created: String::new(),
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect(),
-			vec![
-				GiteaPullRequest {
-					title:            Some(String::from("1")),
-					number:           42,
-					merge_commit_sha: Some(String::from(
-						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("rust"),
-					}],
-				},
-				GiteaPullRequest {
-					title:            Some(String::from("2")),
-					number:           66,
-					merge_commit_sha: Some(String::from(
-						"21f6aa587fcb772de13f2fde0e92697c51f84162",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("rust"),
-					}],
-				},
-				GiteaPullRequest {
-					title:            Some(String::from("3")),
-					number:           53,
-					merge_commit_sha: Some(String::from(
-						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("deps"),
-					}],
-				},
-				GiteaPullRequest {
-					title:            Some(String::from("4")),
-					number:           1000,
-					merge_commit_sha: Some(String::from(
-						"4d3ffe4753b923f4d7807c490e650e6624a12074",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("deps"),
-					}],
-				},
-				GiteaPullRequest {
-					title:            Some(String::from("5")),
-					number:           999999,
-					merge_commit_sha: Some(String::from(
-						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
-					)),
-					labels:           vec![PullRequestLabel {
-						name: String::from("github"),
-					}],
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect(),
-		)?;
-		#[allow(deprecated)]
-		let expected_commits = vec![
-			Commit {
-				id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-				message: String::from("add github integration"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-				message: String::from("fix github integration"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("2")),
-					pr_number:     Some(66),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("2")),
-					pr_number:     Some(66),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-				message: String::from("update metadata"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-				message: String::from("do some stuff"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-				message: String::from("alright"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("5")),
-					pr_number:     Some(999999),
-					pr_labels:     vec![String::from("github")],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("5")),
-					pr_number:     Some(999999),
-					pr_labels:     vec![String::from("github")],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
-				message: String::from("should be fine"),
-				gitea: RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-		];
-		assert_eq!(expected_commits, release.commits);
+        let mut release = Release {
+            version: None,
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit::from(String::from(
+                    "1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add github integration",
+                )),
+                Commit::from(String::from(
+                    "21f6aa587fcb772de13f2fde0e92697c51f84162 fix github integration",
+                )),
+                Commit::from(String::from(
+                    "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
+                )),
+                Commit::from(String::from(
+                    "4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
+                )),
+                Commit::from(String::from(
+                    "5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
+                )),
+                Commit::from(String::from(
+                    "6c34967147560ea09658776d4901709139b4ad66 should be fine",
+                )),
+            ],
+            commit_range: None,
+            commit_id: None,
+            timestamp: None,
+            previous: Some(Box::new(Release {
+                version: Some(String::from("1.0.0")),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        };
+        release.update_gitea_metadata(
+            vec![
+                GiteaCommit {
+                    sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    created: String::from("2021-07-18T15:14:39+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    created: String::from("2021-07-18T15:12:19+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("nuhro")),
+                    }),
+                    created: String::from("2021-07-18T15:07:23+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("awesome_contributor")),
+                    }),
+                    created: String::from("2021-07-18T15:05:10+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    created: String::from("2021-07-18T15:03:30+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("someone")),
+                    }),
+                    created: String::from("2021-07-18T15:00:38+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("0c34967147560e809658776d4901709139b4ad68"),
+                    author: Some(GiteaCommitAuthor {
+                        login: Some(String::from("idk")),
+                    }),
+                    created: String::from("2021-07-18T15:00:38+03:00"),
+                },
+                GiteaCommit {
+                    sha: String::from("kk34967147560e809658776d4901709139b4ad68"),
+                    author: None,
+                    created: String::new(),
+                },
+                GiteaCommit {
+                    sha: String::new(),
+                    author: None,
+                    created: String::new(),
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect(),
+            vec![
+                GiteaPullRequest {
+                    title: Some(String::from("1")),
+                    number: 42,
+                    merge_commit_sha: Some(String::from(
+                        "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("rust"),
+                    }],
+                },
+                GiteaPullRequest {
+                    title: Some(String::from("2")),
+                    number: 66,
+                    merge_commit_sha: Some(String::from(
+                        "21f6aa587fcb772de13f2fde0e92697c51f84162",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("rust"),
+                    }],
+                },
+                GiteaPullRequest {
+                    title: Some(String::from("3")),
+                    number: 53,
+                    merge_commit_sha: Some(String::from(
+                        "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("deps"),
+                    }],
+                },
+                GiteaPullRequest {
+                    title: Some(String::from("4")),
+                    number: 1000,
+                    merge_commit_sha: Some(String::from(
+                        "4d3ffe4753b923f4d7807c490e650e6624a12074",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("deps"),
+                    }],
+                },
+                GiteaPullRequest {
+                    title: Some(String::from("5")),
+                    number: 999999,
+                    merge_commit_sha: Some(String::from(
+                        "5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
+                    )),
+                    labels: vec![PullRequestLabel {
+                        name: String::from("github"),
+                    }],
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect(),
+        )?;
+        #[allow(deprecated)]
+        let expected_commits = vec![
+            Commit {
+                id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                message: String::from("add github integration"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                message: String::from("fix github integration"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("2")),
+                    pr_number: Some(66),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("2")),
+                    pr_number: Some(66),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                message: String::from("update metadata"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                message: String::from("do some stuff"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                message: String::from("alright"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("5")),
+                    pr_number: Some(999999),
+                    pr_labels: vec![String::from("github")],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("5")),
+                    pr_number: Some(999999),
+                    pr_labels: vec![String::from("github")],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                message: String::from("should be fine"),
+                gitea: RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(expected_commits, release.commits);
 
-		release
-			.gitea
-			.contributors
-			.sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+        release
+            .gitea
+            .contributors
+            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
-		let expected_metadata = RemoteReleaseMetadata {
-			contributors: vec![
-				RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(42),
-					pr_labels:     vec![String::from("rust")],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      Some(String::from("3")),
-					pr_number:     Some(53),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      Some(String::from("4")),
-					pr_number:     Some(1000),
-					pr_labels:     vec![String::from("deps")],
-					is_first_time: true,
-				},
-			],
-		};
-		assert_eq!(expected_metadata, release.gitea);
+        let expected_metadata = RemoteReleaseMetadata {
+            contributors: vec![
+                RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(42),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: Some(String::from("3")),
+                    pr_number: Some(53),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: Some(String::from("4")),
+                    pr_number: Some(1000),
+                    pr_labels: vec![String::from("deps")],
+                    is_first_time: true,
+                },
+            ],
+        };
+        assert_eq!(expected_metadata, release.gitea);
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[cfg(feature = "bitbucket")]
-	#[test]
-	fn update_bitbucket_metadata() -> Result<()> {
-		use crate::remote::bitbucket::{
-			BitbucketCommit, BitbucketCommitAuthor, BitbucketPullRequest,
-			BitbucketPullRequestMergeCommit,
-		};
+    #[cfg(feature = "bitbucket")]
+    #[test]
+    fn update_bitbucket_metadata() -> Result<()> {
+        use crate::remote::bitbucket::{
+            BitbucketCommit, BitbucketCommitAuthor, BitbucketPullRequest,
+            BitbucketPullRequestMergeCommit,
+        };
 
-		let mut release = Release {
-			version: None,
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit::from(String::from(
-					"1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add bitbucket \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"21f6aa587fcb772de13f2fde0e92697c51f84162 fix bitbucket \
-					 integration",
-				)),
-				Commit::from(String::from(
-					"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
-				)),
-				Commit::from(String::from(
-					"4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
-				)),
-				Commit::from(String::from(
-					"5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
-				)),
-				Commit::from(String::from(
-					"6c34967147560ea09658776d4901709139b4ad66 should be fine",
-				)),
-			],
-			commit_range: None,
-			commit_id: None,
-			timestamp: None,
-			previous: Some(Box::new(Release {
-				version: Some(String::from("1.0.0")),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		};
-		release.update_bitbucket_metadata(
-			vec![
-				BitbucketCommit {
-					hash:   String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					date:   String::from("2021-07-18T15:14:39+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					date:   String::from("2021-07-18T15:12:19+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("nuhro")),
-					}),
-					date:   String::from("2021-07-18T15:07:23+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("awesome_contributor")),
-					}),
-					date:   String::from("2021-07-18T15:05:10+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					date:   String::from("2021-07-18T15:03:30+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("6c34967147560ea09658776d4901709139b4ad66"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("someone")),
-					}),
-					date:   String::from("2021-07-18T15:00:38+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("0c34967147560e809658776d4901709139b4ad68"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("idk")),
-					}),
-					date:   String::from("2021-07-18T15:00:01+03:00"),
-				},
-				BitbucketCommit {
-					hash:   String::from("kk34967147560e809658776d4901709139b4ad68"),
-					author: Some(BitbucketCommitAuthor {
-						login: Some(String::from("orhun")),
-					}),
-					date:   String::from("2021-07-14T21:25:24+03:00"),
-				},
-			]
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect(),
-			vec![Box::new(BitbucketPullRequest {
-				id:           1,
-				title:        Some(String::from("1")),
-				author:       BitbucketCommitAuthor {
-					login: Some(String::from("42")),
-				},
-				merge_commit: BitbucketPullRequestMergeCommit {
-					// Bitbucket merge commits returned in short format
-					hash: String::from("1d244937ee6c"),
-				},
-			})],
-		)?;
-		#[allow(deprecated)]
-		let expected_commits = vec![
-			Commit {
-				id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-				message: String::from("add bitbucket integration"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
-				message: String::from("fix bitbucket integration"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
-				message: String::from("update metadata"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
-				message: String::from("do some stuff"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
-				message: String::from("alright"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-			Commit {
-				id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
-				message: String::from("should be fine"),
-				bitbucket: RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-				remote: Some(RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: false,
-				}),
-				..Default::default()
-			},
-		];
-		assert_eq!(expected_commits, release.commits);
+        let mut release = Release {
+            version: None,
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit::from(String::from(
+                    "1d244937ee6ceb8e0314a4a201ba93a7a61f2071 add bitbucket integration",
+                )),
+                Commit::from(String::from(
+                    "21f6aa587fcb772de13f2fde0e92697c51f84162 fix bitbucket integration",
+                )),
+                Commit::from(String::from(
+                    "35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973 update metadata",
+                )),
+                Commit::from(String::from(
+                    "4d3ffe4753b923f4d7807c490e650e6624a12074 do some stuff",
+                )),
+                Commit::from(String::from(
+                    "5a55e92e5a62dc5bf9872ffb2566959fad98bd05 alright",
+                )),
+                Commit::from(String::from(
+                    "6c34967147560ea09658776d4901709139b4ad66 should be fine",
+                )),
+            ],
+            commit_range: None,
+            commit_id: None,
+            timestamp: None,
+            previous: Some(Box::new(Release {
+                version: Some(String::from("1.0.0")),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        };
+        release.update_bitbucket_metadata(
+            vec![
+                BitbucketCommit {
+                    hash: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    date: String::from("2021-07-18T15:14:39+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    date: String::from("2021-07-18T15:12:19+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("nuhro")),
+                    }),
+                    date: String::from("2021-07-18T15:07:23+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("awesome_contributor")),
+                    }),
+                    date: String::from("2021-07-18T15:05:10+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    date: String::from("2021-07-18T15:03:30+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("someone")),
+                    }),
+                    date: String::from("2021-07-18T15:00:38+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("0c34967147560e809658776d4901709139b4ad68"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("idk")),
+                    }),
+                    date: String::from("2021-07-18T15:00:01+03:00"),
+                },
+                BitbucketCommit {
+                    hash: String::from("kk34967147560e809658776d4901709139b4ad68"),
+                    author: Some(BitbucketCommitAuthor {
+                        login: Some(String::from("orhun")),
+                    }),
+                    date: String::from("2021-07-14T21:25:24+03:00"),
+                },
+            ]
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect(),
+            vec![Box::new(BitbucketPullRequest {
+                id: 1,
+                title: Some(String::from("1")),
+                author: BitbucketCommitAuthor {
+                    login: Some(String::from("42")),
+                },
+                merge_commit: BitbucketPullRequestMergeCommit {
+                    // Bitbucket merge commits returned in short format
+                    hash: String::from("1d244937ee6c"),
+                },
+            })],
+        )?;
+        #[allow(deprecated)]
+        let expected_commits = vec![
+            Commit {
+                id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+                message: String::from("add bitbucket integration"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
+                message: String::from("fix bitbucket integration"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
+                message: String::from("update metadata"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
+                message: String::from("do some stuff"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
+                message: String::from("alright"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("6c34967147560ea09658776d4901709139b4ad66"),
+                message: String::from("should be fine"),
+                bitbucket: RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+                remote: Some(RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: false,
+                }),
+                ..Default::default()
+            },
+        ];
+        assert_eq!(expected_commits, release.commits);
 
-		release
-			.bitbucket
-			.contributors
-			.sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+        release
+            .bitbucket
+            .contributors
+            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
-		let expected_metadata = RemoteReleaseMetadata {
-			contributors: vec![
-				RemoteContributor {
-					username:      Some(String::from("nuhro")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("awesome_contributor")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("someone")),
-					pr_title:      None,
-					pr_number:     None,
-					pr_labels:     vec![],
-					is_first_time: true,
-				},
-				RemoteContributor {
-					username:      Some(String::from("orhun")),
-					pr_title:      Some(String::from("1")),
-					pr_number:     Some(1),
-					pr_labels:     vec![],
-					is_first_time: false,
-				},
-			],
-		};
-		assert_eq!(expected_metadata, release.bitbucket);
+        let expected_metadata = RemoteReleaseMetadata {
+            contributors: vec![
+                RemoteContributor {
+                    username: Some(String::from("nuhro")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("awesome_contributor")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("someone")),
+                    pr_title: None,
+                    pr_number: None,
+                    pr_labels: vec![],
+                    is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![],
+                    is_first_time: false,
+                },
+            ],
+        };
+        assert_eq!(expected_metadata, release.bitbucket);
 
-		Ok(())
-	}
+        Ok(())
+    }
 }

--- a/git-cliff-core/src/remote/bitbucket.rs
+++ b/git-cliff-core/src/remote/bitbucket.rs
@@ -12,8 +12,7 @@ pub const START_FETCHING_MSG: &str = "Retrieving data from Bitbucket...";
 pub const FINISHED_FETCHING_MSG: &str = "Done fetching Bitbucket data.";
 
 /// Template variables related to this remote.
-pub(crate) const TEMPLATE_VARIABLES: &[&str] =
-	&["bitbucket", "commit.bitbucket", "commit.remote"];
+pub(crate) const TEMPLATE_VARIABLES: &[&str] = &["bitbucket", "commit.bitbucket", "commit.remote"];
 
 /// Maximum number of entries to fetch for bitbucket pull requests.
 pub(crate) const BITBUCKET_MAX_PAGE_PRS: usize = 50;
@@ -21,57 +20,51 @@ pub(crate) const BITBUCKET_MAX_PAGE_PRS: usize = 50;
 /// Representation of a single commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketCommit {
-	/// SHA.
-	pub hash:   String,
-	/// Date of the commit
-	pub date:   String,
-	/// Author of the commit.
-	pub author: Option<BitbucketCommitAuthor>,
+    /// SHA.
+    pub hash: String,
+    /// Date of the commit
+    pub date: String,
+    /// Author of the commit.
+    pub author: Option<BitbucketCommitAuthor>,
 }
 
 impl RemoteCommit for BitbucketCommit {
-	fn id(&self) -> String {
-		self.hash.clone()
-	}
+    fn id(&self) -> String {
+        self.hash.clone()
+    }
 
-	fn username(&self) -> Option<String> {
-		self.author.clone().and_then(|v| v.login)
-	}
+    fn username(&self) -> Option<String> {
+        self.author.clone().and_then(|v| v.login)
+    }
 
-	fn timestamp(&self) -> Option<i64> {
-		Some(self.convert_to_unix_timestamp(self.date.clone().as_str()))
-	}
+    fn timestamp(&self) -> Option<i64> {
+        Some(self.convert_to_unix_timestamp(self.date.clone().as_str()))
+    }
 }
 
 /// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commits-get>
 impl RemoteEntry for BitbucketPagination<BitbucketCommit> {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		let commit_page = page + 1;
-		let mut url = format!(
-			"{}/{}/{}/commits?pagelen={MAX_PAGE_SIZE}&page={commit_page}",
-			api_url, remote.owner, remote.repo
-		);
+    fn url(_id: i64, api_url: &str, remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
+        let commit_page = page + 1;
+        let mut url = format!(
+            "{}/{}/{}/commits?pagelen={MAX_PAGE_SIZE}&page={commit_page}",
+            api_url, remote.owner, remote.repo
+        );
 
-		if let Some(ref_name) = ref_name {
-			url.push_str(&format!("&include={}", ref_name));
-		}
+        if let Some(ref_name) = ref_name {
+            url.push_str(&format!("&include={}", ref_name));
+        }
 
-		url
-	}
+        url
+    }
 
-	fn buffer_size() -> usize {
-		10
-	}
+    fn buffer_size() -> usize {
+        10
+    }
 
-	fn early_exit(&self) -> bool {
-		self.values.is_empty()
-	}
+    fn early_exit(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 /// Bitbucket Pagination Header
@@ -79,185 +72,171 @@ impl RemoteEntry for BitbucketPagination<BitbucketCommit> {
 /// <https://developer.atlassian.com/cloud/bitbucket/rest/intro/#pagination>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketPagination<T> {
-	/// Total number of objects in the response.
-	pub size:     Option<i64>,
-	/// Page number of the current results.
-	pub page:     Option<i64>,
-	/// Current number of objects on the existing page.  Globally, the minimum
-	/// length is 10 and the maximum is 100.
-	pub pagelen:  Option<i64>,
-	/// Link to the next page if it exists.
-	pub next:     Option<String>,
-	/// Link to the previous page if it exists.
-	pub previous: Option<String>,
-	/// List of Objects.
-	pub values:   Vec<T>,
+    /// Total number of objects in the response.
+    pub size: Option<i64>,
+    /// Page number of the current results.
+    pub page: Option<i64>,
+    /// Current number of objects on the existing page.  Globally, the minimum
+    /// length is 10 and the maximum is 100.
+    pub pagelen: Option<i64>,
+    /// Link to the next page if it exists.
+    pub next: Option<String>,
+    /// Link to the previous page if it exists.
+    pub previous: Option<String>,
+    /// List of Objects.
+    pub values: Vec<T>,
 }
 
 /// Author of the commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketCommitAuthor {
-	/// Username.
-	#[serde(rename = "raw")]
-	pub login: Option<String>,
+    /// Username.
+    #[serde(rename = "raw")]
+    pub login: Option<String>,
 }
 
 /// Label of the pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PullRequestLabel {
-	/// Name of the label.
-	pub name: String,
+    /// Name of the label.
+    pub name: String,
 }
 
 /// Representation of a single pull request's merge commit
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketPullRequestMergeCommit {
-	/// SHA of the merge commit.
-	pub hash: String,
+    /// SHA of the merge commit.
+    pub hash: String,
 }
 
 /// Representation of a single pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketPullRequest {
-	/// Pull request number.
-	pub id:           i64,
-	/// Pull request title.
-	pub title:        Option<String>,
-	/// Bitbucket Pull Request Merge Commit
-	pub merge_commit: BitbucketPullRequestMergeCommit,
-	/// Author of Pull Request
-	pub author:       BitbucketCommitAuthor,
+    /// Pull request number.
+    pub id: i64,
+    /// Pull request title.
+    pub title: Option<String>,
+    /// Bitbucket Pull Request Merge Commit
+    pub merge_commit: BitbucketPullRequestMergeCommit,
+    /// Author of Pull Request
+    pub author: BitbucketCommitAuthor,
 }
 
 impl RemotePullRequest for BitbucketPullRequest {
-	fn number(&self) -> i64 {
-		self.id
-	}
+    fn number(&self) -> i64 {
+        self.id
+    }
 
-	fn title(&self) -> Option<String> {
-		self.title.clone()
-	}
+    fn title(&self) -> Option<String> {
+        self.title.clone()
+    }
 
-	fn labels(&self) -> Vec<String> {
-		vec![]
-	}
+    fn labels(&self) -> Vec<String> {
+        vec![]
+    }
 
-	fn merge_commit(&self) -> Option<String> {
-		Some(self.merge_commit.hash.clone())
-	}
+    fn merge_commit(&self) -> Option<String> {
+        Some(self.merge_commit.hash.clone())
+    }
 }
 
 /// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-get>
 impl RemoteEntry for BitbucketPagination<BitbucketPullRequest> {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		_ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		let pr_page = page + 1;
-		format!(
-			"{}/{}/{}/pullrequests?&pagelen={BITBUCKET_MAX_PAGE_PRS}&\
-			 page={pr_page}&state=MERGED",
-			api_url, remote.owner, remote.repo
-		)
-	}
+    fn url(_id: i64, api_url: &str, remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
+        let pr_page = page + 1;
+        format!(
+            "{}/{}/{}/pullrequests?&pagelen={BITBUCKET_MAX_PAGE_PRS}&page={pr_page}&state=MERGED",
+            api_url, remote.owner, remote.repo
+        )
+    }
 
-	fn buffer_size() -> usize {
-		5
-	}
+    fn buffer_size() -> usize {
+        5
+    }
 
-	fn early_exit(&self) -> bool {
-		self.values.is_empty()
-	}
+    fn early_exit(&self) -> bool {
+        self.values.is_empty()
+    }
 }
 
 /// HTTP client for handling Bitbucket REST API requests.
 #[derive(Debug, Clone)]
 pub struct BitbucketClient {
-	/// Remote.
-	remote: Remote,
-	/// HTTP client.
-	client: ClientWithMiddleware,
+    /// Remote.
+    remote: Remote,
+    /// HTTP client.
+    client: ClientWithMiddleware,
 }
 
 /// Constructs a Bitbucket client from the remote configuration.
 impl TryFrom<Remote> for BitbucketClient {
-	type Error = Error;
-	fn try_from(remote: Remote) -> Result<Self> {
-		Ok(Self {
-			client: remote.create_client("application/json")?,
-			remote,
-		})
-	}
+    type Error = Error;
+    fn try_from(remote: Remote) -> Result<Self> {
+        Ok(Self {
+            client: remote.create_client("application/json")?,
+            remote,
+        })
+    }
 }
 
 impl RemoteClient for BitbucketClient {
-	const API_URL: &'static str = "https://api.bitbucket.org/2.0/repositories";
-	const API_URL_ENV: &'static str = "BITBUCKET_API_URL";
+    const API_URL: &'static str = "https://api.bitbucket.org/2.0/repositories";
+    const API_URL_ENV: &'static str = "BITBUCKET_API_URL";
 
-	fn remote(&self) -> Remote {
-		self.remote.clone()
-	}
+    fn remote(&self) -> Remote {
+        self.remote.clone()
+    }
 
-	fn client(&self) -> ClientWithMiddleware {
-		self.client.clone()
-	}
+    fn client(&self) -> ClientWithMiddleware {
+        self.client.clone()
+    }
 }
 
 impl BitbucketClient {
-	/// Fetches the Bitbucket API and returns the commits.
-	pub async fn get_commits(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemoteCommit>>> {
-		Ok(self
-			.fetch_with_early_exit::<BitbucketPagination<BitbucketCommit>>(
-				0, ref_name,
-			)
-			.await?
-			.into_iter()
-			.flat_map(|v| v.values)
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect())
-	}
+    /// Fetches the Bitbucket API and returns the commits.
+    pub async fn get_commits(&self, ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        Ok(self
+            .fetch_with_early_exit::<BitbucketPagination<BitbucketCommit>>(0, ref_name)
+            .await?
+            .into_iter()
+            .flat_map(|v| v.values)
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect())
+    }
 
-	/// Fetches the Bitbucket API and returns the pull requests.
-	pub async fn get_pull_requests(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-		Ok(self
-			.fetch_with_early_exit::<BitbucketPagination<BitbucketPullRequest>>(
-				0, ref_name,
-			)
-			.await?
-			.into_iter()
-			.flat_map(|v| v.values)
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect())
-	}
+    /// Fetches the Bitbucket API and returns the pull requests.
+    pub async fn get_pull_requests(
+        &self,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
+        Ok(self
+            .fetch_with_early_exit::<BitbucketPagination<BitbucketPullRequest>>(0, ref_name)
+            .await?
+            .into_iter()
+            .flat_map(|v| v.values)
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect())
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	use crate::remote::RemoteCommit;
+    use super::*;
+    use crate::remote::RemoteCommit;
 
-	#[test]
-	fn timestamp() {
-		let remote_commit = BitbucketCommit {
-			hash:   String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-			author: Some(BitbucketCommitAuthor {
-				login: Some(String::from("orhun")),
-			}),
-			date:   String::from("2021-07-18T15:14:39+03:00"),
-		};
+    #[test]
+    fn timestamp() {
+        let remote_commit = BitbucketCommit {
+            hash: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+            author: Some(BitbucketCommitAuthor {
+                login: Some(String::from("orhun")),
+            }),
+            date: String::from("2021-07-18T15:14:39+03:00"),
+        };
 
-		assert_eq!(Some(1626610479), remote_commit.timestamp());
-	}
+        assert_eq!(Some(1626610479), remote_commit.timestamp());
+    }
 }

--- a/git-cliff-core/src/remote/gitea.rs
+++ b/git-cliff-core/src/remote/gitea.rs
@@ -12,211 +12,194 @@ pub const START_FETCHING_MSG: &str = "Retrieving data from Gitea...";
 pub const FINISHED_FETCHING_MSG: &str = "Done fetching Gitea data.";
 
 /// Template variables related to this remote.
-pub(crate) const TEMPLATE_VARIABLES: &[&str] =
-	&["gitea", "commit.gitea", "commit.remote"];
+pub(crate) const TEMPLATE_VARIABLES: &[&str] = &["gitea", "commit.gitea", "commit.remote"];
 
 /// Representation of a single commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GiteaCommit {
-	/// SHA.
-	pub sha:     String,
-	/// Author of the commit.
-	pub author:  Option<GiteaCommitAuthor>,
-	/// Timestamp of the commit.
-	pub created: String,
+    /// SHA.
+    pub sha: String,
+    /// Author of the commit.
+    pub author: Option<GiteaCommitAuthor>,
+    /// Timestamp of the commit.
+    pub created: String,
 }
 
 impl RemoteCommit for GiteaCommit {
-	fn id(&self) -> String {
-		self.sha.clone()
-	}
+    fn id(&self) -> String {
+        self.sha.clone()
+    }
 
-	fn username(&self) -> Option<String> {
-		self.author.clone().and_then(|v| v.login)
-	}
+    fn username(&self) -> Option<String> {
+        self.author.clone().and_then(|v| v.login)
+    }
 
-	fn timestamp(&self) -> Option<i64> {
-		Some(self.convert_to_unix_timestamp(self.created.clone().as_str()))
-	}
+    fn timestamp(&self) -> Option<i64> {
+        Some(self.convert_to_unix_timestamp(self.created.clone().as_str()))
+    }
 }
 
 impl RemoteEntry for GiteaCommit {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		let mut url = format!(
-			"{}/api/v1/repos/{}/{}/commits?limit={MAX_PAGE_SIZE}&page={page}",
-			api_url, remote.owner, remote.repo
-		);
+    fn url(_id: i64, api_url: &str, remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
+        let mut url = format!(
+            "{}/api/v1/repos/{}/{}/commits?limit={MAX_PAGE_SIZE}&page={page}",
+            api_url, remote.owner, remote.repo
+        );
 
-		if let Some(ref_name) = ref_name {
-			url.push_str(&format!("&sha={}", ref_name));
-		}
+        if let Some(ref_name) = ref_name {
+            url.push_str(&format!("&sha={}", ref_name));
+        }
 
-		url
-	}
+        url
+    }
 
-	fn buffer_size() -> usize {
-		10
-	}
+    fn buffer_size() -> usize {
+        10
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// Author of the commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GiteaCommitAuthor {
-	/// Username.
-	pub login: Option<String>,
+    /// Username.
+    pub login: Option<String>,
 }
 
 /// Label of the pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PullRequestLabel {
-	/// Name of the label.
-	pub name: String,
+    /// Name of the label.
+    pub name: String,
 }
 
 /// Representation of a single pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GiteaPullRequest {
-	/// Pull request number.
-	pub number:           i64,
-	/// Pull request title.
-	pub title:            Option<String>,
-	/// SHA of the merge commit.
-	pub merge_commit_sha: Option<String>,
-	/// Labels of the pull request.
-	pub labels:           Vec<PullRequestLabel>,
+    /// Pull request number.
+    pub number: i64,
+    /// Pull request title.
+    pub title: Option<String>,
+    /// SHA of the merge commit.
+    pub merge_commit_sha: Option<String>,
+    /// Labels of the pull request.
+    pub labels: Vec<PullRequestLabel>,
 }
 
 impl RemotePullRequest for GiteaPullRequest {
-	fn number(&self) -> i64 {
-		self.number
-	}
+    fn number(&self) -> i64 {
+        self.number
+    }
 
-	fn title(&self) -> Option<String> {
-		self.title.clone()
-	}
+    fn title(&self) -> Option<String> {
+        self.title.clone()
+    }
 
-	fn labels(&self) -> Vec<String> {
-		self.labels.iter().map(|v| v.name.clone()).collect()
-	}
+    fn labels(&self) -> Vec<String> {
+        self.labels.iter().map(|v| v.name.clone()).collect()
+    }
 
-	fn merge_commit(&self) -> Option<String> {
-		self.merge_commit_sha.clone()
-	}
+    fn merge_commit(&self) -> Option<String> {
+        self.merge_commit_sha.clone()
+    }
 }
 
 impl RemoteEntry for GiteaPullRequest {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		_ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		format!(
-			"{}/api/v1/repos/{}/{}/pulls?limit={MAX_PAGE_SIZE}&page={page}&\
-			 state=closed",
-			api_url, remote.owner, remote.repo
-		)
-	}
+    fn url(_id: i64, api_url: &str, remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
+        format!(
+            "{}/api/v1/repos/{}/{}/pulls?limit={MAX_PAGE_SIZE}&page={page}&state=closed",
+            api_url, remote.owner, remote.repo
+        )
+    }
 
-	fn buffer_size() -> usize {
-		5
-	}
+    fn buffer_size() -> usize {
+        5
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// HTTP client for handling Gitea REST API requests.
 #[derive(Debug, Clone)]
 pub struct GiteaClient {
-	/// Remote.
-	remote: Remote,
-	/// HTTP client.
-	client: ClientWithMiddleware,
+    /// Remote.
+    remote: Remote,
+    /// HTTP client.
+    client: ClientWithMiddleware,
 }
 
 /// Constructs a Gitea client from the remote configuration.
 impl TryFrom<Remote> for GiteaClient {
-	type Error = Error;
-	fn try_from(remote: Remote) -> Result<Self> {
-		Ok(Self {
-			client: remote.create_client("application/json")?,
-			remote,
-		})
-	}
+    type Error = Error;
+    fn try_from(remote: Remote) -> Result<Self> {
+        Ok(Self {
+            client: remote.create_client("application/json")?,
+            remote,
+        })
+    }
 }
 
 impl RemoteClient for GiteaClient {
-	const API_URL: &'static str = "https://codeberg.org";
-	const API_URL_ENV: &'static str = "GITEA_API_URL";
+    const API_URL: &'static str = "https://codeberg.org";
+    const API_URL_ENV: &'static str = "GITEA_API_URL";
 
-	fn remote(&self) -> Remote {
-		self.remote.clone()
-	}
+    fn remote(&self) -> Remote {
+        self.remote.clone()
+    }
 
-	fn client(&self) -> ClientWithMiddleware {
-		self.client.clone()
-	}
+    fn client(&self) -> ClientWithMiddleware {
+        self.client.clone()
+    }
 }
 
 impl GiteaClient {
-	/// Fetches the Gitea API and returns the commits.
-	pub async fn get_commits(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemoteCommit>>> {
-		Ok(self
-			.fetch::<GiteaCommit>(0, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect())
-	}
+    /// Fetches the Gitea API and returns the commits.
+    pub async fn get_commits(&self, ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        Ok(self
+            .fetch::<GiteaCommit>(0, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect())
+    }
 
-	/// Fetches the Gitea API and returns the pull requests.
-	pub async fn get_pull_requests(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-		Ok(self
-			.fetch::<GiteaPullRequest>(0, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect())
-	}
+    /// Fetches the Gitea API and returns the pull requests.
+    pub async fn get_pull_requests(
+        &self,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
+        Ok(self
+            .fetch::<GiteaPullRequest>(0, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect())
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	use crate::remote::RemoteCommit;
+    use super::*;
+    use crate::remote::RemoteCommit;
 
-	#[test]
-	fn timestamp() {
-		let remote_commit = GiteaCommit {
-			sha:     String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-			author:  Some(GiteaCommitAuthor {
-				login: Some(String::from("orhun")),
-			}),
-			created: String::from("2021-07-18T15:14:39+03:00"),
-		};
+    #[test]
+    fn timestamp() {
+        let remote_commit = GiteaCommit {
+            sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+            author: Some(GiteaCommitAuthor {
+                login: Some(String::from("orhun")),
+            }),
+            created: String::from("2021-07-18T15:14:39+03:00"),
+        };
 
-		assert_eq!(Some(1626610479), remote_commit.timestamp());
-	}
+        assert_eq!(Some(1626610479), remote_commit.timestamp());
+    }
 }

--- a/git-cliff-core/src/remote/github.rs
+++ b/git-cliff-core/src/remote/github.rs
@@ -12,230 +12,214 @@ pub const START_FETCHING_MSG: &str = "Retrieving data from GitHub...";
 pub const FINISHED_FETCHING_MSG: &str = "Done fetching GitHub data.";
 
 /// Template variables related to this remote.
-pub(crate) const TEMPLATE_VARIABLES: &[&str] =
-	&["github", "commit.github", "commit.remote"];
+pub(crate) const TEMPLATE_VARIABLES: &[&str] = &["github", "commit.github", "commit.remote"];
 
 /// Representation of a single commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubCommit {
-	/// SHA.
-	pub sha:    String,
-	/// Author of the commit.
-	pub author: Option<GitHubCommitAuthor>,
-	/// Details of the commit
-	pub commit: Option<GitHubCommitDetails>,
+    /// SHA.
+    pub sha: String,
+    /// Author of the commit.
+    pub author: Option<GitHubCommitAuthor>,
+    /// Details of the commit
+    pub commit: Option<GitHubCommitDetails>,
 }
 
 /// Representation of subset of commit details
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubCommitDetails {
-	/// Author of the commit
-	pub author: GitHubCommitDetailsAuthor,
+    /// Author of the commit
+    pub author: GitHubCommitDetailsAuthor,
 }
 
 /// Representation of subset of commit author details
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubCommitDetailsAuthor {
-	/// Date of the commit
-	pub date: String,
+    /// Date of the commit
+    pub date: String,
 }
 
 impl RemoteCommit for GitHubCommit {
-	fn id(&self) -> String {
-		self.sha.clone()
-	}
+    fn id(&self) -> String {
+        self.sha.clone()
+    }
 
-	fn username(&self) -> Option<String> {
-		self.author.clone().and_then(|v| v.login)
-	}
+    fn username(&self) -> Option<String> {
+        self.author.clone().and_then(|v| v.login)
+    }
 
-	fn timestamp(&self) -> Option<i64> {
-		self.commit
-			.clone()
-			.map(|f| self.convert_to_unix_timestamp(f.author.date.clone().as_str()))
-	}
+    fn timestamp(&self) -> Option<i64> {
+        self.commit
+            .clone()
+            .map(|f| self.convert_to_unix_timestamp(f.author.date.clone().as_str()))
+    }
 }
 
 impl RemoteEntry for GitHubCommit {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		let mut url = format!(
-			"{}/repos/{}/{}/commits?per_page={MAX_PAGE_SIZE}&page={page}",
-			api_url, remote.owner, remote.repo
-		);
+    fn url(_id: i64, api_url: &str, remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
+        let mut url = format!(
+            "{}/repos/{}/{}/commits?per_page={MAX_PAGE_SIZE}&page={page}",
+            api_url, remote.owner, remote.repo
+        );
 
-		if let Some(ref_name) = ref_name {
-			url.push_str(&format!("&sha={}", ref_name));
-		}
+        if let Some(ref_name) = ref_name {
+            url.push_str(&format!("&sha={}", ref_name));
+        }
 
-		url
-	}
+        url
+    }
 
-	fn buffer_size() -> usize {
-		10
-	}
+    fn buffer_size() -> usize {
+        10
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// Author of the commit.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubCommitAuthor {
-	/// Username.
-	pub login: Option<String>,
+    /// Username.
+    pub login: Option<String>,
 }
 
 /// Label of the pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PullRequestLabel {
-	/// Name of the label.
-	pub name: String,
+    /// Name of the label.
+    pub name: String,
 }
 
 /// Representation of a single pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitHubPullRequest {
-	/// Pull request number.
-	pub number:           i64,
-	/// Pull request title.
-	pub title:            Option<String>,
-	/// SHA of the merge commit.
-	pub merge_commit_sha: Option<String>,
-	/// Labels of the pull request.
-	pub labels:           Vec<PullRequestLabel>,
+    /// Pull request number.
+    pub number: i64,
+    /// Pull request title.
+    pub title: Option<String>,
+    /// SHA of the merge commit.
+    pub merge_commit_sha: Option<String>,
+    /// Labels of the pull request.
+    pub labels: Vec<PullRequestLabel>,
 }
 
 impl RemotePullRequest for GitHubPullRequest {
-	fn number(&self) -> i64 {
-		self.number
-	}
+    fn number(&self) -> i64 {
+        self.number
+    }
 
-	fn title(&self) -> Option<String> {
-		self.title.clone()
-	}
+    fn title(&self) -> Option<String> {
+        self.title.clone()
+    }
 
-	fn labels(&self) -> Vec<String> {
-		self.labels.iter().map(|v| v.name.clone()).collect()
-	}
+    fn labels(&self) -> Vec<String> {
+        self.labels.iter().map(|v| v.name.clone()).collect()
+    }
 
-	fn merge_commit(&self) -> Option<String> {
-		self.merge_commit_sha.clone()
-	}
+    fn merge_commit(&self) -> Option<String> {
+        self.merge_commit_sha.clone()
+    }
 }
 
 impl RemoteEntry for GitHubPullRequest {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		_ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		format!(
-			"{}/repos/{}/{}/pulls?per_page={MAX_PAGE_SIZE}&page={page}&state=closed",
-			api_url, remote.owner, remote.repo
-		)
-	}
+    fn url(_id: i64, api_url: &str, remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
+        format!(
+            "{}/repos/{}/{}/pulls?per_page={MAX_PAGE_SIZE}&page={page}&state=closed",
+            api_url, remote.owner, remote.repo
+        )
+    }
 
-	fn buffer_size() -> usize {
-		5
-	}
+    fn buffer_size() -> usize {
+        5
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// HTTP client for handling GitHub REST API requests.
 #[derive(Debug, Clone)]
 pub struct GitHubClient {
-	/// Remote.
-	remote: Remote,
-	/// HTTP client.
-	client: ClientWithMiddleware,
+    /// Remote.
+    remote: Remote,
+    /// HTTP client.
+    client: ClientWithMiddleware,
 }
 
 /// Constructs a GitHub client from the remote configuration.
 impl TryFrom<Remote> for GitHubClient {
-	type Error = Error;
-	fn try_from(remote: Remote) -> Result<Self> {
-		Ok(Self {
-			client: remote.create_client("application/vnd.github+json")?,
-			remote,
-		})
-	}
+    type Error = Error;
+    fn try_from(remote: Remote) -> Result<Self> {
+        Ok(Self {
+            client: remote.create_client("application/vnd.github+json")?,
+            remote,
+        })
+    }
 }
 
 impl RemoteClient for GitHubClient {
-	const API_URL: &'static str = "https://api.github.com";
-	const API_URL_ENV: &'static str = "GITHUB_API_URL";
+    const API_URL: &'static str = "https://api.github.com";
+    const API_URL_ENV: &'static str = "GITHUB_API_URL";
 
-	fn remote(&self) -> Remote {
-		self.remote.clone()
-	}
+    fn remote(&self) -> Remote {
+        self.remote.clone()
+    }
 
-	fn client(&self) -> ClientWithMiddleware {
-		self.client.clone()
-	}
+    fn client(&self) -> ClientWithMiddleware {
+        self.client.clone()
+    }
 }
 
 impl GitHubClient {
-	/// Fetches the GitHub API and returns the commits.
-	pub async fn get_commits(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemoteCommit>>> {
-		Ok(self
-			.fetch::<GitHubCommit>(0, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect())
-	}
+    /// Fetches the GitHub API and returns the commits.
+    pub async fn get_commits(&self, ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        Ok(self
+            .fetch::<GitHubCommit>(0, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect())
+    }
 
-	/// Fetches the GitHub API and returns the pull requests.
-	pub async fn get_pull_requests(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-		Ok(self
-			.fetch::<GitHubPullRequest>(0, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect())
-	}
+    /// Fetches the GitHub API and returns the pull requests.
+    pub async fn get_pull_requests(
+        &self,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
+        Ok(self
+            .fetch::<GitHubPullRequest>(0, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect())
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	use crate::remote::RemoteCommit;
+    use super::*;
+    use crate::remote::RemoteCommit;
 
-	#[test]
-	fn timestamp() {
-		let remote_commit = GitHubCommit {
-			sha:    String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-			author: Some(GitHubCommitAuthor {
-				login: Some(String::from("orhun")),
-			}),
-			commit: Some(GitHubCommitDetails {
-				author: GitHubCommitDetailsAuthor {
-					date: String::from("2021-07-18T15:14:39+03:00"),
-				},
-			}),
-		};
+    #[test]
+    fn timestamp() {
+        let remote_commit = GitHubCommit {
+            sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+            author: Some(GitHubCommitAuthor {
+                login: Some(String::from("orhun")),
+            }),
+            commit: Some(GitHubCommitDetails {
+                author: GitHubCommitDetailsAuthor {
+                    date: String::from("2021-07-18T15:14:39+03:00"),
+                },
+            }),
+        };
 
-		assert_eq!(Some(1626610479), remote_commit.timestamp());
-	}
+        assert_eq!(Some(1626610479), remote_commit.timestamp());
+    }
 }

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -12,53 +12,52 @@ pub const START_FETCHING_MSG: &str = "Retrieving data from GitLab...";
 pub const FINISHED_FETCHING_MSG: &str = "Done fetching GitLab data.";
 
 /// Template variables related to this remote.
-pub(crate) const TEMPLATE_VARIABLES: &[&str] =
-	&["gitlab", "commit.gitlab", "commit.remote"];
+pub(crate) const TEMPLATE_VARIABLES: &[&str] = &["gitlab", "commit.gitlab", "commit.remote"];
 
 /// Representation of a single GitLab Project.
 ///
 /// <https://docs.gitlab.com/ee/api/projects.html#get-single-project>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitLabProject {
-	/// GitLab id for project
-	pub id:                  i64,
-	/// Optional Description of project
-	pub description:         Option<String>,
-	/// Name of project
-	pub name:                String,
-	/// Name of project with namespace owner / repo
-	pub name_with_namespace: String,
-	/// Name of project with namespace owner/repo
-	pub path_with_namespace: String,
-	/// Project created at
-	pub created_at:          String,
-	/// Default branch eg (main/master)
-	pub default_branch:      String,
+    /// GitLab id for project
+    pub id: i64,
+    /// Optional Description of project
+    pub description: Option<String>,
+    /// Name of project
+    pub name: String,
+    /// Name of project with namespace owner / repo
+    pub name_with_namespace: String,
+    /// Name of project with namespace owner/repo
+    pub path_with_namespace: String,
+    /// Project created at
+    pub created_at: String,
+    /// Default branch eg (main/master)
+    pub default_branch: String,
 }
 
 impl RemoteEntry for GitLabProject {
-	fn url(
-		_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		_ref_name: Option<&str>,
-		_page: i32,
-	) -> String {
-		format!(
-			"{}/projects/{}%2F{}",
-			api_url,
-			urlencoding::encode(remote.owner.as_str()),
-			remote.repo
-		)
-	}
+    fn url(
+        _id: i64,
+        api_url: &str,
+        remote: &Remote,
+        _ref_name: Option<&str>,
+        _page: i32,
+    ) -> String {
+        format!(
+            "{}/projects/{}%2F{}",
+            api_url,
+            urlencoding::encode(remote.owner.as_str()),
+            remote.repo
+        )
+    }
 
-	fn buffer_size() -> usize {
-		1
-	}
+    fn buffer_size() -> usize {
+        1
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// Representation of a single commit.
@@ -66,77 +65,70 @@ impl RemoteEntry for GitLabProject {
 /// <https://docs.gitlab.com/ee/api/commits.html>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitLabCommit {
-	/// Sha
-	pub id:              String,
-	/// Short Sha
-	pub short_id:        String,
-	/// Git message
-	pub title:           String,
-	/// Author
-	pub author_name:     String,
-	/// Author Email
-	pub author_email:    String,
-	/// Authored Date
-	pub authored_date:   String,
-	/// Committer Name
-	pub committer_name:  String,
-	/// Committer Email
-	pub committer_email: String,
-	/// Committed Date
-	pub committed_date:  String,
-	/// Created At
-	pub created_at:      String,
-	/// Git Message
-	pub message:         String,
-	/// Parent Ids
-	pub parent_ids:      Vec<String>,
-	/// Web Url
-	pub web_url:         String,
+    /// Sha
+    pub id: String,
+    /// Short Sha
+    pub short_id: String,
+    /// Git message
+    pub title: String,
+    /// Author
+    pub author_name: String,
+    /// Author Email
+    pub author_email: String,
+    /// Authored Date
+    pub authored_date: String,
+    /// Committer Name
+    pub committer_name: String,
+    /// Committer Email
+    pub committer_email: String,
+    /// Committed Date
+    pub committed_date: String,
+    /// Created At
+    pub created_at: String,
+    /// Git Message
+    pub message: String,
+    /// Parent Ids
+    pub parent_ids: Vec<String>,
+    /// Web Url
+    pub web_url: String,
 }
 
 impl RemoteCommit for GitLabCommit {
-	fn id(&self) -> String {
-		self.id.clone()
-	}
+    fn id(&self) -> String {
+        self.id.clone()
+    }
 
-	fn username(&self) -> Option<String> {
-		Some(self.author_name.clone())
-	}
+    fn username(&self) -> Option<String> {
+        Some(self.author_name.clone())
+    }
 
-	fn timestamp(&self) -> Option<i64> {
-		Some(self.convert_to_unix_timestamp(self.committed_date.clone().as_str()))
-	}
+    fn timestamp(&self) -> Option<i64> {
+        Some(self.convert_to_unix_timestamp(self.committed_date.clone().as_str()))
+    }
 }
 
 impl RemoteEntry for GitLabCommit {
-	fn url(
-		id: i64,
-		api_url: &str,
-		_remote: &Remote,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		let commit_page = page + 1;
-		let mut url = format!(
-			"{}/projects/{}/repository/commits?per_page={MAX_PAGE_SIZE}&\
-			 page={commit_page}",
-			api_url, id
-		);
+    fn url(id: i64, api_url: &str, _remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
+        let commit_page = page + 1;
+        let mut url = format!(
+            "{}/projects/{}/repository/commits?per_page={MAX_PAGE_SIZE}&page={commit_page}",
+            api_url, id
+        );
 
-		if let Some(ref_name) = ref_name {
-			url.push_str(&format!("&ref_name={}", ref_name));
-		}
+        if let Some(ref_name) = ref_name {
+            url.push_str(&format!("&ref_name={}", ref_name));
+        }
 
-		url
-	}
+        url
+    }
 
-	fn buffer_size() -> usize {
-		10
-	}
+    fn buffer_size() -> usize {
+        10
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// Representation of a single pull request.
@@ -144,227 +136,209 @@ impl RemoteEntry for GitLabCommit {
 /// <https://docs.gitlab.com/ee/api/merge_requests.html>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GitLabMergeRequest {
-	/// Id
-	pub id:                i64,
-	/// Iid
-	pub iid:               i64,
-	/// Project Id
-	pub project_id:        i64,
-	/// Title
-	pub title:             String,
-	/// Description
-	pub description:       String,
-	/// State
-	pub state:             String,
-	/// Created At
-	pub created_at:        String,
-	/// Author
-	pub author:            GitLabUser,
-	/// Commit Sha
-	pub sha:               String,
-	/// Merge Commit Sha
-	pub merge_commit_sha:  Option<String>,
-	/// Squash Commit Sha
-	pub squash_commit_sha: Option<String>,
-	/// Web Url
-	pub web_url:           String,
-	/// Labels
-	pub labels:            Vec<String>,
+    /// Id
+    pub id: i64,
+    /// Iid
+    pub iid: i64,
+    /// Project Id
+    pub project_id: i64,
+    /// Title
+    pub title: String,
+    /// Description
+    pub description: String,
+    /// State
+    pub state: String,
+    /// Created At
+    pub created_at: String,
+    /// Author
+    pub author: GitLabUser,
+    /// Commit Sha
+    pub sha: String,
+    /// Merge Commit Sha
+    pub merge_commit_sha: Option<String>,
+    /// Squash Commit Sha
+    pub squash_commit_sha: Option<String>,
+    /// Web Url
+    pub web_url: String,
+    /// Labels
+    pub labels: Vec<String>,
 }
 
 impl RemotePullRequest for GitLabMergeRequest {
-	fn number(&self) -> i64 {
-		self.iid
-	}
+    fn number(&self) -> i64 {
+        self.iid
+    }
 
-	fn title(&self) -> Option<String> {
-		Some(self.title.clone())
-	}
+    fn title(&self) -> Option<String> {
+        Some(self.title.clone())
+    }
 
-	fn labels(&self) -> Vec<String> {
-		self.labels.clone()
-	}
+    fn labels(&self) -> Vec<String> {
+        self.labels.clone()
+    }
 
-	fn merge_commit(&self) -> Option<String> {
-		self.merge_commit_sha
-			.clone()
-			.or(self.squash_commit_sha.clone())
-			.or(Some(self.sha.clone()))
-	}
+    fn merge_commit(&self) -> Option<String> {
+        self.merge_commit_sha
+            .clone()
+            .or(self.squash_commit_sha.clone())
+            .or(Some(self.sha.clone()))
+    }
 }
 
 impl RemoteEntry for GitLabMergeRequest {
-	fn url(
-		id: i64,
-		api_url: &str,
-		_remote: &Remote,
-		_ref_name: Option<&str>,
-		page: i32,
-	) -> String {
-		format!(
-			"{}/projects/{}/merge_requests?per_page={MAX_PAGE_SIZE}&page={page}&\
-			 state=merged",
-			api_url, id
-		)
-	}
+    fn url(id: i64, api_url: &str, _remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
+        format!(
+            "{}/projects/{}/merge_requests?per_page={MAX_PAGE_SIZE}&page={page}&state=merged",
+            api_url, id
+        )
+    }
 
-	fn buffer_size() -> usize {
-		5
-	}
+    fn buffer_size() -> usize {
+        5
+    }
 
-	fn early_exit(&self) -> bool {
-		false
-	}
+    fn early_exit(&self) -> bool {
+        false
+    }
 }
 
 /// Representation of a GitLab User.
 #[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub struct GitLabUser {
-	/// Id
-	pub id:         i64,
-	/// Name
-	pub name:       String,
-	/// Username
-	pub username:   String,
-	/// State of the User
-	pub state:      String,
-	/// Url for avatar
-	pub avatar_url: Option<String>,
-	/// Web Url
-	pub web_url:    String,
+    /// Id
+    pub id: i64,
+    /// Name
+    pub name: String,
+    /// Username
+    pub username: String,
+    /// State of the User
+    pub state: String,
+    /// Url for avatar
+    pub avatar_url: Option<String>,
+    /// Web Url
+    pub web_url: String,
 }
 
 /// Representation of a GitLab Reference.
 #[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub struct GitLabReference {
-	/// Short id
-	pub short:    String,
-	/// Relative Link
-	pub relative: String,
-	/// Full Link
-	pub full:     String,
+    /// Short id
+    pub short: String,
+    /// Relative Link
+    pub relative: String,
+    /// Full Link
+    pub full: String,
 }
 
 /// HTTP client for handling GitLab REST API requests.
 #[derive(Debug, Clone)]
 pub struct GitLabClient {
-	/// Remote.
-	remote: Remote,
-	/// HTTP client.
-	client: ClientWithMiddleware,
+    /// Remote.
+    remote: Remote,
+    /// HTTP client.
+    client: ClientWithMiddleware,
 }
 
 /// Constructs a GitLab client from the remote configuration.
 impl TryFrom<Remote> for GitLabClient {
-	type Error = Error;
-	fn try_from(remote: Remote) -> Result<Self> {
-		Ok(Self {
-			client: remote.create_client("application/json")?,
-			remote,
-		})
-	}
+    type Error = Error;
+    fn try_from(remote: Remote) -> Result<Self> {
+        Ok(Self {
+            client: remote.create_client("application/json")?,
+            remote,
+        })
+    }
 }
 
 impl RemoteClient for GitLabClient {
-	const API_URL: &'static str = "https://gitlab.com/api/v4";
-	const API_URL_ENV: &'static str = "GITLAB_API_URL";
+    const API_URL: &'static str = "https://gitlab.com/api/v4";
+    const API_URL_ENV: &'static str = "GITLAB_API_URL";
 
-	fn remote(&self) -> Remote {
-		self.remote.clone()
-	}
+    fn remote(&self) -> Remote {
+        self.remote.clone()
+    }
 
-	fn client(&self) -> ClientWithMiddleware {
-		self.client.clone()
-	}
+    fn client(&self) -> ClientWithMiddleware {
+        self.client.clone()
+    }
 }
 
 impl GitLabClient {
-	/// Fetches the GitLab API and returns the pull requests.
-	pub async fn get_project(
-		&self,
-		ref_name: Option<&str>,
-	) -> Result<GitLabProject> {
-		self.get_entry::<GitLabProject>(0, ref_name, 1).await
-	}
+    /// Fetches the GitLab API and returns the pull requests.
+    pub async fn get_project(&self, ref_name: Option<&str>) -> Result<GitLabProject> {
+        self.get_entry::<GitLabProject>(0, ref_name, 1).await
+    }
 
-	/// Fetches the GitLab API and returns the commits.
-	pub async fn get_commits(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemoteCommit>>> {
-		Ok(self
-			.fetch::<GitLabCommit>(project_id, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-			.collect())
-	}
+    /// Fetches the GitLab API and returns the commits.
+    pub async fn get_commits(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        Ok(self
+            .fetch::<GitLabCommit>(project_id, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .collect())
+    }
 
-	/// Fetches the GitLab API and returns the pull requests.
-	pub async fn get_merge_requests(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-	) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-		Ok(self
-			.fetch::<GitLabMergeRequest>(project_id, ref_name)
-			.await?
-			.into_iter()
-			.map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-			.collect())
-	}
+    /// Fetches the GitLab API and returns the pull requests.
+    pub async fn get_merge_requests(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
+        Ok(self
+            .fetch::<GitLabMergeRequest>(project_id, ref_name)
+            .await?
+            .into_iter()
+            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
+            .collect())
+    }
 }
 #[cfg(test)]
 mod test {
-	use pretty_assertions::assert_eq;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn gitlab_remote_encodes_owner() {
-		let remote = Remote::new("abc/def", "xyz1");
-		assert_eq!(
-			"https://gitlab.test.com/api/v4/projects/abc%2Fdef%2Fxyz1",
-			GitLabProject::url(
-				1,
-				"https://gitlab.test.com/api/v4",
-				&remote,
-				None,
-				0
-			)
-		);
-	}
+    #[test]
+    fn gitlab_remote_encodes_owner() {
+        let remote = Remote::new("abc/def", "xyz1");
+        assert_eq!(
+            "https://gitlab.test.com/api/v4/projects/abc%2Fdef%2Fxyz1",
+            GitLabProject::url(1, "https://gitlab.test.com/api/v4", &remote, None, 0)
+        );
+    }
 
-	#[test]
-	fn timestamp() {
-		let remote_commit = GitLabCommit {
-			id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-			author_name: String::from("orhun"),
-			committed_date: String::from("2021-07-18T15:14:39+03:00"),
-			..Default::default()
-		};
+    #[test]
+    fn timestamp() {
+        let remote_commit = GitLabCommit {
+            id: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+            author_name: String::from("orhun"),
+            committed_date: String::from("2021-07-18T15:14:39+03:00"),
+            ..Default::default()
+        };
 
-		assert_eq!(Some(1626610479), remote_commit.timestamp());
-	}
+        assert_eq!(Some(1626610479), remote_commit.timestamp());
+    }
 
-	#[test]
-	fn merge_request_no_merge_commit() {
-		let mr = GitLabMergeRequest {
-			sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
-			..Default::default()
-		};
-		assert!(mr.merge_commit().is_some());
-	}
+    #[test]
+    fn merge_request_no_merge_commit() {
+        let mr = GitLabMergeRequest {
+            sha: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
+            ..Default::default()
+        };
+        assert!(mr.merge_commit().is_some());
+    }
 
-	#[test]
-	fn merge_request_squash_commit() {
-		let mr = GitLabMergeRequest {
-			squash_commit_sha: Some(String::from(
-				"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
-			)),
-			..Default::default()
-		};
-		assert!(mr.merge_commit().is_some());
-	}
+    #[test]
+    fn merge_request_squash_commit() {
+        let mr = GitLabMergeRequest {
+            squash_commit_sha: Some(String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071")),
+            ..Default::default()
+        };
+        assert!(mr.merge_commit().is_some());
+    }
 }

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -20,9 +20,7 @@ use std::time::Duration;
 
 use dyn_clone::DynClone;
 use futures::{StreamExt, future, stream};
-use http_cache_reqwest::{
-	CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions,
-};
+use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
@@ -39,8 +37,7 @@ use crate::error::{Error, Result};
 /// User agent for interacting with the GitHub API.
 ///
 /// This is needed since GitHub API does not accept empty user agent.
-pub(crate) const USER_AGENT: &str =
-	concat!(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+pub(crate) const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
 /// Request timeout value in seconds.
 pub(crate) const REQUEST_TIMEOUT: u64 = 30;
@@ -53,337 +50,328 @@ pub(crate) const MAX_PAGE_SIZE: usize = 100;
 
 /// Trait for handling the different entries returned from the remote.
 pub trait RemoteEntry {
-	/// Returns the API URL for fetching the entries at the specified page.
-	fn url(
-		project_id: i64,
-		api_url: &str,
-		remote: &Remote,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> String;
-	/// Returns the request buffer size.
-	fn buffer_size() -> usize;
-	/// Whether if exit early.
-	fn early_exit(&self) -> bool;
+    /// Returns the API URL for fetching the entries at the specified page.
+    fn url(
+        project_id: i64,
+        api_url: &str,
+        remote: &Remote,
+        ref_name: Option<&str>,
+        page: i32,
+    ) -> String;
+    /// Returns the request buffer size.
+    fn buffer_size() -> usize;
+    /// Whether if exit early.
+    fn early_exit(&self) -> bool;
 }
 
 /// Trait for handling remote commits.
 pub trait RemoteCommit: DynClone {
-	/// Commit SHA.
-	fn id(&self) -> String;
-	/// Commit author.
-	fn username(&self) -> Option<String>;
-	/// Timestamp.
-	fn timestamp(&self) -> Option<i64>;
-	/// Convert date in RFC3339 format to unix timestamp
-	fn convert_to_unix_timestamp(&self, date: &str) -> i64 {
-		OffsetDateTime::parse(date, &Rfc3339)
-			.expect("failed to parse date")
-			.unix_timestamp()
-	}
+    /// Commit SHA.
+    fn id(&self) -> String;
+    /// Commit author.
+    fn username(&self) -> Option<String>;
+    /// Timestamp.
+    fn timestamp(&self) -> Option<i64>;
+    /// Convert date in RFC3339 format to unix timestamp
+    fn convert_to_unix_timestamp(&self, date: &str) -> i64 {
+        OffsetDateTime::parse(date, &Rfc3339)
+            .expect("failed to parse date")
+            .unix_timestamp()
+    }
 }
 
 dyn_clone::clone_trait_object!(RemoteCommit);
 
 /// Trait for handling remote pull requests.
 pub trait RemotePullRequest: DynClone {
-	/// Number.
-	fn number(&self) -> i64;
-	/// Title.
-	fn title(&self) -> Option<String>;
-	/// Labels of the pull request.
-	fn labels(&self) -> Vec<String>;
-	/// Merge commit SHA.
-	fn merge_commit(&self) -> Option<String>;
+    /// Number.
+    fn number(&self) -> i64;
+    /// Title.
+    fn title(&self) -> Option<String>;
+    /// Labels of the pull request.
+    fn labels(&self) -> Vec<String>;
+    /// Merge commit SHA.
+    fn merge_commit(&self) -> Option<String>;
 }
 
 dyn_clone::clone_trait_object!(RemotePullRequest);
 
 /// Result of a remote metadata.
-pub type RemoteMetadata =
-	(Vec<Box<dyn RemoteCommit>>, Vec<Box<dyn RemotePullRequest>>);
+pub type RemoteMetadata = (Vec<Box<dyn RemoteCommit>>, Vec<Box<dyn RemotePullRequest>>);
 
 /// Metadata of a remote release.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct RemoteReleaseMetadata {
-	/// Contributors.
-	pub contributors: Vec<RemoteContributor>,
+    /// Contributors.
+    pub contributors: Vec<RemoteContributor>,
 }
 
 impl Remote {
-	/// Creates a HTTP client for the remote.
-	fn create_client(&self, accept_header: &str) -> Result<ClientWithMiddleware> {
-		if !self.is_set() {
-			return Err(Error::RemoteNotSetError);
-		}
-		let mut headers = HeaderMap::new();
-		headers.insert(
-			reqwest::header::ACCEPT,
-			HeaderValue::from_str(accept_header)?,
-		);
-		if let Some(token) = &self.token {
-			headers.insert(
-				reqwest::header::AUTHORIZATION,
-				format!("Bearer {}", token.expose_secret()).parse()?,
-			);
-		}
-		headers.insert(reqwest::header::USER_AGENT, USER_AGENT.parse()?);
-		let client_builder = Client::builder()
-			.timeout(Duration::from_secs(REQUEST_TIMEOUT))
-			.tcp_keepalive(Duration::from_secs(REQUEST_KEEP_ALIVE))
-			.default_headers(headers)
-			.tls_built_in_root_certs(false);
-		let client_builder = if self.native_tls.unwrap_or(false) {
-			client_builder.tls_built_in_native_certs(true)
-		} else {
-			client_builder.tls_built_in_webpki_certs(true)
-		};
-		let client = client_builder.build()?;
-		let client = ClientBuilder::new(client)
-			.with(Cache(HttpCache {
-				mode:    CacheMode::Default,
-				manager: CACacheManager {
-					path: dirs::cache_dir()
-						.ok_or_else(|| {
-							Error::DirsError(String::from(
-								"failed to find the user's cache directory",
-							))
-						})?
-						.join(env!("CARGO_PKG_NAME")),
-				},
-				options: HttpCacheOptions::default(),
-			}))
-			.build();
-		Ok(client)
-	}
+    /// Creates a HTTP client for the remote.
+    fn create_client(&self, accept_header: &str) -> Result<ClientWithMiddleware> {
+        if !self.is_set() {
+            return Err(Error::RemoteNotSetError);
+        }
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            reqwest::header::ACCEPT,
+            HeaderValue::from_str(accept_header)?,
+        );
+        if let Some(token) = &self.token {
+            headers.insert(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", token.expose_secret()).parse()?,
+            );
+        }
+        headers.insert(reqwest::header::USER_AGENT, USER_AGENT.parse()?);
+        let client_builder = Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT))
+            .tcp_keepalive(Duration::from_secs(REQUEST_KEEP_ALIVE))
+            .default_headers(headers)
+            .tls_built_in_root_certs(false);
+        let client_builder = if self.native_tls.unwrap_or(false) {
+            client_builder.tls_built_in_native_certs(true)
+        } else {
+            client_builder.tls_built_in_webpki_certs(true)
+        };
+        let client = client_builder.build()?;
+        let client = ClientBuilder::new(client)
+            .with(Cache(HttpCache {
+                mode: CacheMode::Default,
+                manager: CACacheManager {
+                    path: dirs::cache_dir()
+                        .ok_or_else(|| {
+                            Error::DirsError(String::from(
+                                "failed to find the user's cache directory",
+                            ))
+                        })?
+                        .join(env!("CARGO_PKG_NAME")),
+                },
+                options: HttpCacheOptions::default(),
+            }))
+            .build();
+        Ok(client)
+    }
 }
 
 /// Trait for handling the API connection and fetching.
 pub trait RemoteClient {
-	/// API URL for a particular client
-	const API_URL: &'static str;
+    /// API URL for a particular client
+    const API_URL: &'static str;
 
-	/// Name of the environment variable used to set the API URL to a
-	/// self-hosted instance (if applicable).
-	const API_URL_ENV: &'static str;
+    /// Name of the environment variable used to set the API URL to a
+    /// self-hosted instance (if applicable).
+    const API_URL_ENV: &'static str;
 
-	/// Returns the API url.
-	fn api_url(&self) -> String {
-		env::var(Self::API_URL_ENV)
-			.ok()
-			.or(self.remote().api_url)
-			.unwrap_or_else(|| Self::API_URL.to_string())
-	}
+    /// Returns the API url.
+    fn api_url(&self) -> String {
+        env::var(Self::API_URL_ENV)
+            .ok()
+            .or(self.remote().api_url)
+            .unwrap_or_else(|| Self::API_URL.to_string())
+    }
 
-	/// Returns the remote repository information.
-	fn remote(&self) -> Remote;
+    /// Returns the remote repository information.
+    fn remote(&self) -> Remote;
 
-	/// Returns the HTTP client for making requests.
-	fn client(&self) -> ClientWithMiddleware;
+    /// Returns the HTTP client for making requests.
+    fn client(&self) -> ClientWithMiddleware;
 
-	/// Returns true if the client should early exit.
-	fn early_exit<T: DeserializeOwned + RemoteEntry>(&self, page: &T) -> bool {
-		page.early_exit()
-	}
+    /// Returns true if the client should early exit.
+    fn early_exit<T: DeserializeOwned + RemoteEntry>(&self, page: &T) -> bool {
+        page.early_exit()
+    }
 
-	/// Retrieves a single object.
-	async fn get_entry<T: DeserializeOwned + RemoteEntry>(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> Result<T> {
-		let url =
-			T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
-		debug!("Sending request to: {url}");
-		let response = self.client().get(&url).send().await?;
-		let response_text = if response.status().is_success() {
-			let text = response.text().await?;
-			trace!("Response: {:?}", text);
-			text
-		} else {
-			let text = response.text().await?;
-			error!("Request error: {}", text);
-			text
-		};
-		Ok(serde_json::from_str::<T>(&response_text)?)
-	}
+    /// Retrieves a single object.
+    async fn get_entry<T: DeserializeOwned + RemoteEntry>(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+        page: i32,
+    ) -> Result<T> {
+        let url = T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
+        debug!("Sending request to: {url}");
+        let response = self.client().get(&url).send().await?;
+        let response_text = if response.status().is_success() {
+            let text = response.text().await?;
+            trace!("Response: {:?}", text);
+            text
+        } else {
+            let text = response.text().await?;
+            error!("Request error: {}", text);
+            text
+        };
+        Ok(serde_json::from_str::<T>(&response_text)?)
+    }
 
-	/// Retrieves a single page of entries.
-	async fn get_entries_with_page<T: DeserializeOwned + RemoteEntry>(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-		page: i32,
-	) -> Result<Vec<T>> {
-		let url =
-			T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
-		debug!("Sending request to: {url}");
-		let response = self.client().get(&url).send().await?;
-		let response_text = if response.status().is_success() {
-			let text = response.text().await?;
-			trace!("Response: {:?}", text);
-			text
-		} else {
-			let text = response.text().await?;
-			error!("Request error: {}", text);
-			text
-		};
-		let response = serde_json::from_str::<Vec<T>>(&response_text)?;
-		if response.is_empty() {
-			Err(Error::PaginationError(String::from("end of entries")))
-		} else {
-			Ok(response)
-		}
-	}
+    /// Retrieves a single page of entries.
+    async fn get_entries_with_page<T: DeserializeOwned + RemoteEntry>(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+        page: i32,
+    ) -> Result<Vec<T>> {
+        let url = T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
+        debug!("Sending request to: {url}");
+        let response = self.client().get(&url).send().await?;
+        let response_text = if response.status().is_success() {
+            let text = response.text().await?;
+            trace!("Response: {:?}", text);
+            text
+        } else {
+            let text = response.text().await?;
+            error!("Request error: {}", text);
+            text
+        };
+        let response = serde_json::from_str::<Vec<T>>(&response_text)?;
+        if response.is_empty() {
+            Err(Error::PaginationError(String::from("end of entries")))
+        } else {
+            Ok(response)
+        }
+    }
 
-	/// Fetches the remote API and returns the given entry.
-	///
-	/// See `fetch_with_early_exit` for the early exit version of this method.
-	async fn fetch<T: DeserializeOwned + RemoteEntry>(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-	) -> Result<Vec<T>> {
-		let entries: Vec<Vec<T>> = stream::iter(0..)
-			.map(|i| self.get_entries_with_page(project_id, ref_name, i))
-			.buffered(T::buffer_size())
-			.take_while(|page| {
-				if let Err(e) = page {
-					debug!("Error while fetching page: {:?}", e);
-				}
-				future::ready(page.is_ok())
-			})
-			.map(|page| match page {
-				Ok(v) => v,
-				Err(ref e) => {
-					log::error!("{:#?}", e);
-					page.expect("failed to fetch page: {}")
-				}
-			})
-			.collect()
-			.await;
-		Ok(entries.into_iter().flatten().collect())
-	}
+    /// Fetches the remote API and returns the given entry.
+    ///
+    /// See `fetch_with_early_exit` for the early exit version of this method.
+    async fn fetch<T: DeserializeOwned + RemoteEntry>(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<T>> {
+        let entries: Vec<Vec<T>> = stream::iter(0..)
+            .map(|i| self.get_entries_with_page(project_id, ref_name, i))
+            .buffered(T::buffer_size())
+            .take_while(|page| {
+                if let Err(e) = page {
+                    debug!("Error while fetching page: {:?}", e);
+                }
+                future::ready(page.is_ok())
+            })
+            .map(|page| match page {
+                Ok(v) => v,
+                Err(ref e) => {
+                    log::error!("{:#?}", e);
+                    page.expect("failed to fetch page: {}")
+                }
+            })
+            .collect()
+            .await;
+        Ok(entries.into_iter().flatten().collect())
+    }
 
-	/// Fetches the remote API and returns the given entry.
-	///
-	/// Early exits based on the response.
-	async fn fetch_with_early_exit<T: DeserializeOwned + RemoteEntry>(
-		&self,
-		project_id: i64,
-		ref_name: Option<&str>,
-	) -> Result<Vec<T>> {
-		let entries: Vec<T> = stream::iter(0..)
-			.map(|i| self.get_entry::<T>(project_id, ref_name, i))
-			.buffered(T::buffer_size())
-			.take_while(|page| {
-				let status = match page {
-					Ok(v) => !self.early_exit(v),
-					Err(e) => {
-						debug!("Error while fetching page: {:?}", e);
-						true
-					}
-				};
-				future::ready(status && page.is_ok())
-			})
-			.map(|page| match page {
-				Ok(v) => v,
-				Err(ref e) => {
-					log::error!("{:#?}", e);
-					page.expect("failed to fetch page: {}")
-				}
-			})
-			.collect()
-			.await;
-		Ok(entries)
-	}
+    /// Fetches the remote API and returns the given entry.
+    ///
+    /// Early exits based on the response.
+    async fn fetch_with_early_exit<T: DeserializeOwned + RemoteEntry>(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+    ) -> Result<Vec<T>> {
+        let entries: Vec<T> = stream::iter(0..)
+            .map(|i| self.get_entry::<T>(project_id, ref_name, i))
+            .buffered(T::buffer_size())
+            .take_while(|page| {
+                let status = match page {
+                    Ok(v) => !self.early_exit(v),
+                    Err(e) => {
+                        debug!("Error while fetching page: {:?}", e);
+                        true
+                    }
+                };
+                future::ready(status && page.is_ok())
+            })
+            .map(|page| match page {
+                Ok(v) => v,
+                Err(ref e) => {
+                    log::error!("{:#?}", e);
+                    page.expect("failed to fetch page: {}")
+                }
+            })
+            .collect()
+            .await;
+        Ok(entries)
+    }
 }
 
 /// Generates a function for updating the release metadata for a remote.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! update_release_metadata {
-	($remote: ident, $fn: ident) => {
-		impl<'a> Release<'a> {
-			/// Updates the remote metadata that is contained in the release.
-			///
-			/// This function takes two arguments:
-			///
-			/// - Commits: needed for associating the Git user with the GitHub
-			///   username.
-			/// - Pull requests: needed for generating the contributor list for the
-			///   release.
-			#[allow(deprecated)]
-			pub fn $fn(
-				&mut self,
-				mut commits: Vec<Box<dyn RemoteCommit>>,
-				pull_requests: Vec<Box<dyn RemotePullRequest>>,
-			) -> Result<()> {
-				let mut contributors: Vec<RemoteContributor> = Vec::new();
-				let mut release_commit_timestamp: Option<i64> = None;
-				// retain the commits that are not a part of this release for later
-				// on checking the first contributors.
-				commits.retain(|v| {
-					if let Some(commit) =
-						self.commits.iter_mut().find(|commit| commit.id == v.id())
-					{
-						let sha_short =
-							Some(v.id().clone().chars().take(12).collect());
-						let pull_request = pull_requests.iter().find(|pr| {
-							pr.merge_commit() == Some(v.id().clone()) ||
-								pr.merge_commit() == sha_short
-						});
-						commit.$remote.username = v.username();
-						commit.$remote.pr_number = pull_request.map(|v| v.number());
-						commit.$remote.pr_title =
-							pull_request.and_then(|v| v.title().clone());
-						commit.$remote.pr_labels = pull_request
-							.map(|v| v.labels().clone())
-							.unwrap_or_default();
-						if !contributors
-							.iter()
-							.any(|v| commit.$remote.username == v.username)
-						{
-							contributors.push(RemoteContributor {
-								username:      commit.$remote.username.clone(),
-								pr_title:      commit.$remote.pr_title.clone(),
-								pr_number:     commit.$remote.pr_number,
-								pr_labels:     commit.$remote.pr_labels.clone(),
-								is_first_time: false,
-							});
-						}
-						commit.remote = Some(commit.$remote.clone());
-						// if remote commit is the release commit store timestamp for
-						// use in calculation of first time
-						if Some(v.id().clone()) == self.commit_id {
-							release_commit_timestamp = v.timestamp().clone();
-						}
-						false
-					} else {
-						true
-					}
-				});
-				// mark contributors as first-time
-				self.$remote.contributors = contributors
-					.into_iter()
-					.map(|mut v| {
-						v.is_first_time = !commits
-							.iter()
-							.filter(|commit| {
-								// if current release is unreleased no need to filter
-								// commits or filter commits that are from
-								// newer releases
-								self.timestamp == None ||
-									commit.timestamp() < release_commit_timestamp
-							})
-							.map(|v| v.username())
-							.any(|login| login == v.username);
-						v
-					})
-					.collect();
-				Ok(())
-			}
-		}
-	};
+    ($remote: ident, $fn: ident) => {
+        impl<'a> Release<'a> {
+            /// Updates the remote metadata that is contained in the release.
+            ///
+            /// This function takes two arguments:
+            ///
+            /// - Commits: needed for associating the Git user with the GitHub username.
+            /// - Pull requests: needed for generating the contributor list for the release.
+            #[allow(deprecated)]
+            pub fn $fn(
+                &mut self,
+                mut commits: Vec<Box<dyn RemoteCommit>>,
+                pull_requests: Vec<Box<dyn RemotePullRequest>>,
+            ) -> Result<()> {
+                let mut contributors: Vec<RemoteContributor> = Vec::new();
+                let mut release_commit_timestamp: Option<i64> = None;
+                // retain the commits that are not a part of this release for later
+                // on checking the first contributors.
+                commits.retain(|v| {
+                    if let Some(commit) = self.commits.iter_mut().find(|commit| commit.id == v.id())
+                    {
+                        let sha_short = Some(v.id().clone().chars().take(12).collect());
+                        let pull_request = pull_requests.iter().find(|pr| {
+                            pr.merge_commit() == Some(v.id().clone()) ||
+                                pr.merge_commit() == sha_short
+                        });
+                        commit.$remote.username = v.username();
+                        commit.$remote.pr_number = pull_request.map(|v| v.number());
+                        commit.$remote.pr_title = pull_request.and_then(|v| v.title().clone());
+                        commit.$remote.pr_labels =
+                            pull_request.map(|v| v.labels().clone()).unwrap_or_default();
+                        if !contributors
+                            .iter()
+                            .any(|v| commit.$remote.username == v.username)
+                        {
+                            contributors.push(RemoteContributor {
+                                username: commit.$remote.username.clone(),
+                                pr_title: commit.$remote.pr_title.clone(),
+                                pr_number: commit.$remote.pr_number,
+                                pr_labels: commit.$remote.pr_labels.clone(),
+                                is_first_time: false,
+                            });
+                        }
+                        commit.remote = Some(commit.$remote.clone());
+                        // if remote commit is the release commit store timestamp for
+                        // use in calculation of first time
+                        if Some(v.id().clone()) == self.commit_id {
+                            release_commit_timestamp = v.timestamp().clone();
+                        }
+                        false
+                    } else {
+                        true
+                    }
+                });
+                // mark contributors as first-time
+                self.$remote.contributors = contributors
+                    .into_iter()
+                    .map(|mut v| {
+                        v.is_first_time = !commits
+                            .iter()
+                            .filter(|commit| {
+                                // if current release is unreleased no need to filter
+                                // commits or filter commits that are from
+                                // newer releases
+                                self.timestamp == None ||
+                                    commit.timestamp() < release_commit_timestamp
+                            })
+                            .map(|v| v.username())
+                            .any(|login| login == v.username);
+                        v
+                    })
+                    .collect();
+                Ok(())
+            }
+        }
+    };
 }

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 
 use git2::{
-	BranchType, Commit, DescribeOptions, Oid, Repository as GitRepository, Sort,
-	TreeWalkMode, Worktree,
+    BranchType, Commit, DescribeOptions, Oid, Repository as GitRepository, Sort, TreeWalkMode,
+    Worktree,
 };
 use glob::Pattern;
 use indexmap::IndexMap;
@@ -17,8 +17,8 @@ use crate::tag::Tag;
 
 /// Regex for replacing the signature part of a tag message.
 static TAG_SIGNATURE_REGEX: Lazy<Regex> = lazy_regex!(
-	// https://git-scm.com/docs/gitformat-signature#_description
-	r"(?s)-----BEGIN (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----(.*?)-----END (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----"
+    // https://git-scm.com/docs/gitformat-signature#_description
+    r"(?s)-----BEGIN (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----(.*?)-----END (PGP|SSH|SIGNED) (SIGNATURE|MESSAGE)-----"
 );
 
 /// Name of the cache file for changed files.
@@ -28,525 +28,496 @@ const CHANGED_FILES_CACHE: &str = "changed_files_cache";
 ///
 /// [`Repository`]: GitRepository
 pub struct Repository {
-	inner:                    GitRepository,
-	/// Repository path.
-	path:                     PathBuf,
-	/// Cache path for the changed files of the commits.
-	changed_files_cache_path: PathBuf,
+    inner: GitRepository,
+    /// Repository path.
+    path: PathBuf,
+    /// Cache path for the changed files of the commits.
+    changed_files_cache_path: PathBuf,
 }
 
 /// Range of commits in a submodule.
 pub struct SubmoduleRange {
-	/// Repository object to which this range belongs.
-	pub repository: Repository,
-	/// Commit range in "<first_submodule_commit>..<last_submodule_commit>" or
-	/// "<last_submodule_commit>" format.
-	pub range:      String,
+    /// Repository object to which this range belongs.
+    pub repository: Repository,
+    /// Commit range in "<first_submodule_commit>..<last_submodule_commit>" or
+    /// "<last_submodule_commit>" format.
+    pub range: String,
 }
 
 impl Repository {
-	/// Initializes (opens) the repository.
-	pub fn init(path: PathBuf) -> Result<Self> {
-		if path.exists() {
-			let inner = GitRepository::discover(&path).or_else(|err| {
-				let jujutsu_path =
-					path.join(".jj").join("repo").join("store").join("git");
-				if jujutsu_path.exists() {
-					GitRepository::open_bare(&jujutsu_path)
-				} else {
-					Err(err)
-				}
-			})?;
-			let changed_files_cache_path = inner
-				.path()
-				.join(env!("CARGO_PKG_NAME"))
-				.join(CHANGED_FILES_CACHE);
-			Ok(Self {
-				inner,
-				path,
-				changed_files_cache_path,
-			})
-		} else {
-			Err(Error::IoError(io::Error::new(
-				io::ErrorKind::NotFound,
-				"repository path not found",
-			)))
-		}
-	}
+    /// Initializes (opens) the repository.
+    pub fn init(path: PathBuf) -> Result<Self> {
+        if path.exists() {
+            let inner = GitRepository::discover(&path).or_else(|err| {
+                let jujutsu_path = path.join(".jj").join("repo").join("store").join("git");
+                if jujutsu_path.exists() {
+                    GitRepository::open_bare(&jujutsu_path)
+                } else {
+                    Err(err)
+                }
+            })?;
+            let changed_files_cache_path = inner
+                .path()
+                .join(env!("CARGO_PKG_NAME"))
+                .join(CHANGED_FILES_CACHE);
+            Ok(Self {
+                inner,
+                path,
+                changed_files_cache_path,
+            })
+        } else {
+            Err(Error::IoError(io::Error::new(
+                io::ErrorKind::NotFound,
+                "repository path not found",
+            )))
+        }
+    }
 
-	/// Returns the path of the repository.
-	pub fn root_path(&self) -> Result<PathBuf> {
-		let mut path = if self.inner.is_worktree() {
-			let worktree = Worktree::open_from_repository(&self.inner)?;
-			worktree.path().to_path_buf()
-		} else {
-			self.inner.path().to_path_buf()
-		};
-		if path.ends_with(".git") {
-			path.pop();
-		}
-		Ok(path)
-	}
+    /// Returns the path of the repository.
+    pub fn root_path(&self) -> Result<PathBuf> {
+        let mut path = if self.inner.is_worktree() {
+            let worktree = Worktree::open_from_repository(&self.inner)?;
+            worktree.path().to_path_buf()
+        } else {
+            self.inner.path().to_path_buf()
+        };
+        if path.ends_with(".git") {
+            path.pop();
+        }
+        Ok(path)
+    }
 
-	/// Returns the initial path of the repository.
-	///
-	/// In case of a submodule this is the relative path to the toplevel
-	/// repository.
-	pub fn path(&self) -> &PathBuf {
-		&self.path
-	}
+    /// Returns the initial path of the repository.
+    ///
+    /// In case of a submodule this is the relative path to the toplevel
+    /// repository.
+    pub fn path(&self) -> &PathBuf {
+        &self.path
+    }
 
-	/// Sets the range for the commit search.
-	///
-	/// When a single SHA is provided as the range, start from the
-	/// root.
-	fn set_commit_range(
-		revwalk: &mut git2::Revwalk<'_>,
-		range: Option<&str>,
-	) -> StdResult<(), git2::Error> {
-		if let Some(range) = range {
-			if range.contains("..") {
-				revwalk.push_range(range)?;
-			} else {
-				revwalk.push(Oid::from_str(range)?)?;
-			}
-		} else {
-			revwalk.push_head()?;
-		}
-		Ok(())
-	}
+    /// Sets the range for the commit search.
+    ///
+    /// When a single SHA is provided as the range, start from the
+    /// root.
+    fn set_commit_range(
+        revwalk: &mut git2::Revwalk<'_>,
+        range: Option<&str>,
+    ) -> StdResult<(), git2::Error> {
+        if let Some(range) = range {
+            if range.contains("..") {
+                revwalk.push_range(range)?;
+            } else {
+                revwalk.push(Oid::from_str(range)?)?;
+            }
+        } else {
+            revwalk.push_head()?;
+        }
+        Ok(())
+    }
 
-	/// Parses and returns the commits.
-	///
-	/// Sorts the commits by their time.
-	pub fn commits(
-		&self,
-		range: Option<&str>,
-		include_path: Option<Vec<Pattern>>,
-		exclude_path: Option<Vec<Pattern>>,
-		topo_order_commits: bool,
-	) -> Result<Vec<Commit<'_>>> {
-		let mut revwalk = self.inner.revwalk()?;
-		if topo_order_commits {
-			revwalk.set_sorting(Sort::TOPOLOGICAL)?;
-		} else {
-			revwalk.set_sorting(Sort::TIME)?;
-		}
+    /// Parses and returns the commits.
+    ///
+    /// Sorts the commits by their time.
+    pub fn commits(
+        &self,
+        range: Option<&str>,
+        include_path: Option<Vec<Pattern>>,
+        exclude_path: Option<Vec<Pattern>>,
+        topo_order_commits: bool,
+    ) -> Result<Vec<Commit<'_>>> {
+        let mut revwalk = self.inner.revwalk()?;
+        if topo_order_commits {
+            revwalk.set_sorting(Sort::TOPOLOGICAL)?;
+        } else {
+            revwalk.set_sorting(Sort::TIME)?;
+        }
 
-		Self::set_commit_range(&mut revwalk, range).map_err(|e| {
-			Error::SetCommitRangeError(
-				range.map(String::from).unwrap_or_else(|| "?".to_string()),
-				e,
-			)
-		})?;
-		let mut commits: Vec<Commit> = revwalk
-			.filter_map(|id| id.ok())
-			.filter_map(|id| self.inner.find_commit(id).ok())
-			.collect();
-		if include_path.is_some() || exclude_path.is_some() {
-			let include_patterns = include_path.map(|patterns| {
-				patterns.into_iter().map(Self::normalize_pattern).collect()
-			});
-			let exclude_patterns = exclude_path.map(|patterns| {
-				patterns.into_iter().map(Self::normalize_pattern).collect()
-			});
-			commits.retain(|commit| {
-				self.should_retain_commit(
-					commit,
-					&include_patterns,
-					&exclude_patterns,
-				)
-			});
-		}
-		Ok(commits)
-	}
+        Self::set_commit_range(&mut revwalk, range).map_err(|e| {
+            Error::SetCommitRangeError(
+                range.map(String::from).unwrap_or_else(|| "?".to_string()),
+                e,
+            )
+        })?;
+        let mut commits: Vec<Commit> = revwalk
+            .filter_map(|id| id.ok())
+            .filter_map(|id| self.inner.find_commit(id).ok())
+            .collect();
+        if include_path.is_some() || exclude_path.is_some() {
+            let include_patterns = include_path
+                .map(|patterns| patterns.into_iter().map(Self::normalize_pattern).collect());
+            let exclude_patterns = exclude_path
+                .map(|patterns| patterns.into_iter().map(Self::normalize_pattern).collect());
+            commits.retain(|commit| {
+                self.should_retain_commit(commit, &include_patterns, &exclude_patterns)
+            });
+        }
+        Ok(commits)
+    }
 
-	/// Returns submodule repositories for a given commit range.
-	///
-	/// For one or two given commits in this repository, a list of changed
-	/// submodules is calculated. If only one commit is given, then all
-	/// submodule commits up to the referenced commit will be included. This is
-	/// usually the case if a submodule is added to the repository.
-	///
-	///  For each submodule a [`SubmoduleRange`] object is created
-	///
-	/// This can then be used to query the submodule's commits by using
-	/// [`Repository::commits`].
-	pub fn submodules_range(
-		&self,
-		old_commit: Option<Commit<'_>>,
-		new_commit: Commit<'_>,
-	) -> Result<Vec<SubmoduleRange>> {
-		let old_tree = old_commit.and_then(|commit| commit.tree().ok());
-		let new_tree = new_commit.tree().ok();
-		let diff = self.inner.diff_tree_to_tree(
-			old_tree.as_ref(),
-			new_tree.as_ref(),
-			None,
-		)?;
-		// iterate through all diffs and accumulate old/new commit ids
-		let before_and_after_deltas = diff.deltas().filter_map(|delta| {
-			let old_file_id = delta.old_file().id();
-			let new_file_id = delta.new_file().id();
-			let range = if old_file_id == new_file_id || new_file_id.is_zero() {
-				// no changes or submodule removed
-				None
-			} else if old_file_id.is_zero() {
-				// submodule added
-				Some(new_file_id.to_string())
-			} else {
-				// submodule updated
-				Some(format!("{}..{}", old_file_id, new_file_id))
-			};
-			trace!("Release commit range for submodules: {:?}", range);
-			delta.new_file().path().and_then(Path::to_str).zip(range)
-		});
-		// iterate through all path diffs and find corresponding submodule if
-		// possible
-		let submodule_range = before_and_after_deltas.filter_map(|(path, range)| {
-			let repository = self
-				.inner
-				.find_submodule(path)
-				.ok()
-				.and_then(|submodule| Self::init(submodule.path().into()).ok());
-			repository.map(|repository| SubmoduleRange { repository, range })
-		});
-		Ok(submodule_range.collect())
-	}
+    /// Returns submodule repositories for a given commit range.
+    ///
+    /// For one or two given commits in this repository, a list of changed
+    /// submodules is calculated. If only one commit is given, then all
+    /// submodule commits up to the referenced commit will be included. This is
+    /// usually the case if a submodule is added to the repository.
+    ///
+    ///  For each submodule a [`SubmoduleRange`] object is created
+    ///
+    /// This can then be used to query the submodule's commits by using
+    /// [`Repository::commits`].
+    pub fn submodules_range(
+        &self,
+        old_commit: Option<Commit<'_>>,
+        new_commit: Commit<'_>,
+    ) -> Result<Vec<SubmoduleRange>> {
+        let old_tree = old_commit.and_then(|commit| commit.tree().ok());
+        let new_tree = new_commit.tree().ok();
+        let diff = self
+            .inner
+            .diff_tree_to_tree(old_tree.as_ref(), new_tree.as_ref(), None)?;
+        // iterate through all diffs and accumulate old/new commit ids
+        let before_and_after_deltas = diff.deltas().filter_map(|delta| {
+            let old_file_id = delta.old_file().id();
+            let new_file_id = delta.new_file().id();
+            let range = if old_file_id == new_file_id || new_file_id.is_zero() {
+                // no changes or submodule removed
+                None
+            } else if old_file_id.is_zero() {
+                // submodule added
+                Some(new_file_id.to_string())
+            } else {
+                // submodule updated
+                Some(format!("{}..{}", old_file_id, new_file_id))
+            };
+            trace!("Release commit range for submodules: {:?}", range);
+            delta.new_file().path().and_then(Path::to_str).zip(range)
+        });
+        // iterate through all path diffs and find corresponding submodule if
+        // possible
+        let submodule_range = before_and_after_deltas.filter_map(|(path, range)| {
+            let repository = self
+                .inner
+                .find_submodule(path)
+                .ok()
+                .and_then(|submodule| Self::init(submodule.path().into()).ok());
+            repository.map(|repository| SubmoduleRange { repository, range })
+        });
+        Ok(submodule_range.collect())
+    }
 
-	/// Normalizes the glob pattern to match the git diff paths.
-	///
-	/// It removes the leading `./` and adds `**` to the end if the pattern is a
-	/// directory.
-	fn normalize_pattern(pattern: Pattern) -> Pattern {
-		let star_added = match pattern.as_str().chars().last() {
-			Some('/' | '\\') => Pattern::new(&format!("{pattern}**"))
-				.expect("failed to add '**' to the end of glob"),
-			_ => pattern,
-		};
-		match star_added.as_str().strip_prefix("./") {
-			Some(stripped) => Pattern::new(stripped)
-				.expect("failed to remove leading ./ from glob"),
-			None => star_added,
-		}
-	}
+    /// Normalizes the glob pattern to match the git diff paths.
+    ///
+    /// It removes the leading `./` and adds `**` to the end if the pattern is a
+    /// directory.
+    fn normalize_pattern(pattern: Pattern) -> Pattern {
+        let star_added = match pattern.as_str().chars().last() {
+            Some('/' | '\\') => Pattern::new(&format!("{pattern}**"))
+                .expect("failed to add '**' to the end of glob"),
+            _ => pattern,
+        };
+        match star_added.as_str().strip_prefix("./") {
+            Some(stripped) => {
+                Pattern::new(stripped).expect("failed to remove leading ./ from glob")
+            }
+            None => star_added,
+        }
+    }
 
-	/// Calculates whether the commit should be retained or not.
-	///
-	/// This function is used to filter the commits based on the changed files,
-	/// and include/exclude patterns.
-	fn should_retain_commit(
-		&self,
-		commit: &Commit,
-		include_patterns: &Option<Vec<Pattern>>,
-		exclude_patterns: &Option<Vec<Pattern>>,
-	) -> bool {
-		let changed_files = self.commit_changed_files(commit);
-		match (include_patterns, exclude_patterns) {
-			(Some(include_pattern), Some(exclude_pattern)) => {
-				// check if the commit has any changed files that match any of the
-				// include patterns and none of the exclude patterns.
-				changed_files.iter().any(|path| {
-					include_pattern
-						.iter()
-						.any(|pattern| pattern.matches_path(path)) &&
-						!exclude_pattern
-							.iter()
-							.any(|pattern| pattern.matches_path(path))
-				})
-			}
-			(Some(include_pattern), None) => {
-				// check if the commit has any changed files that match the include
-				// patterns.
-				changed_files.iter().any(|path| {
-					include_pattern
-						.iter()
-						.any(|pattern| pattern.matches_path(path))
-				})
-			}
-			(None, Some(exclude_pattern)) => {
-				// check if the commit has at least one changed file that does not
-				// match all exclude patterns.
-				changed_files.iter().any(|path| {
-					!exclude_pattern
-						.iter()
-						.any(|pattern| pattern.matches_path(path))
-				})
-			}
-			(None, None) => true,
-		}
-	}
+    /// Calculates whether the commit should be retained or not.
+    ///
+    /// This function is used to filter the commits based on the changed files,
+    /// and include/exclude patterns.
+    fn should_retain_commit(
+        &self,
+        commit: &Commit,
+        include_patterns: &Option<Vec<Pattern>>,
+        exclude_patterns: &Option<Vec<Pattern>>,
+    ) -> bool {
+        let changed_files = self.commit_changed_files(commit);
+        match (include_patterns, exclude_patterns) {
+            (Some(include_pattern), Some(exclude_pattern)) => {
+                // check if the commit has any changed files that match any of the
+                // include patterns and none of the exclude patterns.
+                changed_files.iter().any(|path| {
+                    include_pattern
+                        .iter()
+                        .any(|pattern| pattern.matches_path(path)) &&
+                        !exclude_pattern
+                            .iter()
+                            .any(|pattern| pattern.matches_path(path))
+                })
+            }
+            (Some(include_pattern), None) => {
+                // check if the commit has any changed files that match the include
+                // patterns.
+                changed_files.iter().any(|path| {
+                    include_pattern
+                        .iter()
+                        .any(|pattern| pattern.matches_path(path))
+                })
+            }
+            (None, Some(exclude_pattern)) => {
+                // check if the commit has at least one changed file that does not
+                // match all exclude patterns.
+                changed_files.iter().any(|path| {
+                    !exclude_pattern
+                        .iter()
+                        .any(|pattern| pattern.matches_path(path))
+                })
+            }
+            (None, None) => true,
+        }
+    }
 
-	/// Returns the changed files of the commit.
-	///
-	/// It uses a cache to speed up checks to store the changed files of the
-	/// commits under `./.git/git-cliff-core/changed_files_cache`. The speed-up
-	/// was measured to be around 260x for large repositories.
-	///
-	/// If the cache is not found, it calculates the changed files and adds them
-	/// to the cache via [`Self::commit_changed_files_no_cache`].
-	fn commit_changed_files(&self, commit: &Commit) -> Vec<PathBuf> {
-		// Cache key is generated from the repository path and commit id
-		let cache_key = format!("commit_id:{}", commit.id());
+    /// Returns the changed files of the commit.
+    ///
+    /// It uses a cache to speed up checks to store the changed files of the
+    /// commits under `./.git/git-cliff-core/changed_files_cache`. The speed-up
+    /// was measured to be around 260x for large repositories.
+    ///
+    /// If the cache is not found, it calculates the changed files and adds them
+    /// to the cache via [`Self::commit_changed_files_no_cache`].
+    fn commit_changed_files(&self, commit: &Commit) -> Vec<PathBuf> {
+        // Cache key is generated from the repository path and commit id
+        let cache_key = format!("commit_id:{}", commit.id());
 
-		// Check the cache first.
-		{
-			if let Ok(result) =
-				cacache::read_sync(&self.changed_files_cache_path, &cache_key)
-			{
-				if let Ok((files, _)) =
-					bincode::decode_from_slice(&result, bincode::config::standard())
-				{
-					return files;
-				}
-			}
-		}
+        // Check the cache first.
+        {
+            if let Ok(result) = cacache::read_sync(&self.changed_files_cache_path, &cache_key) {
+                if let Ok((files, _)) =
+                    bincode::decode_from_slice(&result, bincode::config::standard())
+                {
+                    return files;
+                }
+            }
+        }
 
-		// If the cache is not found, calculate the result and set it to the cache.
-		let result = self.commit_changed_files_no_cache(commit);
-		match bincode::encode_to_vec(
-			self.commit_changed_files_no_cache(commit),
-			bincode::config::standard(),
-		) {
-			Ok(v) => {
-				if let Err(e) = cacache::write_sync_with_algo(
-					cacache::Algorithm::Xxh3,
-					&self.changed_files_cache_path,
-					cache_key,
-					v,
-				) {
-					error!("Failed to set cache for repo {:?}: {e}", self.path);
-				}
-			}
-			Err(e) => {
-				error!("Failed to serialize cache for repo {:?}: {e}", self.path);
-			}
-		}
+        // If the cache is not found, calculate the result and set it to the cache.
+        let result = self.commit_changed_files_no_cache(commit);
+        match bincode::encode_to_vec(
+            self.commit_changed_files_no_cache(commit),
+            bincode::config::standard(),
+        ) {
+            Ok(v) => {
+                if let Err(e) = cacache::write_sync_with_algo(
+                    cacache::Algorithm::Xxh3,
+                    &self.changed_files_cache_path,
+                    cache_key,
+                    v,
+                ) {
+                    error!("Failed to set cache for repo {:?}: {e}", self.path);
+                }
+            }
+            Err(e) => {
+                error!("Failed to serialize cache for repo {:?}: {e}", self.path);
+            }
+        }
 
-		result
-	}
+        result
+    }
 
-	/// Calculate the changed files of the commit.
-	///
-	/// This function does not use the cache (directly calls git2).
-	fn commit_changed_files_no_cache(&self, commit: &Commit) -> Vec<PathBuf> {
-		let mut changed_files = Vec::new();
-		if let Ok(prev_commit) = commit.parent(0) {
-			// Compare the current commit with the previous commit to get the
-			// changed files.
-			// libgit2 does not provide a way to get the changed files directly, so
-			// the full diff is calculated here.
-			if let Ok(diff) = self.inner.diff_tree_to_tree(
-				commit.tree().ok().as_ref(),
-				prev_commit.tree().ok().as_ref(),
-				None,
-			) {
-				changed_files.extend(
-					diff.deltas().filter_map(|delta| {
-						delta.new_file().path().map(PathBuf::from)
-					}),
-				);
-			}
-		} else {
-			// If there is no parent, it is the first commit.
-			// So get all the files in the tree.
-			if let Ok(tree) = commit.tree() {
-				tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
-					if entry.kind().expect("failed to get entry kind") !=
-						git2::ObjectType::Blob
-					{
-						return 0;
-					}
-					let name = entry.name().expect("failed to get entry name");
-					let entry_path = if dir == "," {
-						name.to_string()
-					} else {
-						format!("{dir}/{name}")
-					};
-					changed_files.push(entry_path.into());
-					0
-				})
-				.expect("failed to get the changed files of the first commit");
-			}
-		}
-		changed_files
-	}
+    /// Calculate the changed files of the commit.
+    ///
+    /// This function does not use the cache (directly calls git2).
+    fn commit_changed_files_no_cache(&self, commit: &Commit) -> Vec<PathBuf> {
+        let mut changed_files = Vec::new();
+        if let Ok(prev_commit) = commit.parent(0) {
+            // Compare the current commit with the previous commit to get the
+            // changed files.
+            // libgit2 does not provide a way to get the changed files directly, so
+            // the full diff is calculated here.
+            if let Ok(diff) = self.inner.diff_tree_to_tree(
+                commit.tree().ok().as_ref(),
+                prev_commit.tree().ok().as_ref(),
+                None,
+            ) {
+                changed_files.extend(
+                    diff.deltas()
+                        .filter_map(|delta| delta.new_file().path().map(PathBuf::from)),
+                );
+            }
+        } else {
+            // If there is no parent, it is the first commit.
+            // So get all the files in the tree.
+            if let Ok(tree) = commit.tree() {
+                tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
+                    if entry.kind().expect("failed to get entry kind") != git2::ObjectType::Blob {
+                        return 0;
+                    }
+                    let name = entry.name().expect("failed to get entry name");
+                    let entry_path = if dir == "," {
+                        name.to_string()
+                    } else {
+                        format!("{dir}/{name}")
+                    };
+                    changed_files.push(entry_path.into());
+                    0
+                })
+                .expect("failed to get the changed files of the first commit");
+            }
+        }
+        changed_files
+    }
 
-	/// Returns the current tag.
-	///
-	/// It is the same as running `git describe --tags`
-	pub fn current_tag(&self) -> Option<Tag> {
-		self.inner
-			.describe(DescribeOptions::new().describe_tags())
-			.ok()
-			.and_then(|describe| {
-				describe
-					.format(None)
-					.ok()
-					.map(|name| self.resolve_tag(&name))
-			})
-	}
+    /// Returns the current tag.
+    ///
+    /// It is the same as running `git describe --tags`
+    pub fn current_tag(&self) -> Option<Tag> {
+        self.inner
+            .describe(DescribeOptions::new().describe_tags())
+            .ok()
+            .and_then(|describe| {
+                describe
+                    .format(None)
+                    .ok()
+                    .map(|name| self.resolve_tag(&name))
+            })
+    }
 
-	/// Returns the tag object of the given name.
-	///
-	/// If given name doesn't exist, it still returns `Tag` with the given name.
-	pub fn resolve_tag(&self, name: &str) -> Tag {
-		match self
-			.inner
-			.resolve_reference_from_short_name(name)
-			.and_then(|r| r.peel_to_tag())
-		{
-			Ok(tag) => Tag {
-				name:    tag.name().unwrap_or_default().to_owned(),
-				message: tag.message().map(|msg| {
-					TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()
-				}),
-			},
-			_ => Tag {
-				name:    name.to_owned(),
-				message: None,
-			},
-		}
-	}
+    /// Returns the tag object of the given name.
+    ///
+    /// If given name doesn't exist, it still returns `Tag` with the given name.
+    pub fn resolve_tag(&self, name: &str) -> Tag {
+        match self
+            .inner
+            .resolve_reference_from_short_name(name)
+            .and_then(|r| r.peel_to_tag())
+        {
+            Ok(tag) => Tag {
+                name: tag.name().unwrap_or_default().to_owned(),
+                message: tag
+                    .message()
+                    .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
+            },
+            _ => Tag {
+                name: name.to_owned(),
+                message: None,
+            },
+        }
+    }
 
-	/// Returns the commit object of the given ID.
-	pub fn find_commit(&self, id: &str) -> Option<Commit<'_>> {
-		if let Ok(oid) = Oid::from_str(id) {
-			if let Ok(commit) = self.inner.find_commit(oid) {
-				return Some(commit);
-			}
-		}
-		None
-	}
+    /// Returns the commit object of the given ID.
+    pub fn find_commit(&self, id: &str) -> Option<Commit<'_>> {
+        if let Ok(oid) = Oid::from_str(id) {
+            if let Ok(commit) = self.inner.find_commit(oid) {
+                return Some(commit);
+            }
+        }
+        None
+    }
 
-	/// Decide whether to include tag.
-	///
-	/// `head_commit` is the `latest` commit to generate changelog. It can be a
-	/// branch head or a detached head. `tag_commit` is a tagged commit. If the
-	/// commit is in the descendant graph of the `head_commit` or is the
-	/// `head_commit` itself, Changelog should include the tag.
-	fn should_include_tag(
-		&self,
-		head_commit: &Commit,
-		tag_commit: &Commit,
-	) -> Result<bool> {
-		Ok(self
-			.inner
-			.graph_descendant_of(head_commit.id(), tag_commit.id())? ||
-			head_commit.id() == tag_commit.id())
-	}
+    /// Decide whether to include tag.
+    ///
+    /// `head_commit` is the `latest` commit to generate changelog. It can be a
+    /// branch head or a detached head. `tag_commit` is a tagged commit. If the
+    /// commit is in the descendant graph of the `head_commit` or is the
+    /// `head_commit` itself, Changelog should include the tag.
+    fn should_include_tag(&self, head_commit: &Commit, tag_commit: &Commit) -> Result<bool> {
+        Ok(self
+            .inner
+            .graph_descendant_of(head_commit.id(), tag_commit.id())? ||
+            head_commit.id() == tag_commit.id())
+    }
 
-	/// Parses and returns a commit-tag map.
-	///
-	/// It collects lightweight and annotated tags.
-	pub fn tags(
-		&self,
-		pattern: &Option<Regex>,
-		topo_order: bool,
-		use_branch_tags: bool,
-	) -> Result<IndexMap<String, Tag>> {
-		let mut tags: Vec<(Commit, Tag)> = Vec::new();
-		let tag_names = self.inner.tag_names(None)?;
-		let head_commit = self.inner.head()?.peel_to_commit()?;
-		for name in tag_names
-			.iter()
-			.flatten()
-			.filter(|tag_name| {
-				pattern.as_ref().is_none_or(|pat| pat.is_match(tag_name))
-			})
-			.map(String::from)
-		{
-			let obj = self.inner.revparse_single(&name)?;
-			if let Ok(commit) = obj.clone().into_commit() {
-				if use_branch_tags &&
-					!self.should_include_tag(&head_commit, &commit)?
-				{
-					continue;
-				}
+    /// Parses and returns a commit-tag map.
+    ///
+    /// It collects lightweight and annotated tags.
+    pub fn tags(
+        &self,
+        pattern: &Option<Regex>,
+        topo_order: bool,
+        use_branch_tags: bool,
+    ) -> Result<IndexMap<String, Tag>> {
+        let mut tags: Vec<(Commit, Tag)> = Vec::new();
+        let tag_names = self.inner.tag_names(None)?;
+        let head_commit = self.inner.head()?.peel_to_commit()?;
+        for name in tag_names
+            .iter()
+            .flatten()
+            .filter(|tag_name| pattern.as_ref().is_none_or(|pat| pat.is_match(tag_name)))
+            .map(String::from)
+        {
+            let obj = self.inner.revparse_single(&name)?;
+            if let Ok(commit) = obj.clone().into_commit() {
+                if use_branch_tags && !self.should_include_tag(&head_commit, &commit)? {
+                    continue;
+                }
 
-				tags.push((commit, Tag {
-					name,
-					message: None,
-				}));
-			} else if let Some(tag) = obj.as_tag() {
-				if let Some(commit) = tag
-					.target()
-					.ok()
-					.and_then(|target| target.into_commit().ok())
-				{
-					if use_branch_tags &&
-						!self.should_include_tag(&head_commit, &commit)?
-					{
-						continue;
-					}
-					tags.push((commit, Tag {
-						name:    tag.name().map(String::from).unwrap_or(name),
-						message: tag.message().map(|msg| {
-							TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()
-						}),
-					}));
-				}
-			}
-		}
-		if !topo_order {
-			tags.sort_by(|a, b| a.0.time().seconds().cmp(&b.0.time().seconds()));
-		}
-		Ok(tags
-			.into_iter()
-			.map(|(a, b)| (a.id().to_string(), b))
-			.collect())
-	}
+                tags.push((commit, Tag {
+                    name,
+                    message: None,
+                }));
+            } else if let Some(tag) = obj.as_tag() {
+                if let Some(commit) = tag
+                    .target()
+                    .ok()
+                    .and_then(|target| target.into_commit().ok())
+                {
+                    if use_branch_tags && !self.should_include_tag(&head_commit, &commit)? {
+                        continue;
+                    }
+                    tags.push((commit, Tag {
+                        name: tag.name().map(String::from).unwrap_or(name),
+                        message: tag
+                            .message()
+                            .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
+                    }));
+                }
+            }
+        }
+        if !topo_order {
+            tags.sort_by(|a, b| a.0.time().seconds().cmp(&b.0.time().seconds()));
+        }
+        Ok(tags
+            .into_iter()
+            .map(|(a, b)| (a.id().to_string(), b))
+            .collect())
+    }
 
-	/// Returns the remote of the upstream repository.
-	///
-	/// The strategy used here is the following:
-	///
-	/// Find the branch that HEAD points to, and read the remote configured for
-	/// that branch returns the remote and the name of the local branch.
-	///
-	/// Note: HEAD must not be detached.
-	pub fn upstream_remote(&self) -> Result<Remote> {
-		for branch in self.inner.branches(Some(BranchType::Local))? {
-			let branch = branch?.0;
-			if branch.is_head() {
-				let upstream = &self.inner.branch_upstream_remote(&format!(
-					"refs/heads/{}",
-					&branch.name()?.ok_or_else(|| Error::RepoError(
-						String::from("branch name is not valid")
-					))?
-				))?;
-				let upstream_name = upstream.as_str().ok_or_else(|| {
-					Error::RepoError(String::from(
-						"name of the upstream remote is not valid",
-					))
-				})?;
-				let origin = &self.inner.find_remote(upstream_name)?;
-				let url = origin
-					.url()
-					.ok_or_else(|| {
-						Error::RepoError(String::from(
-							"failed to get the remote URL",
-						))
-					})?
-					.to_string();
-				trace!("Upstream URL: {url}");
-				return find_remote(&url);
-			}
-		}
-		Err(Error::RepoError(String::from(
-			"no remotes configured or HEAD is detached",
-		)))
-	}
+    /// Returns the remote of the upstream repository.
+    ///
+    /// The strategy used here is the following:
+    ///
+    /// Find the branch that HEAD points to, and read the remote configured for
+    /// that branch returns the remote and the name of the local branch.
+    ///
+    /// Note: HEAD must not be detached.
+    pub fn upstream_remote(&self) -> Result<Remote> {
+        for branch in self.inner.branches(Some(BranchType::Local))? {
+            let branch = branch?.0;
+            if branch.is_head() {
+                let upstream = &self.inner.branch_upstream_remote(&format!(
+                    "refs/heads/{}",
+                    &branch.name()?.ok_or_else(|| Error::RepoError(String::from(
+                        "branch name is not valid"
+                    )))?
+                ))?;
+                let upstream_name = upstream.as_str().ok_or_else(|| {
+                    Error::RepoError(String::from("name of the upstream remote is not valid"))
+                })?;
+                let origin = &self.inner.find_remote(upstream_name)?;
+                let url = origin
+                    .url()
+                    .ok_or_else(|| Error::RepoError(String::from("failed to get the remote URL")))?
+                    .to_string();
+                trace!("Upstream URL: {url}");
+                return find_remote(&url);
+            }
+        }
+        Err(Error::RepoError(String::from(
+            "no remotes configured or HEAD is detached",
+        )))
+    }
 }
 
 fn find_remote(url: &str) -> Result<Remote> {
-	url_path_segments(url).or_else(|err| {
-		if url.contains("@") && url.contains(":") && url.contains("/") {
-			ssh_path_segments(url)
-		} else {
-			Err(err)
-		}
-	})
+    url_path_segments(url).or_else(|err| {
+        if url.contains("@") && url.contains(":") && url.contains("/") {
+            ssh_path_segments(url)
+        } else {
+            Err(err)
+        }
+    })
 }
 
 /// Returns the Remote from parsing the HTTPS format URL.
@@ -555,25 +526,25 @@ fn find_remote(url: &str) -> Result<Remote> {
 ///
 /// > https://hostname/query/path.git
 fn url_path_segments(url: &str) -> Result<Remote> {
-	let parsed_url = Url::parse(url.strip_suffix(".git").unwrap_or(url))?;
-	let segments: Vec<&str> = parsed_url
-		.path_segments()
-		.ok_or_else(|| Error::RepoError(String::from("failed to get URL segments")))?
-		.rev()
-		.collect();
-	let [repo, owner, ..] = &segments[..] else {
-		return Err(Error::RepoError(String::from(
-			"failed to get the owner and repo",
-		)));
-	};
-	Ok(Remote {
-		owner:      owner.to_string(),
-		repo:       repo.to_string(),
-		token:      None,
-		is_custom:  false,
-		api_url:    None,
-		native_tls: None,
-	})
+    let parsed_url = Url::parse(url.strip_suffix(".git").unwrap_or(url))?;
+    let segments: Vec<&str> = parsed_url
+        .path_segments()
+        .ok_or_else(|| Error::RepoError(String::from("failed to get URL segments")))?
+        .rev()
+        .collect();
+    let [repo, owner, ..] = &segments[..] else {
+        return Err(Error::RepoError(String::from(
+            "failed to get the owner and repo",
+        )));
+    };
+    Ok(Remote {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        token: None,
+        is_custom: false,
+        api_url: None,
+        native_tls: None,
+    })
 }
 
 /// Returns the Remote from parsing the SSH format URL.
@@ -582,477 +553,427 @@ fn url_path_segments(url: &str) -> Result<Remote> {
 ///
 /// > git@hostname:owner/repo.git
 fn ssh_path_segments(url: &str) -> Result<Remote> {
-	let [_, owner_repo, ..] = url
-		.strip_suffix(".git")
-		.unwrap_or(url)
-		.split(":")
-		.collect::<Vec<_>>()[..]
-	else {
-		return Err(Error::RepoError(String::from(
-			"failed to get the owner and repo from ssh remote (:)",
-		)));
-	};
-	let [owner, repo] = owner_repo.split("/").collect::<Vec<_>>()[..] else {
-		return Err(Error::RepoError(String::from(
-			"failed to get the owner and repo from ssh remote (/)",
-		)));
-	};
-	Ok(Remote {
-		owner:      owner.to_string(),
-		repo:       repo.to_string(),
-		token:      None,
-		is_custom:  false,
-		api_url:    None,
-		native_tls: None,
-	})
+    let [_, owner_repo, ..] = url
+        .strip_suffix(".git")
+        .unwrap_or(url)
+        .split(":")
+        .collect::<Vec<_>>()[..]
+    else {
+        return Err(Error::RepoError(String::from(
+            "failed to get the owner and repo from ssh remote (:)",
+        )));
+    };
+    let [owner, repo] = owner_repo.split("/").collect::<Vec<_>>()[..] else {
+        return Err(Error::RepoError(String::from(
+            "failed to get the owner and repo from ssh remote (/)",
+        )));
+    };
+    Ok(Remote {
+        owner: owner.to_string(),
+        repo: repo.to_string(),
+        token: None,
+        is_custom: false,
+        api_url: None,
+        native_tls: None,
+    })
 }
 
 #[cfg(test)]
 mod test {
-	use std::process::Command;
-	use std::{env, fs, str};
+    use std::process::Command;
+    use std::{env, fs, str};
 
-	use temp_dir::TempDir;
+    use temp_dir::TempDir;
 
-	use super::*;
-	use crate::commit::Commit as AppCommit;
+    use super::*;
+    use crate::commit::Commit as AppCommit;
 
-	fn get_last_commit_hash() -> Result<String> {
-		Ok(str::from_utf8(
-			Command::new("git")
-				.args(["log", "--pretty=format:'%H'", "-n", "1"])
-				.output()?
-				.stdout
-				.as_ref(),
-		)?
-		.trim_matches('\'')
-		.to_string())
-	}
+    fn get_last_commit_hash() -> Result<String> {
+        Ok(str::from_utf8(
+            Command::new("git")
+                .args(["log", "--pretty=format:'%H'", "-n", "1"])
+                .output()?
+                .stdout
+                .as_ref(),
+        )?
+        .trim_matches('\'')
+        .to_string())
+    }
 
-	fn get_root_commit_hash() -> Result<String> {
-		Ok(str::from_utf8(
-			Command::new("git")
-				.args(["rev-list", "--max-parents=0", "HEAD"])
-				.output()?
-				.stdout
-				.as_ref(),
-		)?
-		.trim_ascii_end()
-		.to_string())
-	}
+    fn get_root_commit_hash() -> Result<String> {
+        Ok(str::from_utf8(
+            Command::new("git")
+                .args(["rev-list", "--max-parents=0", "HEAD"])
+                .output()?
+                .stdout
+                .as_ref(),
+        )?
+        .trim_ascii_end()
+        .to_string())
+    }
 
-	fn get_last_tag() -> Result<String> {
-		Ok(str::from_utf8(
-			Command::new("git")
-				.args(["describe", "--abbrev=0"])
-				.output()?
-				.stdout
-				.as_ref(),
-		)?
-		.trim()
-		.to_string())
-	}
+    fn get_last_tag() -> Result<String> {
+        Ok(str::from_utf8(
+            Command::new("git")
+                .args(["describe", "--abbrev=0"])
+                .output()?
+                .stdout
+                .as_ref(),
+        )?
+        .trim()
+        .to_string())
+    }
 
-	fn get_repository() -> Result<Repository> {
-		Repository::init(
-			PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-				.parent()
-				.expect("parent directory not found")
-				.to_path_buf(),
-		)
-	}
+    fn get_repository() -> Result<Repository> {
+        Repository::init(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("parent directory not found")
+                .to_path_buf(),
+        )
+    }
 
-	#[test]
-	fn http_url_repo_owner() -> Result<()> {
-		let url = "https://hostname.com/bob/magic.git";
-		let remote = find_remote(url)?;
-		assert_eq!(remote.owner, "bob", "match owner");
-		assert_eq!(remote.repo, "magic", "match repo");
-		Ok(())
-	}
+    #[test]
+    fn http_url_repo_owner() -> Result<()> {
+        let url = "https://hostname.com/bob/magic.git";
+        let remote = find_remote(url)?;
+        assert_eq!(remote.owner, "bob", "match owner");
+        assert_eq!(remote.repo, "magic", "match repo");
+        Ok(())
+    }
 
-	#[test]
-	fn ssh_url_repo_owner() -> Result<()> {
-		let url = "git@hostname.com:bob/magic.git";
-		let remote = find_remote(url)?;
-		assert_eq!(remote.owner, "bob", "match owner");
-		assert_eq!(remote.repo, "magic", "match repo");
-		Ok(())
-	}
+    #[test]
+    fn ssh_url_repo_owner() -> Result<()> {
+        let url = "git@hostname.com:bob/magic.git";
+        let remote = find_remote(url)?;
+        assert_eq!(remote.owner, "bob", "match owner");
+        assert_eq!(remote.repo, "magic", "match repo");
+        Ok(())
+    }
 
-	#[test]
-	fn get_latest_commit() -> Result<()> {
-		let repository = get_repository()?;
-		let commits = repository.commits(None, None, None, false)?;
-		let last_commit =
-			AppCommit::from(&commits.first().expect("no commits found").clone());
-		assert_eq!(get_last_commit_hash()?, last_commit.id);
-		Ok(())
-	}
+    #[test]
+    fn get_latest_commit() -> Result<()> {
+        let repository = get_repository()?;
+        let commits = repository.commits(None, None, None, false)?;
+        let last_commit = AppCommit::from(&commits.first().expect("no commits found").clone());
+        assert_eq!(get_last_commit_hash()?, last_commit.id);
+        Ok(())
+    }
 
-	#[test]
-	fn commit_search() -> Result<()> {
-		let repository = get_repository()?;
-		assert!(
-			repository
-				.find_commit("e936ed571533ea6c41a1dd2b1a29d085c8dbada5")
-				.is_some()
-		);
-		Ok(())
-	}
+    #[test]
+    fn commit_search() -> Result<()> {
+        let repository = get_repository()?;
+        assert!(
+            repository
+                .find_commit("e936ed571533ea6c41a1dd2b1a29d085c8dbada5")
+                .is_some()
+        );
+        Ok(())
+    }
 
-	#[test]
-	fn get_latest_tag() -> Result<()> {
-		let repository = get_repository()?;
-		let tags = repository.tags(&None, false, false)?;
-		let latest = tags.last().expect("no tags found").1.name.clone();
-		assert_eq!(get_last_tag()?, latest);
+    #[test]
+    fn get_latest_tag() -> Result<()> {
+        let repository = get_repository()?;
+        let tags = repository.tags(&None, false, false)?;
+        let latest = tags.last().expect("no tags found").1.name.clone();
+        assert_eq!(get_last_tag()?, latest);
 
-		let current = repository.current_tag().expect("a current tag").name;
-		assert!(current.contains(&latest));
-		Ok(())
-	}
+        let current = repository.current_tag().expect("a current tag").name;
+        assert!(current.contains(&latest));
+        Ok(())
+    }
 
-	#[test]
-	fn git_tags() -> Result<()> {
-		let repository = get_repository()?;
-		let tags = repository.tags(&None, true, false)?;
-		assert_eq!(
-			tags.get("2b8b4d3535f29231e05c3572e919634b9af907b6")
-				.expect(
-					"the commit hash does not exist in the repository (tag v0.1.0)"
-				)
-				.name,
-			"v0.1.0"
-		);
-		assert_eq!(
-			tags.get("4ddef08debfff48117586296e49d5caa0800d1b5")
-				.expect(
-					"the commit hash does not exist in the repository (tag \
-					 v0.1.0-beta.4)"
-				)
-				.name,
-			"v0.1.0-beta.4"
-		);
-		let tags = repository.tags(
-			&Some(
-				Regex::new("^v[0-9]+\\.[0-9]+\\.[0-9]$")
-					.expect("the regex is not valid"),
-			),
-			true,
-			false,
-		)?;
-		assert_eq!(
-			tags.get("2b8b4d3535f29231e05c3572e919634b9af907b6")
-				.expect(
-					"the commit hash does not exist in the repository (tag v0.1.0)"
-				)
-				.name,
-			"v0.1.0"
-		);
-		assert!(!tags.contains_key("4ddef08debfff48117586296e49d5caa0800d1b5"));
-		Ok(())
-	}
+    #[test]
+    fn git_tags() -> Result<()> {
+        let repository = get_repository()?;
+        let tags = repository.tags(&None, true, false)?;
+        assert_eq!(
+            tags.get("2b8b4d3535f29231e05c3572e919634b9af907b6")
+                .expect("the commit hash does not exist in the repository (tag v0.1.0)")
+                .name,
+            "v0.1.0"
+        );
+        assert_eq!(
+            tags.get("4ddef08debfff48117586296e49d5caa0800d1b5")
+                .expect("the commit hash does not exist in the repository (tag v0.1.0-beta.4)")
+                .name,
+            "v0.1.0-beta.4"
+        );
+        let tags = repository.tags(
+            &Some(Regex::new("^v[0-9]+\\.[0-9]+\\.[0-9]$").expect("the regex is not valid")),
+            true,
+            false,
+        )?;
+        assert_eq!(
+            tags.get("2b8b4d3535f29231e05c3572e919634b9af907b6")
+                .expect("the commit hash does not exist in the repository (tag v0.1.0)")
+                .name,
+            "v0.1.0"
+        );
+        assert!(!tags.contains_key("4ddef08debfff48117586296e49d5caa0800d1b5"));
+        Ok(())
+    }
 
-	#[test]
-	fn git_upstream_remote() -> Result<()> {
-		let repository = get_repository()?;
-		let remote = repository.upstream_remote()?;
-		assert_eq!(
-			Remote {
-				owner:      remote.owner.clone(),
-				repo:       String::from("git-cliff"),
-				token:      None,
-				is_custom:  false,
-				api_url:    remote.api_url.clone(),
-				native_tls: None,
-			},
-			remote
-		);
-		Ok(())
-	}
+    #[test]
+    fn git_upstream_remote() -> Result<()> {
+        let repository = get_repository()?;
+        let remote = repository.upstream_remote()?;
+        assert_eq!(
+            Remote {
+                owner: remote.owner.clone(),
+                repo: String::from("git-cliff"),
+                token: None,
+                is_custom: false,
+                api_url: remote.api_url.clone(),
+                native_tls: None,
+            },
+            remote
+        );
+        Ok(())
+    }
 
-	#[test]
-	fn resolves_existing_tag_with_name_and_message() -> Result<()> {
-		let repository = get_repository()?;
-		let tag = repository.resolve_tag("v0.2.3");
-		assert_eq!(tag.name, "v0.2.3");
-		assert_eq!(
-			tag.message,
-			Some(
-				"Release v0.2.3\n\nBug Fixes\n- Fetch the dependencies before \
-				 copying the file to embed (9e29c95)"
-					.to_string()
-			)
-		);
+    #[test]
+    fn resolves_existing_tag_with_name_and_message() -> Result<()> {
+        let repository = get_repository()?;
+        let tag = repository.resolve_tag("v0.2.3");
+        assert_eq!(tag.name, "v0.2.3");
+        assert_eq!(
+            tag.message,
+            Some(
+                "Release v0.2.3\n\nBug Fixes\n- Fetch the dependencies before copying the file to \
+                 embed (9e29c95)"
+                    .to_string()
+            )
+        );
 
-		Ok(())
-	}
+        Ok(())
+    }
 
-	#[test]
-	fn resolves_tag_when_no_tags_exist() -> Result<()> {
-		let repository = get_repository()?;
-		let tag = repository.resolve_tag("nonexistent-tag");
-		assert_eq!(tag.name, "nonexistent-tag");
-		assert_eq!(tag.message, None);
-		Ok(())
-	}
+    #[test]
+    fn resolves_tag_when_no_tags_exist() -> Result<()> {
+        let repository = get_repository()?;
+        let tag = repository.resolve_tag("nonexistent-tag");
+        assert_eq!(tag.name, "nonexistent-tag");
+        assert_eq!(tag.message, None);
+        Ok(())
+    }
 
-	#[test]
-	fn includes_root_commit() -> Result<()> {
-		let repository = get_repository()?;
-		// a close descendant of the root commit
-		let range = Some("eea3914c7ab07472841aa85c36d11bdb2589a234");
-		let commits = repository.commits(range, None, None, false)?;
-		let root_commit =
-			AppCommit::from(&commits.last().expect("no commits found").clone());
-		assert_eq!(get_root_commit_hash()?, root_commit.id);
-		Ok(())
-	}
+    #[test]
+    fn includes_root_commit() -> Result<()> {
+        let repository = get_repository()?;
+        // a close descendant of the root commit
+        let range = Some("eea3914c7ab07472841aa85c36d11bdb2589a234");
+        let commits = repository.commits(range, None, None, false)?;
+        let root_commit = AppCommit::from(&commits.last().expect("no commits found").clone());
+        assert_eq!(get_root_commit_hash()?, root_commit.id);
+        Ok(())
+    }
 
-	fn create_temp_repo() -> (Repository, TempDir) {
-		let temp_dir =
-			TempDir::with_prefix("git-cliff-").expect("failed to create temp dir");
+    fn create_temp_repo() -> (Repository, TempDir) {
+        let temp_dir = TempDir::with_prefix("git-cliff-").expect("failed to create temp dir");
 
-		let output = Command::new("git")
-			.args(["init"])
-			.current_dir(temp_dir.path())
-			.output()
-			.expect("failed to execute git init");
-		assert!(output.status.success(), "git init failed {:?}", output);
+        let output = Command::new("git")
+            .args(["init"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("failed to execute git init");
+        assert!(output.status.success(), "git init failed {:?}", output);
 
-		let repo = Repository::init(temp_dir.path().to_path_buf())
-			.expect("failed to init repo");
-		let output = Command::new("git")
-			.args(["config", "user.email", "test@gmail.com"])
-			.current_dir(temp_dir.path())
-			.output()
-			.expect("failed to execute git config user.email");
-		assert!(
-			output.status.success(),
-			"git config user.email failed {:?}",
-			output
-		);
+        let repo = Repository::init(temp_dir.path().to_path_buf()).expect("failed to init repo");
+        let output = Command::new("git")
+            .args(["config", "user.email", "test@gmail.com"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("failed to execute git config user.email");
+        assert!(
+            output.status.success(),
+            "git config user.email failed {:?}",
+            output
+        );
 
-		let output = Command::new("git")
-			.args(["config", "user.name", "test"])
-			.current_dir(temp_dir.path())
-			.output()
-			.expect("failed to execute git config user.name");
-		assert!(
-			output.status.success(),
-			"git config user.name failed {:?}",
-			output
-		);
+        let output = Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(temp_dir.path())
+            .output()
+            .expect("failed to execute git config user.name");
+        assert!(
+            output.status.success(),
+            "git config user.name failed {:?}",
+            output
+        );
 
-		(repo, temp_dir)
-	}
+        (repo, temp_dir)
+    }
 
-	#[test]
-	fn open_jujutsu_repo() {
-		let (repo, _temp_dir) = create_temp_repo();
-		// working copy is the directory that contains the .git directory:
-		let working_copy = repo.path;
+    #[test]
+    fn open_jujutsu_repo() {
+        let (repo, _temp_dir) = create_temp_repo();
+        // working copy is the directory that contains the .git directory:
+        let working_copy = repo.path;
 
-		// Make the Git repository bare and set HEAD
-		std::process::Command::new("git")
-			.args(["config", "core.bare", "true"])
-			.current_dir(&working_copy)
-			.status()
-			.expect("failed to make git repo non-bare");
-		// Move the Git repo into jj
-		let store = working_copy.join(".jj").join("repo").join("store");
-		fs::create_dir_all(&store).expect("failed to create dir");
-		fs::rename(working_copy.join(".git"), store.join("git"))
-			.expect("failed to move git repo");
+        // Make the Git repository bare and set HEAD
+        std::process::Command::new("git")
+            .args(["config", "core.bare", "true"])
+            .current_dir(&working_copy)
+            .status()
+            .expect("failed to make git repo non-bare");
+        // Move the Git repo into jj
+        let store = working_copy.join(".jj").join("repo").join("store");
+        fs::create_dir_all(&store).expect("failed to create dir");
+        fs::rename(working_copy.join(".git"), store.join("git")).expect("failed to move git repo");
 
-		// Open repo from working copy, that contains the .jj directory
-		let repo = Repository::init(working_copy).expect("failed to init repo");
+        // Open repo from working copy, that contains the .jj directory
+        let repo = Repository::init(working_copy).expect("failed to init repo");
 
-		// macOS canonical path for temp directories is in /private
-		// libgit2 forces the path to be canonical regardless of what we pass in
-		if repo.inner.path().starts_with("/private") {
-			assert_eq!(
-				repo.inner.path().strip_prefix("/private"),
-				store.join("git").strip_prefix("/"),
-				"open git repo in .jj/repo/store/"
-			);
-		} else {
-			assert_eq!(
-				repo.inner.path(),
-				store.join("git"),
-				"open git repo in .jj/repo/store/"
-			);
-		}
-	}
+        // macOS canonical path for temp directories is in /private
+        // libgit2 forces the path to be canonical regardless of what we pass in
+        if repo.inner.path().starts_with("/private") {
+            assert_eq!(
+                repo.inner.path().strip_prefix("/private"),
+                store.join("git").strip_prefix("/"),
+                "open git repo in .jj/repo/store/"
+            );
+        } else {
+            assert_eq!(
+                repo.inner.path(),
+                store.join("git"),
+                "open git repo in .jj/repo/store/"
+            );
+        }
+    }
 
-	#[test]
-	fn propagate_error_if_no_repo_found() {
-		let temp_dir =
-			TempDir::with_prefix("git-cliff-").expect("failed to create temp dir");
+    #[test]
+    fn propagate_error_if_no_repo_found() {
+        let temp_dir = TempDir::with_prefix("git-cliff-").expect("failed to create temp dir");
 
-		let path = temp_dir.path().to_path_buf();
+        let path = temp_dir.path().to_path_buf();
 
-		let result = Repository::init(path.clone());
+        let result = Repository::init(path.clone());
 
-		assert!(result.is_err());
-		if let Err(error) = result {
-			assert!(
-				format!("{error:?}").contains(
-					format!("could not find repository at '{}'", path.display())
-						.as_str()
-				)
-			)
-		}
-	}
+        assert!(result.is_err());
+        if let Err(error) = result {
+            assert!(
+                format!("{error:?}").contains(
+                    format!("could not find repository at '{}'", path.display()).as_str()
+                )
+            )
+        }
+    }
 
-	fn create_commit_with_files<'a>(
-		repo: &'a Repository,
-		files: Vec<(&'a str, &'a str)>,
-	) -> Commit<'a> {
-		for (path, content) in files {
-			if let Some(parent) = repo.path.join(path).parent() {
-				std::fs::create_dir_all(parent).expect("failed to create dir");
-			}
-			std::fs::write(repo.path.join(path), content)
-				.expect("failed to write file");
-		}
+    fn create_commit_with_files<'a>(
+        repo: &'a Repository,
+        files: Vec<(&'a str, &'a str)>,
+    ) -> Commit<'a> {
+        for (path, content) in files {
+            if let Some(parent) = repo.path.join(path).parent() {
+                std::fs::create_dir_all(parent).expect("failed to create dir");
+            }
+            std::fs::write(repo.path.join(path), content).expect("failed to write file");
+        }
 
-		let output = Command::new("git")
-			.args(["add", "."])
-			.current_dir(&repo.path)
-			.output()
-			.expect("failed to execute git add");
-		assert!(output.status.success(), "git add failed {:?}", output);
+        let output = Command::new("git")
+            .args(["add", "."])
+            .current_dir(&repo.path)
+            .output()
+            .expect("failed to execute git add");
+        assert!(output.status.success(), "git add failed {:?}", output);
 
-		let output = Command::new("git")
-			.args(["commit", "--no-gpg-sign", "-m", "test commit"])
-			.current_dir(&repo.path)
-			.output()
-			.expect("failed to execute git commit");
-		assert!(output.status.success(), "git commit failed {:?}", output);
+        let output = Command::new("git")
+            .args(["commit", "--no-gpg-sign", "-m", "test commit"])
+            .current_dir(&repo.path)
+            .output()
+            .expect("failed to execute git commit");
+        assert!(output.status.success(), "git commit failed {:?}", output);
 
-		repo.inner
-			.head()
-			.and_then(|head| head.peel_to_commit())
-			.expect("failed to get the last commit")
-	}
+        repo.inner
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("failed to get the last commit")
+    }
 
-	#[test]
-	fn test_should_retain_commit() {
-		let (repo, _temp_dir) = create_temp_repo();
+    #[test]
+    fn test_should_retain_commit() {
+        let (repo, _temp_dir) = create_temp_repo();
 
-		let new_pattern = |input: &str| {
-			Repository::normalize_pattern(
-				Pattern::new(input).expect("valid pattern"),
-			)
-		};
+        let new_pattern = |input: &str| {
+            Repository::normalize_pattern(Pattern::new(input).expect("valid pattern"))
+        };
 
-		let first_commit = create_commit_with_files(&repo, vec![
-			("initial.txt", "initial content"),
-			("dir/initial.txt", "initial content"),
-		]);
+        let first_commit = create_commit_with_files(&repo, vec![
+            ("initial.txt", "initial content"),
+            ("dir/initial.txt", "initial content"),
+        ]);
 
-		{
-			let retain = repo.should_retain_commit(
-				&first_commit,
-				&Some(vec![new_pattern("dir/")]),
-				&None,
-			);
-			assert!(retain, "include: dir/");
-		}
+        {
+            let retain =
+                repo.should_retain_commit(&first_commit, &Some(vec![new_pattern("dir/")]), &None);
+            assert!(retain, "include: dir/");
+        }
 
-		let commit = create_commit_with_files(&repo, vec![
-			("file1.txt", "content1"),
-			("file2.txt", "content2"),
-			("dir/file3.txt", "content3"),
-			("dir/subdir/file4.txt", "content4"),
-		]);
+        let commit = create_commit_with_files(&repo, vec![
+            ("file1.txt", "content1"),
+            ("file2.txt", "content2"),
+            ("dir/file3.txt", "content3"),
+            ("dir/subdir/file4.txt", "content4"),
+        ]);
 
-		{
-			let retain = repo.should_retain_commit(&commit, &None, &None);
-			assert!(retain, "no include/exclude patterns");
-		}
+        {
+            let retain = repo.should_retain_commit(&commit, &None, &None);
+            assert!(retain, "no include/exclude patterns");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("./")]),
-				&None,
-			);
-			assert!(retain, "include: ./");
-		}
+        {
+            let retain = repo.should_retain_commit(&commit, &Some(vec![new_pattern("./")]), &None);
+            assert!(retain, "include: ./");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("**")]),
-				&None,
-			);
-			assert!(retain, "include: **");
-		}
+        {
+            let retain = repo.should_retain_commit(&commit, &Some(vec![new_pattern("**")]), &None);
+            assert!(retain, "include: **");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("*")]),
-				&None,
-			);
-			assert!(retain, "include: *");
-		}
+        {
+            let retain = repo.should_retain_commit(&commit, &Some(vec![new_pattern("*")]), &None);
+            assert!(retain, "include: *");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("dir/")]),
-				&None,
-			);
-			assert!(retain, "include: dir/");
-		}
+        {
+            let retain =
+                repo.should_retain_commit(&commit, &Some(vec![new_pattern("dir/")]), &None);
+            assert!(retain, "include: dir/");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("dir/*")]),
-				&None,
-			);
-			assert!(retain, "include: dir/*");
-		}
+        {
+            let retain =
+                repo.should_retain_commit(&commit, &Some(vec![new_pattern("dir/*")]), &None);
+            assert!(retain, "include: dir/*");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("file1.txt")]),
-				&None,
-			);
-			assert!(retain, "include: file1.txt");
-		}
+        {
+            let retain =
+                repo.should_retain_commit(&commit, &Some(vec![new_pattern("file1.txt")]), &None);
+            assert!(retain, "include: file1.txt");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&None,
-				&Some(vec![new_pattern("file1.txt")]),
-			);
-			assert!(retain, "exclude: file1.txt");
-		}
+        {
+            let retain =
+                repo.should_retain_commit(&commit, &None, &Some(vec![new_pattern("file1.txt")]));
+            assert!(retain, "exclude: file1.txt");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&Some(vec![new_pattern("file1.txt")]),
-				&Some(vec![new_pattern("file2.txt")]),
-			);
-			assert!(retain, "include: file1.txt, exclude: file2.txt");
-		}
+        {
+            let retain = repo.should_retain_commit(
+                &commit,
+                &Some(vec![new_pattern("file1.txt")]),
+                &Some(vec![new_pattern("file2.txt")]),
+            );
+            assert!(retain, "include: file1.txt, exclude: file2.txt");
+        }
 
-		{
-			let retain = repo.should_retain_commit(
-				&commit,
-				&None,
-				&Some(vec![new_pattern("**/*.txt")]),
-			);
-			assert!(!retain, "exclude: **/*.txt");
-		}
-	}
+        {
+            let retain =
+                repo.should_retain_commit(&commit, &None, &Some(vec![new_pattern("**/*.txt")]));
+            assert!(!retain, "exclude: **/*.txt");
+        }
+    }
 }

--- a/git-cliff-core/src/statistics.rs
+++ b/git-cliff-core/src/statistics.rs
@@ -10,301 +10,288 @@ use crate::release::Release;
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkCount {
-	/// Text of the link.
-	pub text:  String,
-	/// URL of the link.
-	pub href:  String,
-	/// The number of times this link was referenced.
-	pub count: usize,
+    /// Text of the link.
+    pub text: String,
+    /// URL of the link.
+    pub href: String,
+    /// The number of times this link was referenced.
+    pub count: usize,
 }
 
 /// Aggregated statistics about commits in the release.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Statistics {
-	/// The total number of commits included in the release.
-	pub commit_count: usize,
-	/// The time span, in days, from the first to the last commit in the
-	/// release. Only present if there is more than one commit.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub commits_timespan: Option<i64>,
-	/// The number of commits that follow the Conventional Commits
-	/// specification.
-	pub conventional_commit_count: usize,
-	/// The number of times each link was referenced in commit messages.
-	pub links: Vec<LinkCount>,
-	/// The number of days since the previous release.
-	/// Only present if this is not the first release.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub days_passed_since_last_release: Option<i64>,
+    /// The total number of commits included in the release.
+    pub commit_count: usize,
+    /// The time span, in days, from the first to the last commit in the
+    /// release. Only present if there is more than one commit.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commits_timespan: Option<i64>,
+    /// The number of commits that follow the Conventional Commits
+    /// specification.
+    pub conventional_commit_count: usize,
+    /// The number of times each link was referenced in commit messages.
+    pub links: Vec<LinkCount>,
+    /// The number of days since the previous release.
+    /// Only present if this is not the first release.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub days_passed_since_last_release: Option<i64>,
 }
 
 impl From<&Release<'_>> for Statistics {
-	/// Aggregates various statistics from the release data.
-	///
-	/// This method computes several metrics based on the current release and
-	/// its commits:
-	///
-	/// - Counts the total number of commits.
-	/// - Determines the number of days between the first and last commit.
-	/// - Counts the number of commits that follow the Conventional Commits
-	///   specification.
-	/// - Tallies how many times each link appears across all commit messages.
-	/// - Calculates the number of days since the previous release, if
-	///   available.
-	fn from(release: &Release) -> Self {
-		let commit_count = release.commits.len();
-		let commits_timespan = if release.commits.len() < 2 {
-			trace!(
-				"commits_timespan: insufficient commits to calculate duration \
-				 (found {})",
-				release.commits.len()
-			);
-			None
-		} else {
-			release
-				.commits
-				.iter()
-				.min_by_key(|c| c.committer.timestamp)
-				.zip(release.commits.iter().max_by_key(|c| c.committer.timestamp))
-				.and_then(|(first, last)| {
-					Utc.timestamp_opt(first.committer.timestamp, 0)
-						.single()
-						.zip(Utc.timestamp_opt(last.committer.timestamp, 0).single())
-						.map(|(start, end)| {
-							(end.date_naive() - start.date_naive()).num_days()
-						})
-				})
-		};
-		let conventional_commit_count =
-			release.commits.iter().filter(|c| c.conv.is_some()).count();
-		let mut links: Vec<LinkCount> = release
-			.commits
-			.iter()
-			.fold(HashMap::new(), |mut acc, c| {
-				for link in &c.links {
-					*acc.entry((link.text.clone(), link.href.clone()))
-						.or_insert(0) += 1;
-				}
-				acc
-			})
-			.into_iter()
-			.map(|((text, href), count)| LinkCount { text, href, count })
-			.collect();
-		links.sort_by(|lhs, rhs| {
-			rhs.count
-				.cmp(&lhs.count)
-				.then_with(|| lhs.text.cmp(&rhs.text))
-				.then_with(|| lhs.href.cmp(&rhs.href))
-		});
-		let days_passed_since_last_release = match release.previous.as_ref() {
-			Some(prev) => release
-				.timestamp
-				.map(|ts| Utc.timestamp_opt(ts, 0))
-				.unwrap_or_else(|| {
-					let now = Utc::now();
-					Utc.timestamp_opt(now.timestamp(), 0)
-				})
-				.single()
-				.zip(
-					prev.timestamp
-						.and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
-				)
-				.map(|(curr, prev)| {
-					(curr.date_naive() - prev.date_naive()).num_days()
-				}),
-			None => {
-				trace!("days_passed_since_last_release: previous release not found");
-				None
-			}
-		};
-		Self {
-			commit_count,
-			commits_timespan,
-			conventional_commit_count,
-			links,
-			days_passed_since_last_release,
-		}
-	}
+    /// Aggregates various statistics from the release data.
+    ///
+    /// This method computes several metrics based on the current release and
+    /// its commits:
+    ///
+    /// - Counts the total number of commits.
+    /// - Determines the number of days between the first and last commit.
+    /// - Counts the number of commits that follow the Conventional Commits specification.
+    /// - Tallies how many times each link appears across all commit messages.
+    /// - Calculates the number of days since the previous release, if available.
+    fn from(release: &Release) -> Self {
+        let commit_count = release.commits.len();
+        let commits_timespan = if release.commits.len() < 2 {
+            trace!(
+                "commits_timespan: insufficient commits to calculate duration (found {})",
+                release.commits.len()
+            );
+            None
+        } else {
+            release
+                .commits
+                .iter()
+                .min_by_key(|c| c.committer.timestamp)
+                .zip(release.commits.iter().max_by_key(|c| c.committer.timestamp))
+                .and_then(|(first, last)| {
+                    Utc.timestamp_opt(first.committer.timestamp, 0)
+                        .single()
+                        .zip(Utc.timestamp_opt(last.committer.timestamp, 0).single())
+                        .map(|(start, end)| (end.date_naive() - start.date_naive()).num_days())
+                })
+        };
+        let conventional_commit_count = release.commits.iter().filter(|c| c.conv.is_some()).count();
+        let mut links: Vec<LinkCount> = release
+            .commits
+            .iter()
+            .fold(HashMap::new(), |mut acc, c| {
+                for link in &c.links {
+                    *acc.entry((link.text.clone(), link.href.clone()))
+                        .or_insert(0) += 1;
+                }
+                acc
+            })
+            .into_iter()
+            .map(|((text, href), count)| LinkCount { text, href, count })
+            .collect();
+        links.sort_by(|lhs, rhs| {
+            rhs.count
+                .cmp(&lhs.count)
+                .then_with(|| lhs.text.cmp(&rhs.text))
+                .then_with(|| lhs.href.cmp(&rhs.href))
+        });
+        let days_passed_since_last_release = match release.previous.as_ref() {
+            Some(prev) => release
+                .timestamp
+                .map(|ts| Utc.timestamp_opt(ts, 0))
+                .unwrap_or_else(|| {
+                    let now = Utc::now();
+                    Utc.timestamp_opt(now.timestamp(), 0)
+                })
+                .single()
+                .zip(
+                    prev.timestamp
+                        .and_then(|ts| Utc.timestamp_opt(ts, 0).single()),
+                )
+                .map(|(curr, prev)| (curr.date_naive() - prev.date_naive()).num_days()),
+            None => {
+                trace!("days_passed_since_last_release: previous release not found");
+                None
+            }
+        };
+        Self {
+            commit_count,
+            commits_timespan,
+            conventional_commit_count,
+            links,
+            days_passed_since_last_release,
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use lazy_regex::Regex;
-	use pretty_assertions::assert_eq;
+    use lazy_regex::Regex;
+    use pretty_assertions::assert_eq;
 
-	use super::*;
-	use crate::commit::{Commit, Signature};
-	use crate::config::LinkParser;
-	use crate::error::Result;
-	use crate::release::Release;
-	#[test]
-	fn from_release() -> Result<()> {
-		fn find_count(v: &[LinkCount], text: &str, href: &str) -> Option<usize> {
-			v.iter()
-				.find(|l| l.text == text && l.href == href)
-				.map(|l| l.count)
-		}
-		let link_parsers = vec![
-			LinkParser {
-				pattern: Regex::new("RFC(\\d+)")?,
-				href:    String::from("rfc://$1"),
-				text:    None,
-			},
-			LinkParser {
-				pattern: Regex::new("#(\\d+)")?,
-				href:    String::from("https://github.com/$1"),
-				text:    None,
-			},
-		];
-		let unconventional_commits = vec![
-			Commit {
-				id: String::from("123123"),
-				message: String::from("add feature"),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649201111,
-				},
-				..Default::default()
-			},
-			Commit {
-				id: String::from("123123"),
-				message: String::from("fix feature"),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649201112,
-				},
-				..Default::default()
-			},
-			Commit {
-				id: String::from("123123"),
-				message: String::from("refactor feature"),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649201113,
-				},
-				..Default::default()
-			},
-			Commit {
-				id: String::from("123123"),
-				message: String::from("add docs for RFC456-related feature"),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649201114,
-				},
-				..Default::default()
-			},
-		];
-		let conventional_commits = vec![
-			Commit {
-				id: String::from("123123"),
-				message: String::from(
-					"perf: improve feature performance, fixes #455",
-				),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649287515,
-				},
-				..Default::default()
-			},
-			Commit {
-				id: String::from("123123"),
-				message: String::from("style(schema): fix feature schema"),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649287516,
-				},
-				..Default::default()
-			},
-			Commit {
-				id: String::from("123123"),
-				message: String::from(
-					"test: add unit tests for RFC456-related feature",
-				),
-				committer: Signature {
-					name:      Some(String::from("John Doe")),
-					email:     Some(String::from("john@doe.com")),
-					timestamp: 1649287517,
-				},
-				..Default::default()
-			},
-		];
-		let commits: Vec<Commit> =
-			[unconventional_commits.clone(), conventional_commits.clone()]
-				.concat()
-				.into_iter()
-				.map(|c| c.parse_links(&link_parsers))
-				.map(|c| c.clone().into_conventional().unwrap_or(c))
-				.collect();
-		let release = Release {
-			commits,
-			timestamp: Some(1649373910),
-			previous: Some(Box::new(Release {
-				timestamp: Some(1649201110),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			..Default::default()
-		};
+    use super::*;
+    use crate::commit::{Commit, Signature};
+    use crate::config::LinkParser;
+    use crate::error::Result;
+    use crate::release::Release;
+    #[test]
+    fn from_release() -> Result<()> {
+        fn find_count(v: &[LinkCount], text: &str, href: &str) -> Option<usize> {
+            v.iter()
+                .find(|l| l.text == text && l.href == href)
+                .map(|l| l.count)
+        }
+        let link_parsers = vec![
+            LinkParser {
+                pattern: Regex::new("RFC(\\d+)")?,
+                href: String::from("rfc://$1"),
+                text: None,
+            },
+            LinkParser {
+                pattern: Regex::new("#(\\d+)")?,
+                href: String::from("https://github.com/$1"),
+                text: None,
+            },
+        ];
+        let unconventional_commits = vec![
+            Commit {
+                id: String::from("123123"),
+                message: String::from("add feature"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649201111,
+                },
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("123123"),
+                message: String::from("fix feature"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649201112,
+                },
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("123123"),
+                message: String::from("refactor feature"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649201113,
+                },
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("123123"),
+                message: String::from("add docs for RFC456-related feature"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649201114,
+                },
+                ..Default::default()
+            },
+        ];
+        let conventional_commits = vec![
+            Commit {
+                id: String::from("123123"),
+                message: String::from("perf: improve feature performance, fixes #455"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649287515,
+                },
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("123123"),
+                message: String::from("style(schema): fix feature schema"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649287516,
+                },
+                ..Default::default()
+            },
+            Commit {
+                id: String::from("123123"),
+                message: String::from("test: add unit tests for RFC456-related feature"),
+                committer: Signature {
+                    name: Some(String::from("John Doe")),
+                    email: Some(String::from("john@doe.com")),
+                    timestamp: 1649287517,
+                },
+                ..Default::default()
+            },
+        ];
+        let commits: Vec<Commit> = [unconventional_commits.clone(), conventional_commits.clone()]
+            .concat()
+            .into_iter()
+            .map(|c| c.parse_links(&link_parsers))
+            .map(|c| c.clone().into_conventional().unwrap_or(c))
+            .collect();
+        let release = Release {
+            commits,
+            timestamp: Some(1649373910),
+            previous: Some(Box::new(Release {
+                timestamp: Some(1649201110),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            ..Default::default()
+        };
 
-		let statistics = Statistics::from(&release);
-		assert_eq!(release.commits.len(), statistics.commit_count);
-		assert_eq!(Some(1), statistics.commits_timespan);
-		assert_eq!(
-			conventional_commits.len(),
-			statistics.conventional_commit_count
-		);
-		assert_eq!(
-			Some(2),
-			find_count(&statistics.links, "RFC456", "rfc://456")
-		);
-		assert_eq!(
-			Some(1),
-			find_count(&statistics.links, "#455", "https://github.com/455")
-		);
-		assert_eq!(Some(2), statistics.days_passed_since_last_release);
+        let statistics = Statistics::from(&release);
+        assert_eq!(release.commits.len(), statistics.commit_count);
+        assert_eq!(Some(1), statistics.commits_timespan);
+        assert_eq!(
+            conventional_commits.len(),
+            statistics.conventional_commit_count
+        );
+        assert_eq!(
+            Some(2),
+            find_count(&statistics.links, "RFC456", "rfc://456")
+        );
+        assert_eq!(
+            Some(1),
+            find_count(&statistics.links, "#455", "https://github.com/455")
+        );
+        assert_eq!(Some(2), statistics.days_passed_since_last_release);
 
-		let commits = vec![Commit {
-			id: String::from("123123"),
-			message: String::from("add feature"),
-			committer: Signature {
-				name:      Some(String::from("John Doe")),
-				email:     Some(String::from("john@doe.com")),
-				timestamp: 1649201111,
-			},
-			..Default::default()
-		}];
-		let release = Release {
-			commits,
-			timestamp: Some(1649373910),
-			previous: Some(Box::new(Release {
-				timestamp: Some(1649201110),
-				..Default::default()
-			})),
-			repository: Some(String::from("/root/repo")),
-			..Default::default()
-		};
+        let commits = vec![Commit {
+            id: String::from("123123"),
+            message: String::from("add feature"),
+            committer: Signature {
+                name: Some(String::from("John Doe")),
+                email: Some(String::from("john@doe.com")),
+                timestamp: 1649201111,
+            },
+            ..Default::default()
+        }];
+        let release = Release {
+            commits,
+            timestamp: Some(1649373910),
+            previous: Some(Box::new(Release {
+                timestamp: Some(1649201110),
+                ..Default::default()
+            })),
+            repository: Some(String::from("/root/repo")),
+            ..Default::default()
+        };
 
-		let statistics = Statistics::from(&release);
-		assert_eq!(None, statistics.commits_timespan);
+        let statistics = Statistics::from(&release);
+        assert_eq!(None, statistics.commits_timespan);
 
-		let commits = vec![];
-		let release = Release {
-			commits,
-			timestamp: Some(1649373910),
-			previous: None,
-			repository: Some(String::from("/root/repo")),
-			..Default::default()
-		};
+        let commits = vec![];
+        let release = Release {
+            commits,
+            timestamp: Some(1649373910),
+            previous: None,
+            repository: Some(String::from("/root/repo")),
+            ..Default::default()
+        };
 
-		let statistics = Statistics::from(&release);
-		assert_eq!(None, statistics.days_passed_since_last_release);
+        let statistics = Statistics::from(&release);
+        assert_eq!(None, statistics.days_passed_since_last_release);
 
-		Ok(())
-	}
+        Ok(())
+    }
 }

--- a/git-cliff-core/src/tag.rs
+++ b/git-cliff-core/src/tag.rs
@@ -3,45 +3,45 @@
 /// Lightweight tags will have `None` as message.
 #[derive(Debug)]
 pub struct Tag {
-	/// The name of the tag
-	pub name:    String,
-	/// The message of the tag (only if it was annotated).
-	pub message: Option<String>,
+    /// The name of the tag
+    pub name: String,
+    /// The message of the tag (only if it was annotated).
+    pub message: Option<String>,
 }
 
 #[cfg(test)]
 mod test {
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn create_tag_with_name_and_message() {
-		let tag = Tag {
-			name:    String::from("v1.0"),
-			message: Some(String::from("Initial release")),
-		};
-		assert_eq!(tag.name, "v1.0");
-		assert_eq!(tag.message, Some(String::from("Initial release")));
-	}
+    #[test]
+    fn create_tag_with_name_and_message() {
+        let tag = Tag {
+            name: String::from("v1.0"),
+            message: Some(String::from("Initial release")),
+        };
+        assert_eq!(tag.name, "v1.0");
+        assert_eq!(tag.message, Some(String::from("Initial release")));
+    }
 
-	#[test]
-	fn create_tag_with_name_and_no_message() {
-		let tag = Tag {
-			name:    String::from("v1.0"),
-			message: None,
-		};
-		assert_eq!(tag.name, "v1.0");
-		assert_eq!(tag.message, None);
-	}
+    #[test]
+    fn create_tag_with_name_and_no_message() {
+        let tag = Tag {
+            name: String::from("v1.0"),
+            message: None,
+        };
+        assert_eq!(tag.name, "v1.0");
+        assert_eq!(tag.message, None);
+    }
 
-	#[test]
-	fn debug_print_tag_with_message() {
-		let tag = Tag {
-			name:    String::from("v1.0"),
-			message: Some(String::from("Initial release")),
-		};
-		assert_eq!(
-			format!("{:?}", tag),
-			"Tag { name: \"v1.0\", message: Some(\"Initial release\") }"
-		);
-	}
+    #[test]
+    fn debug_print_tag_with_message() {
+        let tag = Tag {
+            name: String::from("v1.0"),
+            message: Some(String::from("Initial release")),
+        };
+        assert_eq!(
+            format!("{:?}", tag),
+            "Tag { name: \"v1.0\", message: Some(\"Initial release\") }"
+        );
+    }
 }

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -10,297 +10,275 @@ use crate::error::{Error, Result};
 /// Wrapper for [`Tera`].
 #[derive(Debug)]
 pub struct Template {
-	/// Template name.
-	name:          String,
-	/// Internal Tera instance.
-	tera:          Tera,
-	/// Template variables.
-	#[cfg_attr(not(feature = "github"), allow(dead_code))]
-	pub variables: Vec<String>,
+    /// Template name.
+    name: String,
+    /// Internal Tera instance.
+    tera: Tera,
+    /// Template variables.
+    #[cfg_attr(not(feature = "github"), allow(dead_code))]
+    pub variables: Vec<String>,
 }
 
 impl Template {
-	/// Constructs a new instance.
-	pub fn new(name: &str, mut content: String, trim: bool) -> Result<Self> {
-		if trim {
-			content = content
-				.lines()
-				.map(|v| v.trim())
-				.collect::<Vec<&str>>()
-				.join("\n");
-		}
-		let mut tera = Tera::default();
-		if let Err(e) = tera.add_raw_template(name, &content) {
-			return if let Some(error_source) = e.source() {
-				Err(Error::TemplateParseError(error_source.to_string()))
-			} else {
-				Err(Error::TemplateError(e))
-			};
-		}
-		tera.register_filter("upper_first", Self::upper_first_filter);
-		Ok(Self {
-			name: name.to_string(),
-			variables: Self::get_template_variables(name, &tera)?,
-			tera,
-		})
-	}
+    /// Constructs a new instance.
+    pub fn new(name: &str, mut content: String, trim: bool) -> Result<Self> {
+        if trim {
+            content = content
+                .lines()
+                .map(|v| v.trim())
+                .collect::<Vec<&str>>()
+                .join("\n");
+        }
+        let mut tera = Tera::default();
+        if let Err(e) = tera.add_raw_template(name, &content) {
+            return if let Some(error_source) = e.source() {
+                Err(Error::TemplateParseError(error_source.to_string()))
+            } else {
+                Err(Error::TemplateError(e))
+            };
+        }
+        tera.register_filter("upper_first", Self::upper_first_filter);
+        Ok(Self {
+            name: name.to_string(),
+            variables: Self::get_template_variables(name, &tera)?,
+            tera,
+        })
+    }
 
-	/// Filter for making the first character of a string uppercase.
-	fn upper_first_filter(
-		value: &Value,
-		_: &HashMap<String, Value>,
-	) -> TeraResult<Value> {
-		let mut s =
-			tera::try_get_value!("upper_first_filter", "value", String, value);
-		let mut c = s.chars();
-		s = match c.next() {
-			None => String::new(),
-			Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-		};
-		Ok(tera::to_value(&s)?)
-	}
+    /// Filter for making the first character of a string uppercase.
+    fn upper_first_filter(value: &Value, _: &HashMap<String, Value>) -> TeraResult<Value> {
+        let mut s = tera::try_get_value!("upper_first_filter", "value", String, value);
+        let mut c = s.chars();
+        s = match c.next() {
+            None => String::new(),
+            Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+        };
+        Ok(tera::to_value(&s)?)
+    }
 
-	/// Recursively finds the identifiers from the AST.
-	fn find_identifiers(node: &ast::Node, names: &mut HashSet<String>) {
-		match node {
-			ast::Node::Block(_, block, _) => {
-				for node in &block.body {
-					Self::find_identifiers(node, names);
-				}
-			}
-			ast::Node::VariableBlock(_, expr) => {
-				if let ast::ExprVal::Ident(v) = &expr.val {
-					names.insert(v.clone());
-				}
-			}
-			ast::Node::MacroDefinition(_, def, _) => {
-				for node in &def.body {
-					Self::find_identifiers(node, names);
-				}
-			}
-			ast::Node::FilterSection(_, section, _) => {
-				for node in &section.body {
-					Self::find_identifiers(node, names);
-				}
-			}
-			ast::Node::Forloop(_, forloop, _) => {
-				if let ast::ExprVal::Ident(v) = &forloop.container.val {
-					names.insert(v.clone());
-				}
-				for node in &forloop.body {
-					Self::find_identifiers(node, names);
-				}
-				for node in &forloop.empty_body.clone().unwrap_or_default() {
-					Self::find_identifiers(node, names);
-				}
-				for (_, expr) in
-					forloop.container.filters.iter().flat_map(|v| v.args.iter())
-				{
-					if let ast::ExprVal::String(ref v) = expr.val {
-						names.insert(v.clone());
-					}
-				}
-			}
-			ast::Node::If(cond, _) => {
-				for (_, expr, nodes) in &cond.conditions {
-					if let ast::ExprVal::Ident(v) = &expr.val {
-						names.insert(v.clone());
-					}
-					for node in nodes {
-						Self::find_identifiers(node, names);
-					}
-				}
-				if let Some((_, nodes)) = &cond.otherwise {
-					for node in nodes {
-						Self::find_identifiers(node, names);
-					}
-				}
-			}
-			_ => {}
-		}
-	}
+    /// Recursively finds the identifiers from the AST.
+    fn find_identifiers(node: &ast::Node, names: &mut HashSet<String>) {
+        match node {
+            ast::Node::Block(_, block, _) => {
+                for node in &block.body {
+                    Self::find_identifiers(node, names);
+                }
+            }
+            ast::Node::VariableBlock(_, expr) => {
+                if let ast::ExprVal::Ident(v) = &expr.val {
+                    names.insert(v.clone());
+                }
+            }
+            ast::Node::MacroDefinition(_, def, _) => {
+                for node in &def.body {
+                    Self::find_identifiers(node, names);
+                }
+            }
+            ast::Node::FilterSection(_, section, _) => {
+                for node in &section.body {
+                    Self::find_identifiers(node, names);
+                }
+            }
+            ast::Node::Forloop(_, forloop, _) => {
+                if let ast::ExprVal::Ident(v) = &forloop.container.val {
+                    names.insert(v.clone());
+                }
+                for node in &forloop.body {
+                    Self::find_identifiers(node, names);
+                }
+                for node in &forloop.empty_body.clone().unwrap_or_default() {
+                    Self::find_identifiers(node, names);
+                }
+                for (_, expr) in forloop.container.filters.iter().flat_map(|v| v.args.iter()) {
+                    if let ast::ExprVal::String(ref v) = expr.val {
+                        names.insert(v.clone());
+                    }
+                }
+            }
+            ast::Node::If(cond, _) => {
+                for (_, expr, nodes) in &cond.conditions {
+                    if let ast::ExprVal::Ident(v) = &expr.val {
+                        names.insert(v.clone());
+                    }
+                    for node in nodes {
+                        Self::find_identifiers(node, names);
+                    }
+                }
+                if let Some((_, nodes)) = &cond.otherwise {
+                    for node in nodes {
+                        Self::find_identifiers(node, names);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
 
-	/// Returns the variable names that are used in the template.
-	fn get_template_variables(name: &str, tera: &Tera) -> Result<Vec<String>> {
-		let mut variables = HashSet::new();
-		let ast = &tera.get_template(name)?.ast;
-		for node in ast {
-			Self::find_identifiers(node, &mut variables);
-		}
-		trace!("Template variables for {name}: {variables:?}");
-		Ok(variables.into_iter().collect())
-	}
+    /// Returns the variable names that are used in the template.
+    fn get_template_variables(name: &str, tera: &Tera) -> Result<Vec<String>> {
+        let mut variables = HashSet::new();
+        let ast = &tera.get_template(name)?.ast;
+        for node in ast {
+            Self::find_identifiers(node, &mut variables);
+        }
+        trace!("Template variables for {name}: {variables:?}");
+        Ok(variables.into_iter().collect())
+    }
 
-	/// Returns `true` if the template contains one of the given variables.
-	pub(crate) fn contains_variable(&self, variables: &[&str]) -> bool {
-		variables
-			.iter()
-			.any(|var| self.variables.iter().any(|v| v.starts_with(var)))
-	}
+    /// Returns `true` if the template contains one of the given variables.
+    pub(crate) fn contains_variable(&self, variables: &[&str]) -> bool {
+        variables
+            .iter()
+            .any(|var| self.variables.iter().any(|v| v.starts_with(var)))
+    }
 
-	/// Renders the template.
-	pub fn render<C: Serialize, T: Serialize, S: Into<String> + Clone>(
-		&self,
-		context: &C,
-		additional_context: Option<&HashMap<S, T>>,
-		postprocessors: &[TextProcessor],
-	) -> Result<String> {
-		let mut context = TeraContext::from_serialize(context)?;
-		if let Some(additional_context) = additional_context {
-			for (key, value) in additional_context {
-				context.insert(key.clone(), &value);
-			}
-		}
-		match self.tera.render(&self.name, &context) {
-			Ok(mut v) => {
-				for postprocessor in postprocessors {
-					postprocessor.replace(&mut v, vec![])?;
-				}
-				Ok(v)
-			}
-			Err(e) => {
-				if let Some(source1) = e.source() {
-					if let Some(source2) = source1.source() {
-						Err(Error::TemplateRenderDetailedError(
-							source1.to_string(),
-							source2.to_string(),
-						))
-					} else {
-						Err(Error::TemplateRenderError(source1.to_string()))
-					}
-				} else {
-					Err(Error::TemplateError(e))
-				}
-			}
-		}
-	}
+    /// Renders the template.
+    pub fn render<C: Serialize, T: Serialize, S: Into<String> + Clone>(
+        &self,
+        context: &C,
+        additional_context: Option<&HashMap<S, T>>,
+        postprocessors: &[TextProcessor],
+    ) -> Result<String> {
+        let mut context = TeraContext::from_serialize(context)?;
+        if let Some(additional_context) = additional_context {
+            for (key, value) in additional_context {
+                context.insert(key.clone(), &value);
+            }
+        }
+        match self.tera.render(&self.name, &context) {
+            Ok(mut v) => {
+                for postprocessor in postprocessors {
+                    postprocessor.replace(&mut v, vec![])?;
+                }
+                Ok(v)
+            }
+            Err(e) => {
+                if let Some(source1) = e.source() {
+                    if let Some(source2) = source1.source() {
+                        Err(Error::TemplateRenderDetailedError(
+                            source1.to_string(),
+                            source2.to_string(),
+                        ))
+                    } else {
+                        Err(Error::TemplateRenderError(source1.to_string()))
+                    }
+                } else {
+                    Err(Error::TemplateError(e))
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use regex::Regex;
+    use regex::Regex;
 
-	use super::*;
-	use crate::commit::Commit;
-	use crate::release::Release;
+    use super::*;
+    use crate::commit::Commit;
+    use crate::release::Release;
 
-	fn get_fake_release_data() -> Release<'static> {
-		Release {
-			version: Some(String::from("1.0")),
-			message: None,
-			extra: None,
-			commits: vec![
-				Commit::new(
-					String::from("123123"),
-					String::from("feat(xyz): add xyz"),
-				),
-				Commit::new(
-					String::from("124124"),
-					String::from("fix(abc): fix abc"),
-				),
-			]
-			.into_iter()
-			.filter_map(|c| c.into_conventional().ok())
-			.collect(),
-			commit_range: None,
-			commit_id: None,
-			timestamp: None,
-			previous: None,
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: crate::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		}
-	}
+    fn get_fake_release_data() -> Release<'static> {
+        Release {
+            version: Some(String::from("1.0")),
+            message: None,
+            extra: None,
+            commits: vec![
+                Commit::new(String::from("123123"), String::from("feat(xyz): add xyz")),
+                Commit::new(String::from("124124"), String::from("fix(abc): fix abc")),
+            ]
+            .into_iter()
+            .filter_map(|c| c.into_conventional().ok())
+            .collect(),
+            commit_range: None,
+            commit_id: None,
+            timestamp: None,
+            previous: None,
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: crate::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        }
+    }
 
-	#[test]
-	fn render_template() -> Result<()> {
-		let template = r#"
+    #[test]
+    fn render_template() -> Result<()> {
+        let template = r#"
 		## {{ version }} - <DATE>
 		{% for commit in commits %}
 		### {{ commit.group }}
 		- {{ commit.message | upper_first }}
 		{% endfor %}"#;
-		let mut template = Template::new("test", template.to_string(), false)?;
-		let release = get_fake_release_data();
-		assert_eq!(
-			"\n\t\t## 1.0 - 2023\n\t\t\n\t\t### feat\n\t\t- Add xyz\n\t\t\n\t\t### \
-			 fix\n\t\t- Fix abc\n\t\t",
-			template.render(
-				&release,
-				Option::<HashMap<&str, String>>::None.as_ref(),
-				&[TextProcessor {
-					pattern:         Regex::new("<DATE>")
-						.expect("failed to compile regex"),
-					replace:         Some(String::from("2023")),
-					replace_command: None,
-				}],
-			)?
-		);
-		template.variables.sort();
-		assert_eq!(
-			vec![
-				String::from("commit.group"),
-				String::from("commit.message"),
-				String::from("commits"),
-				String::from("version"),
-			],
-			template.variables
-		);
-		#[cfg(feature = "github")]
-		{
-			assert!(!template.contains_variable(&["commit.github"]));
-			assert!(template.contains_variable(&["commit.group"]));
-		}
-		Ok(())
-	}
+        let mut template = Template::new("test", template.to_string(), false)?;
+        let release = get_fake_release_data();
+        assert_eq!(
+            "\n\t\t## 1.0 - 2023\n\t\t\n\t\t### feat\n\t\t- Add xyz\n\t\t\n\t\t### fix\n\t\t- Fix \
+             abc\n\t\t",
+            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
+                TextProcessor {
+                    pattern: Regex::new("<DATE>").expect("failed to compile regex"),
+                    replace: Some(String::from("2023")),
+                    replace_command: None,
+                }
+            ],)?
+        );
+        template.variables.sort();
+        assert_eq!(
+            vec![
+                String::from("commit.group"),
+                String::from("commit.message"),
+                String::from("commits"),
+                String::from("version"),
+            ],
+            template.variables
+        );
+        #[cfg(feature = "github")]
+        {
+            assert!(!template.contains_variable(&["commit.github"]));
+            assert!(template.contains_variable(&["commit.group"]));
+        }
+        Ok(())
+    }
 
-	#[test]
-	fn render_trimmed_template() -> Result<()> {
-		let template = r#"
+    #[test]
+    fn render_trimmed_template() -> Result<()> {
+        let template = r#"
 		##  {{ version }}
 		"#;
-		let template = Template::new("test", template.to_string(), true)?;
-		let release = get_fake_release_data();
-		assert_eq!(
-			"\n##  1.0\n",
-			template.render(
-				&release,
-				Option::<HashMap<&str, String>>::None.as_ref(),
-				&[],
-			)?
-		);
-		assert_eq!(vec![String::from("version"),], template.variables);
-		Ok(())
-	}
+        let template = Template::new("test", template.to_string(), true)?;
+        let release = get_fake_release_data();
+        assert_eq!(
+            "\n##  1.0\n",
+            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
+            ],)?
+        );
+        assert_eq!(vec![String::from("version"),], template.variables);
+        Ok(())
+    }
 
-	#[test]
-	fn test_upper_first_filter() -> Result<()> {
-		let template =
-			"{% set hello_variable = 'hello' %}{{ hello_variable | upper_first }}";
-		let release = get_fake_release_data();
-		let template = Template::new("test", template.to_string(), true)?;
-		let r = template.render(
-			&release,
-			Option::<HashMap<&str, String>>::None.as_ref(),
-			&[],
-		)?;
-		assert_eq!("Hello", r);
-		Ok(())
-	}
+    #[test]
+    fn test_upper_first_filter() -> Result<()> {
+        let template = "{% set hello_variable = 'hello' %}{{ hello_variable | upper_first }}";
+        let release = get_fake_release_data();
+        let template = Template::new("test", template.to_string(), true)?;
+        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
+        ])?;
+        assert_eq!("Hello", r);
+        Ok(())
+    }
 }

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use git_cliff_core::commit::{Commit, Range, Signature};
-use git_cliff_core::config::{
-	ChangelogConfig, CommitParser, GitConfig, LinkParser, TextProcessor,
-};
+use git_cliff_core::config::{ChangelogConfig, CommitParser, GitConfig, LinkParser, TextProcessor};
 use git_cliff_core::error::Result;
 use git_cliff_core::release::*;
 use git_cliff_core::template::Template;
@@ -13,10 +11,10 @@ use regex::Regex;
 
 #[test]
 fn generate_changelog() -> Result<()> {
-	let changelog_config = ChangelogConfig {
-		header:         Some(String::from("this is a changelog")),
-		body:           String::from(
-			r#"
+    let changelog_config = ChangelogConfig {
+        header: Some(String::from("this is a changelog")),
+        body: String::from(
+            r#"
 ## Release {{ version }} - <DATE>
 
 {{ commit_range.from }}..{{ commit_range.to }}
@@ -33,143 +31,143 @@ fn generate_changelog() -> Result<()> {
 {% endif -%}
 {% endfor -%}
 {% endfor %}"#,
-		),
-		footer:         Some(String::from("eoc - end of changelog")),
-		trim:           true,
-		render_always:  false,
-		postprocessors: [].to_vec(),
-		output:         None,
-	};
-	let git_config = GitConfig {
-		conventional_commits:     true,
-		require_conventional:     false,
-		filter_unconventional:    true,
-		split_commits:            false,
-		commit_preprocessors:     vec![TextProcessor {
-			pattern:         Regex::new(r"\(fixes (#[1-9]+)\)").unwrap(),
-			replace:         Some(String::from("[closes Issue${1}]")),
-			replace_command: None,
-		}],
-		commit_parsers:           vec![
-			CommitParser {
-				sha:           Some(String::from("coffee")),
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("I love coffee")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			},
-			CommitParser {
-				sha:           None,
-				message:       Regex::new("^feat").ok(),
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("shiny features")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			},
-			CommitParser {
-				sha:           None,
-				message:       Regex::new("^fix").ok(),
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("fix bugs")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			},
-			CommitParser {
-				sha:           None,
-				message:       Regex::new("^test").ok(),
-				body:          None,
-				footer:        None,
-				group:         None,
-				default_scope: None,
-				scope:         Some(String::from("tests")),
-				skip:          None,
-				field:         None,
-				pattern:       None,
-			},
-			CommitParser {
-				sha:           None,
-				message:       None,
-				body:          None,
-				footer:        None,
-				group:         Some(String::from("docs")),
-				default_scope: None,
-				scope:         None,
-				skip:          None,
-				field:         Some(String::from("author.name")),
-				pattern:       Regex::new("John Doe").ok(),
-			},
-		],
-		protect_breaking_commits: false,
-		filter_commits:           true,
-		tag_pattern:              None,
-		skip_tags:                None,
-		ignore_tags:              None,
-		count_tags:               None,
-		use_branch_tags:          false,
-		topo_order:               false,
-		topo_order_commits:       true,
-		sort_commits:             String::from("oldest"),
-		link_parsers:             vec![
-			LinkParser {
-				pattern: Regex::new("#(\\d+)").unwrap(),
-				href:    String::from("https://github.com/$1"),
-				text:    None,
-			},
-			LinkParser {
-				pattern: Regex::new("https://github.com/(.*)").unwrap(),
-				href:    String::from("https://github.com/$1"),
-				text:    Some(String::from("$1")),
-			},
-		],
-		limit_commits:            None,
-		recurse_submodules:       None,
-		include_paths:            Vec::new(),
-		exclude_paths:            Vec::new(),
-	};
+        ),
+        footer: Some(String::from("eoc - end of changelog")),
+        trim: true,
+        render_always: false,
+        postprocessors: [].to_vec(),
+        output: None,
+    };
+    let git_config = GitConfig {
+        conventional_commits: true,
+        require_conventional: false,
+        filter_unconventional: true,
+        split_commits: false,
+        commit_preprocessors: vec![TextProcessor {
+            pattern: Regex::new(r"\(fixes (#[1-9]+)\)").unwrap(),
+            replace: Some(String::from("[closes Issue${1}]")),
+            replace_command: None,
+        }],
+        commit_parsers: vec![
+            CommitParser {
+                sha: Some(String::from("coffee")),
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("I love coffee")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            },
+            CommitParser {
+                sha: None,
+                message: Regex::new("^feat").ok(),
+                body: None,
+                footer: None,
+                group: Some(String::from("shiny features")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            },
+            CommitParser {
+                sha: None,
+                message: Regex::new("^fix").ok(),
+                body: None,
+                footer: None,
+                group: Some(String::from("fix bugs")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            },
+            CommitParser {
+                sha: None,
+                message: Regex::new("^test").ok(),
+                body: None,
+                footer: None,
+                group: None,
+                default_scope: None,
+                scope: Some(String::from("tests")),
+                skip: None,
+                field: None,
+                pattern: None,
+            },
+            CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("docs")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("author.name")),
+                pattern: Regex::new("John Doe").ok(),
+            },
+        ],
+        protect_breaking_commits: false,
+        filter_commits: true,
+        tag_pattern: None,
+        skip_tags: None,
+        ignore_tags: None,
+        count_tags: None,
+        use_branch_tags: false,
+        topo_order: false,
+        topo_order_commits: true,
+        sort_commits: String::from("oldest"),
+        link_parsers: vec![
+            LinkParser {
+                pattern: Regex::new("#(\\d+)").unwrap(),
+                href: String::from("https://github.com/$1"),
+                text: None,
+            },
+            LinkParser {
+                pattern: Regex::new("https://github.com/(.*)").unwrap(),
+                href: String::from("https://github.com/$1"),
+                text: Some(String::from("$1")),
+            },
+        ],
+        limit_commits: None,
+        recurse_submodules: None,
+        include_paths: Vec::new(),
+        exclude_paths: Vec::new(),
+    };
 
-	let mut commit_with_author = Commit::new(
-		String::from("hjdfas32"),
-		String::from("docs(cool): testing author filtering"),
-	);
+    let mut commit_with_author = Commit::new(
+        String::from("hjdfas32"),
+        String::from("docs(cool): testing author filtering"),
+    );
 
-	commit_with_author.author = Signature {
-		name:      Some("John Doe".to_string()),
-		email:     None,
-		timestamp: 0x0,
-	};
+    commit_with_author.author = Signature {
+        name: Some("John Doe".to_string()),
+        email: None,
+        timestamp: 0x0,
+    };
 
-	let release_v1_commits = vec![
-		Commit::new(
-			String::from("0bc123"),
-			String::from("feat: add cool features"),
-		),
-		Commit::new(String::from("0werty"), String::from("fix: fix stuff")),
-		Commit::new(String::from("0w3rty"), String::from("fix: fix more stuff")),
-		Commit::new(String::from("0jkl12"), String::from("chore: do nothing")),
-	]
-	.into_iter()
-	.filter_map(|c| c.into_conventional().ok())
-	.collect::<Vec<Commit>>();
+    let release_v1_commits = vec![
+        Commit::new(
+            String::from("0bc123"),
+            String::from("feat: add cool features"),
+        ),
+        Commit::new(String::from("0werty"), String::from("fix: fix stuff")),
+        Commit::new(String::from("0w3rty"), String::from("fix: fix more stuff")),
+        Commit::new(String::from("0jkl12"), String::from("chore: do nothing")),
+    ]
+    .into_iter()
+    .filter_map(|c| c.into_conventional().ok())
+    .collect::<Vec<Commit>>();
 
-	let release_v1_commit_range = Range::new(
-		release_v1_commits.first().unwrap(),
-		release_v1_commits.last().unwrap(),
-	);
+    let release_v1_commit_range = Range::new(
+        release_v1_commits.first().unwrap(),
+        release_v1_commits.last().unwrap(),
+    );
 
-	let release_v2_commits = vec![
+    let release_v2_commits = vec![
 				Commit::new(
 					String::from("000abc"),
 					String::from("Add unconventional commit"),
@@ -210,97 +208,97 @@ fn generate_changelog() -> Result<()> {
 			.filter_map(|c| c.process(&git_config).ok())
 			.collect::<Vec<Commit>>();
 
-	let release_v2_commit_range = Range::new(
-		release_v2_commits.first().unwrap(),
-		release_v2_commits.last().unwrap(),
-	);
+    let release_v2_commit_range = Range::new(
+        release_v2_commits.first().unwrap(),
+        release_v2_commits.last().unwrap(),
+    );
 
-	let releases = vec![
-		Release {
-			version: Some(String::from("v2.0.0")),
-			message: None,
-			extra: None,
-			commits: release_v2_commits,
-			commit_range: Some(release_v2_commit_range),
-			commit_id: None,
-			timestamp: None,
-			previous: None,
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		},
-		Release {
-			version: Some(String::from("v1.0.0")),
-			message: None,
-			extra: None,
-			commits: release_v1_commits,
-			commit_range: Some(release_v1_commit_range),
-			commit_id: None,
-			timestamp: None,
-			previous: None,
-			repository: Some(String::from("/root/repo")),
-			submodule_commits: HashMap::new(),
-			statistics: None,
-			#[cfg(feature = "github")]
-			github: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitlab")]
-			gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "gitea")]
-			gitea: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-			#[cfg(feature = "bitbucket")]
-			bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
-				contributors: vec![],
-			},
-		},
-	];
+    let releases = vec![
+        Release {
+            version: Some(String::from("v2.0.0")),
+            message: None,
+            extra: None,
+            commits: release_v2_commits,
+            commit_range: Some(release_v2_commit_range),
+            commit_id: None,
+            timestamp: None,
+            previous: None,
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        },
+        Release {
+            version: Some(String::from("v1.0.0")),
+            message: None,
+            extra: None,
+            commits: release_v1_commits,
+            commit_range: Some(release_v1_commit_range),
+            commit_id: None,
+            timestamp: None,
+            previous: None,
+            repository: Some(String::from("/root/repo")),
+            submodule_commits: HashMap::new(),
+            statistics: None,
+            #[cfg(feature = "github")]
+            github: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitlab")]
+            gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "gitea")]
+            gitea: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+            #[cfg(feature = "bitbucket")]
+            bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
+                contributors: vec![],
+            },
+        },
+    ];
 
-	let out = &mut String::new();
-	let template = Template::new("test", changelog_config.body, false)?;
+    let out = &mut String::new();
+    let template = Template::new("test", changelog_config.body, false)?;
 
-	writeln!(out, "{}", changelog_config.header.unwrap()).unwrap();
-	let text_processors = [TextProcessor {
-		pattern:         Regex::new("<DATE>").unwrap(),
-		replace:         Some(String::from("2023")),
-		replace_command: None,
-	}];
-	for release in releases {
-		write!(
-			out,
-			"{}",
-			template.render(
-				&release,
-				Option::<HashMap<&str, String>>::None.as_ref(),
-				&text_processors
-			)?
-		)
-		.unwrap();
-	}
-	writeln!(out, "{}", changelog_config.footer.unwrap()).unwrap();
+    writeln!(out, "{}", changelog_config.header.unwrap()).unwrap();
+    let text_processors = [TextProcessor {
+        pattern: Regex::new("<DATE>").unwrap(),
+        replace: Some(String::from("2023")),
+        replace_command: None,
+    }];
+    for release in releases {
+        write!(
+            out,
+            "{}",
+            template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &text_processors
+            )?
+        )
+        .unwrap();
+    }
+    writeln!(out, "{}", changelog_config.footer.unwrap()).unwrap();
 
-	assert_eq!(
-		r#"this is a changelog
+    assert_eq!(
+        r#"this is a changelog
 
 ## Release v2.0.0 - 2023
 
@@ -338,8 +336,8 @@ abc123..hjdfas32
 - fix more stuff
 eoc - end of changelog
 "#,
-		out
-	);
+        out
+    );
 
-	Ok(())
+    Ok(())
 }

--- a/git-cliff/examples/run.rs
+++ b/git-cliff/examples/run.rs
@@ -3,7 +3,7 @@ use git_cliff::args::Opt;
 use git_cliff_core::error::Result;
 
 fn main() -> Result<()> {
-	let args = Opt::parse();
-	git_cliff::run(args)?;
-	Ok(())
+    let args = Opt::parse();
+    git_cliff::run(args)?;
+    Ok(())
 }

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -13,22 +13,22 @@ use url::Url;
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum Strip {
-	Header,
-	Footer,
-	All,
+    Header,
+    Footer,
+    All,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum Sort {
-	Oldest,
-	Newest,
+    Oldest,
+    Newest,
 }
 
 const STYLES: Styles = Styles::styled()
-	.header(Ansi256Color(208).on_default().bold())
-	.usage(Ansi256Color(208).on_default().bold())
-	.literal(AnsiColor::White.on_default())
-	.placeholder(AnsiColor::Green.on_default());
+    .header(Ansi256Color(208).on_default().bold())
+    .usage(Ansi256Color(208).on_default().bold())
+    .literal(AnsiColor::White.on_default())
+    .placeholder(AnsiColor::Green.on_default());
 
 /// Command-line arguments to parse.
 #[derive(Debug, Parser)]
@@ -52,7 +52,7 @@ const STYLES: Styles = Styles::styled()
     styles(STYLES),
 )]
 pub struct Opt {
-	#[arg(
+    #[arg(
 		short,
 		long,
 		action = ArgAction::Help,
@@ -60,8 +60,8 @@ pub struct Opt {
 		help = "Prints help information",
 		help_heading = "FLAGS"
 	)]
-	pub help:             Option<bool>,
-	#[arg(
+    pub help: Option<bool>,
+    #[arg(
 		short = 'V',
 		long,
 		action = ArgAction::Version,
@@ -69,21 +69,21 @@ pub struct Opt {
 		help = "Prints version information",
 		help_heading = "FLAGS"
 	)]
-	pub version:          Option<bool>,
-	/// Increases the logging verbosity.
-	#[arg(short, long, action = ArgAction::Count, alias = "debug", help_heading = Some("FLAGS"))]
-	pub verbose:          u8,
-	/// Writes the default configuration file to cliff.toml
-	#[arg(
+    pub version: Option<bool>,
+    /// Increases the logging verbosity.
+    #[arg(short, long, action = ArgAction::Count, alias = "debug", help_heading = Some("FLAGS"))]
+    pub verbose: u8,
+    /// Writes the default configuration file to cliff.toml
+    #[arg(
 	    short,
 	    long,
 	    value_name = "CONFIG",
 	    num_args = 0..=1,
 	    required = false
 	)]
-	pub init:             Option<Option<String>>,
-	/// Sets the configuration file.
-	#[arg(
+    pub init: Option<Option<String>>,
+    /// Sets the configuration file.
+    #[arg(
 	    short,
 	    long,
 	    env = "GIT_CLIFF_CONFIG",
@@ -91,21 +91,21 @@ pub struct Opt {
 	    default_value = DEFAULT_CONFIG,
 	    value_parser = Opt::parse_dir
 	)]
-	pub config:           PathBuf,
-	/// Sets the URL for the configuration file.
-	#[arg(long, env = "GIT_CLIFF_CONFIG_URL", value_name = "URL", hide = !cfg!(feature = "remote"))]
-	pub config_url:       Option<Url>,
-	/// Sets the working directory.
-	#[arg(
+    pub config: PathBuf,
+    /// Sets the URL for the configuration file.
+    #[arg(long, env = "GIT_CLIFF_CONFIG_URL", value_name = "URL", hide = !cfg!(feature = "remote"))]
+    pub config_url: Option<Url>,
+    /// Sets the working directory.
+    #[arg(
 	    short,
 	    long,
 	    env = "GIT_CLIFF_WORKDIR",
 	    value_name = "PATH",
 	    value_parser = Opt::parse_dir
 	)]
-	pub workdir:          Option<PathBuf>,
-	/// Sets the git repository.
-	#[arg(
+    pub workdir: Option<PathBuf>,
+    /// Sets the git repository.
+    #[arg(
 		short,
 		long,
 		env = "GIT_CLIFF_REPOSITORY",
@@ -113,67 +113,67 @@ pub struct Opt {
 		num_args(1..),
 		value_parser = Opt::parse_dir
 	)]
-	pub repository:       Option<Vec<PathBuf>>,
-	/// Sets the path to include related commits.
-	#[arg(
+    pub repository: Option<Vec<PathBuf>>,
+    /// Sets the path to include related commits.
+    #[arg(
 		long,
 		env = "GIT_CLIFF_INCLUDE_PATH",
 		value_name = "PATTERN",
 		num_args(1..)
 	)]
-	pub include_path:     Option<Vec<Pattern>>,
-	/// Sets the path to exclude related commits.
-	#[arg(
+    pub include_path: Option<Vec<Pattern>>,
+    /// Sets the path to exclude related commits.
+    #[arg(
 		long,
 		env = "GIT_CLIFF_EXCLUDE_PATH",
 		value_name = "PATTERN",
 		num_args(1..)
 	)]
-	pub exclude_path:     Option<Vec<Pattern>>,
-	/// Sets the regex for matching git tags.
-	#[arg(long, env = "GIT_CLIFF_TAG_PATTERN", value_name = "PATTERN")]
-	pub tag_pattern:      Option<Regex>,
-	/// Sets custom commit messages to include in the changelog.
-	#[arg(
+    pub exclude_path: Option<Vec<Pattern>>,
+    /// Sets the regex for matching git tags.
+    #[arg(long, env = "GIT_CLIFF_TAG_PATTERN", value_name = "PATTERN")]
+    pub tag_pattern: Option<Regex>,
+    /// Sets custom commit messages to include in the changelog.
+    #[arg(
 		long,
 		env = "GIT_CLIFF_WITH_COMMIT",
 		value_name = "MSG",
 		num_args(1..)
 	)]
-	pub with_commit:      Option<Vec<String>>,
-	/// Sets custom message for the latest release.
-	#[arg(
+    pub with_commit: Option<Vec<String>>,
+    /// Sets custom message for the latest release.
+    #[arg(
 		long,
 		env = "GIT_CLIFF_WITH_TAG_MESSAGE",
 		value_name = "MSG",
 		num_args = 0..=1,
 	)]
-	pub with_tag_message: Option<String>,
-	/// Sets the tags to ignore in the changelog.
-	#[arg(long, env = "GIT_CLIFF_IGNORE_TAGS", value_name = "PATTERN")]
-	pub ignore_tags:      Option<Regex>,
-	/// Sets the tags to count in the changelog.
-	#[arg(long, env = "GIT_CLIFF_COUNT_TAGS", value_name = "PATTERN")]
-	pub count_tags:       Option<Regex>,
-	/// Sets commits that will be skipped in the changelog.
-	#[arg(
+    pub with_tag_message: Option<String>,
+    /// Sets the tags to ignore in the changelog.
+    #[arg(long, env = "GIT_CLIFF_IGNORE_TAGS", value_name = "PATTERN")]
+    pub ignore_tags: Option<Regex>,
+    /// Sets the tags to count in the changelog.
+    #[arg(long, env = "GIT_CLIFF_COUNT_TAGS", value_name = "PATTERN")]
+    pub count_tags: Option<Regex>,
+    /// Sets commits that will be skipped in the changelog.
+    #[arg(
 		long,
 		env = "GIT_CLIFF_SKIP_COMMIT",
 		value_name = "SHA1",
 		num_args(1..)
 	)]
-	pub skip_commit:      Option<Vec<String>>,
-	/// Prepends entries to the given changelog file.
-	#[arg(
+    pub skip_commit: Option<Vec<String>>,
+    /// Prepends entries to the given changelog file.
+    #[arg(
 	    short,
 	    long,
 	    env = "GIT_CLIFF_PREPEND",
 	    value_name = "PATH",
 	    value_parser = Opt::parse_dir
 	)]
-	pub prepend:          Option<PathBuf>,
-	/// Writes output to the given file.
-	#[arg(
+    pub prepend: Option<PathBuf>,
+    /// Writes output to the given file.
+    #[arg(
 	    short,
 	    long,
 	    env = "GIT_CLIFF_OUTPUT",
@@ -182,155 +182,155 @@ pub struct Opt {
 	    num_args = 0..=1,
 	    default_missing_value = DEFAULT_OUTPUT
 	)]
-	pub output:           Option<PathBuf>,
-	/// Sets the tag for the latest version.
-	#[arg(
-		short,
-		long,
-		env = "GIT_CLIFF_TAG",
-		value_name = "TAG",
-		allow_hyphen_values = true
-	)]
-	pub tag:              Option<String>,
-	/// Bumps the version for unreleased changes. Optionally with specified
-	/// version.
-	#[arg(
+    pub output: Option<PathBuf>,
+    /// Sets the tag for the latest version.
+    #[arg(
+        short,
+        long,
+        env = "GIT_CLIFF_TAG",
+        value_name = "TAG",
+        allow_hyphen_values = true
+    )]
+    pub tag: Option<String>,
+    /// Bumps the version for unreleased changes. Optionally with specified
+    /// version.
+    #[arg(
         long,
         value_name = "BUMP",
         value_enum,
         num_args = 0..=1,
         default_missing_value = "auto",
         value_parser = clap::value_parser!(BumpOption))]
-	pub bump:             Option<BumpOption>,
-	/// Prints bumped version for unreleased changes.
-	#[arg(long, help_heading = Some("FLAGS"))]
-	pub bumped_version:   bool,
-	/// Sets the template for the changelog body.
-	#[arg(
-		short,
-		long,
-		env = "GIT_CLIFF_TEMPLATE",
-		value_name = "TEMPLATE",
-		allow_hyphen_values = true
-	)]
-	pub body:             Option<String>,
-	/// Processes the commits starting from the latest tag.
-	#[arg(short, long, help_heading = Some("FLAGS"))]
-	pub latest:           bool,
-	/// Processes the commits that belong to the current tag.
-	#[arg(long, help_heading = Some("FLAGS"))]
-	pub current:          bool,
-	/// Processes the commits that do not belong to a tag.
-	#[arg(short, long, help_heading = Some("FLAGS"))]
-	pub unreleased:       bool,
-	/// Sorts the tags topologically.
-	#[arg(long, help_heading = Some("FLAGS"))]
-	pub topo_order:       bool,
-	/// Include only the tags that belong to the current branch.
-	#[arg(long, help_heading = Some("FLAGS"))]
-	pub use_branch_tags:  bool,
-	/// Disables the external command execution.
-	#[arg(long, help_heading = Some("FLAGS"))]
-	pub no_exec:          bool,
-	/// Prints changelog context as JSON.
-	#[arg(short = 'x', long, help_heading = Some("FLAGS"))]
-	pub context:          bool,
-	/// Generates changelog from a JSON context.
-	#[arg(
+    pub bump: Option<BumpOption>,
+    /// Prints bumped version for unreleased changes.
+    #[arg(long, help_heading = Some("FLAGS"))]
+    pub bumped_version: bool,
+    /// Sets the template for the changelog body.
+    #[arg(
+        short,
+        long,
+        env = "GIT_CLIFF_TEMPLATE",
+        value_name = "TEMPLATE",
+        allow_hyphen_values = true
+    )]
+    pub body: Option<String>,
+    /// Processes the commits starting from the latest tag.
+    #[arg(short, long, help_heading = Some("FLAGS"))]
+    pub latest: bool,
+    /// Processes the commits that belong to the current tag.
+    #[arg(long, help_heading = Some("FLAGS"))]
+    pub current: bool,
+    /// Processes the commits that do not belong to a tag.
+    #[arg(short, long, help_heading = Some("FLAGS"))]
+    pub unreleased: bool,
+    /// Sorts the tags topologically.
+    #[arg(long, help_heading = Some("FLAGS"))]
+    pub topo_order: bool,
+    /// Include only the tags that belong to the current branch.
+    #[arg(long, help_heading = Some("FLAGS"))]
+    pub use_branch_tags: bool,
+    /// Disables the external command execution.
+    #[arg(long, help_heading = Some("FLAGS"))]
+    pub no_exec: bool,
+    /// Prints changelog context as JSON.
+    #[arg(short = 'x', long, help_heading = Some("FLAGS"))]
+    pub context: bool,
+    /// Generates changelog from a JSON context.
+    #[arg(
         long,
 	    value_name = "PATH",
 	    value_parser = Opt::parse_dir,
 		env = "GIT_CLIFF_CONTEXT",
     )]
-	pub from_context:     Option<PathBuf>,
-	/// Strips the given parts from the changelog.
-	#[arg(short, long, value_name = "PART", value_enum)]
-	pub strip:            Option<Strip>,
-	/// Sets sorting of the commits inside sections.
-	#[arg(
+    pub from_context: Option<PathBuf>,
+    /// Strips the given parts from the changelog.
+    #[arg(short, long, value_name = "PART", value_enum)]
+    pub strip: Option<Strip>,
+    /// Sets sorting of the commits inside sections.
+    #[arg(
 		long,
 		value_enum,
 		default_value_t = Sort::Oldest
 	)]
-	pub sort:             Sort,
-	/// Sets the commit range to process.
-	#[arg(value_name = "RANGE", help_heading = Some("ARGS"))]
-	pub range:            Option<String>,
-	/// Sets the GitHub API token.
-	#[arg(
+    pub sort: Sort,
+    /// Sets the commit range to process.
+    #[arg(value_name = "RANGE", help_heading = Some("ARGS"))]
+    pub range: Option<String>,
+    /// Sets the GitHub API token.
+    #[arg(
 		long,
 		env = "GITHUB_TOKEN",
 		value_name = "TOKEN",
 		hide_env_values = true,
 		hide = !cfg!(feature = "github"),
 	)]
-	pub github_token:     Option<SecretString>,
-	/// Sets the GitHub repository.
-	#[arg(
+    pub github_token: Option<SecretString>,
+    /// Sets the GitHub repository.
+    #[arg(
 		long,
 		env = "GITHUB_REPO",
 		value_parser = clap::value_parser!(RemoteValue),
 		value_name = "OWNER/REPO",
 		hide = !cfg!(feature = "github"),
 	)]
-	pub github_repo:      Option<RemoteValue>,
-	/// Sets the GitLab API token.
-	#[arg(
+    pub github_repo: Option<RemoteValue>,
+    /// Sets the GitLab API token.
+    #[arg(
 		long,
 		env = "GITLAB_TOKEN",
 		value_name = "TOKEN",
 		hide_env_values = true,
 		hide = !cfg!(feature = "gitlab"),
 	)]
-	pub gitlab_token:     Option<SecretString>,
-	/// Sets the GitLab repository.
-	#[arg(
+    pub gitlab_token: Option<SecretString>,
+    /// Sets the GitLab repository.
+    #[arg(
 		long,
 		env = "GITLAB_REPO",
 		value_parser = clap::value_parser!(RemoteValue),
 		value_name = "OWNER/REPO",
 		hide = !cfg!(feature = "gitlab"),
 	)]
-	pub gitlab_repo:      Option<RemoteValue>,
-	/// Sets the Gitea API token.
-	#[arg(
+    pub gitlab_repo: Option<RemoteValue>,
+    /// Sets the Gitea API token.
+    #[arg(
 		long,
 		env = "GITEA_TOKEN",
 		value_name = "TOKEN",
 		hide_env_values = true,
 		hide = !cfg!(feature = "gitea"),
 	)]
-	pub gitea_token:      Option<SecretString>,
-	/// Sets the Gitea repository.
-	#[arg(
+    pub gitea_token: Option<SecretString>,
+    /// Sets the Gitea repository.
+    #[arg(
 		long,
 		env = "GITEA_REPO",
 		value_parser = clap::value_parser!(RemoteValue),
 		value_name = "OWNER/REPO",
 		hide = !cfg!(feature = "gitea"),
 	)]
-	pub gitea_repo:       Option<RemoteValue>,
-	/// Sets the Bitbucket API token.
-	#[arg(
+    pub gitea_repo: Option<RemoteValue>,
+    /// Sets the Bitbucket API token.
+    #[arg(
 		long,
 		env = "BITBUCKET_TOKEN",
 		value_name = "TOKEN",
 		hide_env_values = true,
 		hide = !cfg!(feature = "bitbucket"),
 	)]
-	pub bitbucket_token:  Option<SecretString>,
-	/// Sets the Bitbucket repository.
-	#[arg(
+    pub bitbucket_token: Option<SecretString>,
+    /// Sets the Bitbucket repository.
+    #[arg(
 		long,
 		env = "BITBUCKET_REPO",
 		value_parser = clap::value_parser!(RemoteValue),
 		value_name = "OWNER/REPO",
 		hide = !cfg!(feature = "bitbucket"),
 	)]
-	pub bitbucket_repo:   Option<RemoteValue>,
-	/// Load TLS certificates from the native certificate store.
-	#[arg(long, help_heading = Some("FLAGS"), hide = !cfg!(feature = "remote"))]
-	pub use_native_tls:   bool,
+    pub bitbucket_repo: Option<RemoteValue>,
+    /// Load TLS certificates from the native certificate store.
+    #[arg(long, help_heading = Some("FLAGS"), hide = !cfg!(feature = "remote"))]
+    pub use_native_tls: bool,
 }
 
 /// Custom type for the remote value.
@@ -338,10 +338,10 @@ pub struct Opt {
 pub struct RemoteValue(pub Remote);
 
 impl ValueParserFactory for RemoteValue {
-	type Parser = RemoteValueParser;
-	fn value_parser() -> Self::Parser {
-		RemoteValueParser
-	}
+    type Parser = RemoteValueParser;
+    fn value_parser() -> Self::Parser {
+        RemoteValueParser
+    }
 }
 
 /// Parser for the remote value.
@@ -349,49 +349,49 @@ impl ValueParserFactory for RemoteValue {
 pub struct RemoteValueParser;
 
 impl TypedValueParser for RemoteValueParser {
-	type Value = RemoteValue;
-	fn parse_ref(
-		&self,
-		cmd: &clap::Command,
-		arg: Option<&clap::Arg>,
-		value: &std::ffi::OsStr,
-	) -> Result<Self::Value, clap::Error> {
-		let inner = clap::builder::StringValueParser::new();
-		let mut value = inner.parse_ref(cmd, arg, value)?;
-		if let Ok(url) = Url::parse(&value) {
-			value = url.path().trim_start_matches('/').to_string();
-		}
-		let parts = value.rsplit_once('/');
-		if let Some((owner, repo)) = parts {
-			Ok(RemoteValue(Remote::new(
-				owner.to_string(),
-				repo.to_string(),
-			)))
-		} else {
-			let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-			if let Some(arg) = arg {
-				err.insert(
-					ContextKind::InvalidArg,
-					ContextValue::String(arg.to_string()),
-				);
-			}
-			err.insert(ContextKind::InvalidValue, ContextValue::String(value));
-			Err(err)
-		}
-	}
+    type Value = RemoteValue;
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let inner = clap::builder::StringValueParser::new();
+        let mut value = inner.parse_ref(cmd, arg, value)?;
+        if let Ok(url) = Url::parse(&value) {
+            value = url.path().trim_start_matches('/').to_string();
+        }
+        let parts = value.rsplit_once('/');
+        if let Some((owner, repo)) = parts {
+            Ok(RemoteValue(Remote::new(
+                owner.to_string(),
+                repo.to_string(),
+            )))
+        } else {
+            let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+            if let Some(arg) = arg {
+                err.insert(
+                    ContextKind::InvalidArg,
+                    ContextValue::String(arg.to_string()),
+                );
+            }
+            err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+            Err(err)
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BumpOption {
-	Auto,
-	Specific(BumpType),
+    Auto,
+    Specific(BumpType),
 }
 
 impl ValueParserFactory for BumpOption {
-	type Parser = BumpOptionParser;
-	fn value_parser() -> Self::Parser {
-		BumpOptionParser
-	}
+    type Parser = BumpOptionParser;
+    fn value_parser() -> Self::Parser {
+        BumpOptionParser
+    }
 }
 
 /// Parser for bump type.
@@ -399,140 +399,132 @@ impl ValueParserFactory for BumpOption {
 pub struct BumpOptionParser;
 
 impl TypedValueParser for BumpOptionParser {
-	type Value = BumpOption;
-	fn parse_ref(
-		&self,
-		cmd: &clap::Command,
-		arg: Option<&clap::Arg>,
-		value: &std::ffi::OsStr,
-	) -> Result<Self::Value, clap::Error> {
-		let inner = clap::builder::StringValueParser::new();
-		let value = inner.parse_ref(cmd, arg, value)?;
-		match value.as_str() {
-			"auto" => Ok(BumpOption::Auto),
-			"major" => Ok(BumpOption::Specific(BumpType::Major)),
-			"minor" => Ok(BumpOption::Specific(BumpType::Minor)),
-			"patch" => Ok(BumpOption::Specific(BumpType::Patch)),
-			_ => {
-				let mut err =
-					clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-				if let Some(arg) = arg {
-					err.insert(
-						ContextKind::InvalidArg,
-						ContextValue::String(arg.to_string()),
-					);
-				}
-				err.insert(ContextKind::InvalidValue, ContextValue::String(value));
-				Err(err)
-			}
-		}
-	}
+    type Value = BumpOption;
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let inner = clap::builder::StringValueParser::new();
+        let value = inner.parse_ref(cmd, arg, value)?;
+        match value.as_str() {
+            "auto" => Ok(BumpOption::Auto),
+            "major" => Ok(BumpOption::Specific(BumpType::Major)),
+            "minor" => Ok(BumpOption::Specific(BumpType::Minor)),
+            "patch" => Ok(BumpOption::Specific(BumpType::Patch)),
+            _ => {
+                let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+                if let Some(arg) = arg {
+                    err.insert(
+                        ContextKind::InvalidArg,
+                        ContextValue::String(arg.to_string()),
+                    );
+                }
+                err.insert(ContextKind::InvalidValue, ContextValue::String(value));
+                Err(err)
+            }
+        }
+    }
 }
 
 impl Opt {
-	/// Custom string parser for directories.
-	///
-	/// Expands the tilde (`~`) character in the beginning of the
-	/// input string into contents of the path returned by [`home_dir`].
-	///
-	/// [`home_dir`]: dirs::home_dir
-	fn parse_dir(dir: &str) -> Result<PathBuf, String> {
-		Ok(PathBuf::from(shellexpand::tilde(dir).to_string()))
-	}
+    /// Custom string parser for directories.
+    ///
+    /// Expands the tilde (`~`) character in the beginning of the
+    /// input string into contents of the path returned by [`home_dir`].
+    ///
+    /// [`home_dir`]: dirs::home_dir
+    fn parse_dir(dir: &str) -> Result<PathBuf, String> {
+        Ok(PathBuf::from(shellexpand::tilde(dir).to_string()))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use std::ffi::OsStr;
+    use std::ffi::OsStr;
 
-	use clap::CommandFactory;
+    use clap::CommandFactory;
 
-	use super::*;
+    use super::*;
 
-	#[test]
-	fn verify_cli() {
-		Opt::command().debug_assert();
-	}
+    #[test]
+    fn verify_cli() {
+        Opt::command().debug_assert();
+    }
 
-	#[test]
-	fn path_tilde_expansion() {
-		let home_dir = dirs::home_dir().expect("cannot retrieve home directory");
-		let dir = Opt::parse_dir("~/").expect("cannot expand tilde");
-		assert_eq!(home_dir, dir);
-	}
+    #[test]
+    fn path_tilde_expansion() {
+        let home_dir = dirs::home_dir().expect("cannot retrieve home directory");
+        let dir = Opt::parse_dir("~/").expect("cannot expand tilde");
+        assert_eq!(home_dir, dir);
+    }
 
-	#[test]
-	fn remote_value_parser() -> Result<(), clap::Error> {
-		let remote_value_parser = RemoteValueParser;
-		assert_eq!(
-			RemoteValue(Remote::new("test", "repo")),
-			remote_value_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("test/repo")
-			)?
-		);
-		assert_eq!(
-			RemoteValue(Remote::new("gitlab/group/test", "repo")),
-			remote_value_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("gitlab/group/test/repo")
-			)?
-		);
-		assert_eq!(
-			RemoteValue(Remote::new("test", "testrepo")),
-			remote_value_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("https://github.com/test/testrepo")
-			)?
-		);
-		assert_eq!(
-			RemoteValue(Remote::new("archlinux/packaging/packages", "arch-repro-status")),
-			remote_value_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("https://gitlab.archlinux.org/archlinux/packaging/packages/arch-repro-status")
-			)?
-		);
-		assert!(
-			remote_value_parser
-				.parse_ref(&Opt::command(), None, OsStr::new("test"))
-				.is_err()
-		);
-		assert!(
-			remote_value_parser
-				.parse_ref(&Opt::command(), None, OsStr::new(""))
-				.is_err()
-		);
-		Ok(())
-	}
+    #[test]
+    fn remote_value_parser() -> Result<(), clap::Error> {
+        let remote_value_parser = RemoteValueParser;
+        assert_eq!(
+            RemoteValue(Remote::new("test", "repo")),
+            remote_value_parser.parse_ref(&Opt::command(), None, OsStr::new("test/repo"))?
+        );
+        assert_eq!(
+            RemoteValue(Remote::new("gitlab/group/test", "repo")),
+            remote_value_parser.parse_ref(
+                &Opt::command(),
+                None,
+                OsStr::new("gitlab/group/test/repo")
+            )?
+        );
+        assert_eq!(
+            RemoteValue(Remote::new("test", "testrepo")),
+            remote_value_parser.parse_ref(
+                &Opt::command(),
+                None,
+                OsStr::new("https://github.com/test/testrepo")
+            )?
+        );
+        assert_eq!(
+            RemoteValue(Remote::new(
+                "archlinux/packaging/packages",
+                "arch-repro-status"
+            )),
+            remote_value_parser.parse_ref(
+                &Opt::command(),
+                None,
+                OsStr::new(
+                    "https://gitlab.archlinux.org/archlinux/packaging/packages/arch-repro-status"
+                )
+            )?
+        );
+        assert!(
+            remote_value_parser
+                .parse_ref(&Opt::command(), None, OsStr::new("test"))
+                .is_err()
+        );
+        assert!(
+            remote_value_parser
+                .parse_ref(&Opt::command(), None, OsStr::new(""))
+                .is_err()
+        );
+        Ok(())
+    }
 
-	#[test]
-	fn bump_option_parser() -> Result<(), clap::Error> {
-		let bump_option_parser = BumpOptionParser;
-		assert_eq!(
-			BumpOption::Auto,
-			bump_option_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("auto")
-			)?
-		);
-		assert!(
-			bump_option_parser
-				.parse_ref(&Opt::command(), None, OsStr::new("test"))
-				.is_err()
-		);
-		assert_eq!(
-			BumpOption::Specific(BumpType::Major),
-			bump_option_parser.parse_ref(
-				&Opt::command(),
-				None,
-				OsStr::new("major")
-			)?
-		);
-		Ok(())
-	}
+    #[test]
+    fn bump_option_parser() -> Result<(), clap::Error> {
+        let bump_option_parser = BumpOptionParser;
+        assert_eq!(
+            BumpOption::Auto,
+            bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("auto"))?
+        );
+        assert!(
+            bump_option_parser
+                .parse_ref(&Opt::command(), None, OsStr::new("test"))
+                .is_err()
+        );
+        assert_eq!(
+            BumpOption::Specific(BumpType::Major),
+            bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("major"))?
+        );
+        Ok(())
+    }
 }

--- a/git-cliff/src/bin/completions.rs
+++ b/git-cliff/src/bin/completions.rs
@@ -10,16 +10,11 @@ use git_cliff::args::Opt;
 /// in a directory specified by the environment variable `OUT_DIR`.
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
-	let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
-	let mut app = Opt::command();
-	for &shell in Shell::value_variants() {
-		clap_complete::generate_to(
-			shell,
-			&mut app,
-			env!("CARGO_PKG_NAME"),
-			&out_dir,
-		)?;
-	}
-	println!("Completion scripts are generated in {out_dir:?}");
-	Ok(())
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
+    let mut app = Opt::command();
+    for &shell in Shell::value_variants() {
+        clap_complete::generate_to(shell, &mut app, env!("CARGO_PKG_NAME"), &out_dir)?;
+    }
+    println!("Completion scripts are generated in {out_dir:?}");
+    Ok(())
 }

--- a/git-cliff/src/bin/mangen.rs
+++ b/git-cliff/src/bin/mangen.rs
@@ -11,14 +11,13 @@ use git_cliff::args::Opt;
 /// in a directory specified by the environment variable `OUT_DIR`.
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
-	let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
-	let out_path =
-		PathBuf::from(out_dir).join(format!("{}.1", env!("CARGO_PKG_NAME")));
-	let app = Opt::command();
-	let man = Man::new(app);
-	let mut buffer = Vec::<u8>::new();
-	man.render(&mut buffer)?;
-	fs::write(&out_path, buffer)?;
-	println!("Man page is generated at {out_path:?}");
-	Ok(())
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
+    let out_path = PathBuf::from(out_dir).join(format!("{}.1", env!("CARGO_PKG_NAME")));
+    let app = Opt::command();
+    let man = Man::new(app);
+    let mut buffer = Vec::<u8>::new();
+    man.render(&mut buffer)?;
+    fs::write(&out_path, buffer)?;
+    println!("Man page is generated at {out_path:?}");
+    Ok(())
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -1,7 +1,7 @@
 //! A highly customizable changelog generator ⛰️
 #![doc(
-	html_logo_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff.png",
-	html_favicon_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/favicon/favicon.ico"
+    html_logo_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff.png",
+    html_favicon_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/favicon/favicon.ico"
 )]
 
 /// Command-line argument parser.
@@ -33,22 +33,15 @@ use glob::Pattern;
 /// Checks for a new version on crates.io
 #[cfg(feature = "update-informer")]
 fn check_new_version() {
-	use update_informer::Check;
-	let pkg_name = env!("CARGO_PKG_NAME");
-	let pkg_version = env!("CARGO_PKG_VERSION");
-	let informer = update_informer::new(
-		update_informer::registry::Crates,
-		pkg_name,
-		pkg_version,
-	);
-	if let Some(new_version) = informer.check_version().ok().flatten() {
-		if new_version.semver().pre.is_empty() {
-			log::info!(
-				"A new version of {pkg_name} is available: v{pkg_version} -> \
-				 {new_version}",
-			);
-		}
-	}
+    use update_informer::Check;
+    let pkg_name = env!("CARGO_PKG_NAME");
+    let pkg_version = env!("CARGO_PKG_VERSION");
+    let informer = update_informer::new(update_informer::registry::Crates, pkg_name, pkg_version);
+    if let Some(new_version) = informer.check_version().ok().flatten() {
+        if new_version.semver().pre.is_empty() {
+            log::info!("A new version of {pkg_name} is available: v{pkg_version} -> {new_version}",);
+        }
+    }
 }
 
 /// Produces a commit range on the format `BASE..HEAD`, derived from the
@@ -56,123 +49,114 @@ fn check_new_version() {
 ///
 /// If no commit range could be determined, `None` is returned.
 fn determine_commit_range(
-	args: &Opt,
-	config: &Config,
-	repository: &Repository,
+    args: &Opt,
+    config: &Config,
+    repository: &Repository,
 ) -> Result<Option<String>> {
-	let tags = repository.tags(
-		&config.git.tag_pattern,
-		args.topo_order,
-		args.use_branch_tags,
-	)?;
+    let tags = repository.tags(
+        &config.git.tag_pattern,
+        args.topo_order,
+        args.use_branch_tags,
+    )?;
 
-	let mut commit_range = args.range.clone();
-	if args.unreleased {
-		if let Some(last_tag) = tags.last().map(|(k, _)| k) {
-			commit_range = Some(format!("{last_tag}..HEAD"));
-		}
-	} else if args.latest || args.current {
-		if tags.len() < 2 {
-			let commits = repository.commits(
-				None,
-				None,
-				None,
-				config.git.topo_order_commits,
-			)?;
-			if let (Some(tag1), Some(tag2)) = (
-				commits.last().map(|c| c.id().to_string()),
-				tags.get_index(0).map(|(k, _)| k),
-			) {
-				if tags.len() == 1 {
-					commit_range = Some(tag2.to_owned());
-				} else {
-					commit_range = Some(format!("{tag1}..{tag2}"));
-				}
-			}
-		} else {
-			let mut tag_index = tags.len() - 2;
-			if args.current {
-				if let Some(current_tag_index) =
-					repository.current_tag().as_ref().and_then(|tag| {
-						tags.iter()
-							.enumerate()
-							.find(|(_, (_, v))| v.name == tag.name)
-							.map(|(i, _)| i)
-					}) {
-					match current_tag_index.checked_sub(1) {
-						Some(i) => tag_index = i,
-						None => {
-							return Err(Error::ChangelogError(String::from(
-								"No suitable tags found. Maybe run with \
-								 '--topo-order'?",
-							)));
-						}
-					}
-				} else {
-					return Err(Error::ChangelogError(String::from(
-						"No tag exists for the current commit",
-					)));
-				}
-			}
-			if let (Some(tag1), Some(tag2)) = (
-				tags.get_index(tag_index).map(|(k, _)| k),
-				tags.get_index(tag_index + 1).map(|(k, _)| k),
-			) {
-				commit_range = Some(format!("{tag1}..{tag2}"));
-			}
-		}
-	}
+    let mut commit_range = args.range.clone();
+    if args.unreleased {
+        if let Some(last_tag) = tags.last().map(|(k, _)| k) {
+            commit_range = Some(format!("{last_tag}..HEAD"));
+        }
+    } else if args.latest || args.current {
+        if tags.len() < 2 {
+            let commits = repository.commits(None, None, None, config.git.topo_order_commits)?;
+            if let (Some(tag1), Some(tag2)) = (
+                commits.last().map(|c| c.id().to_string()),
+                tags.get_index(0).map(|(k, _)| k),
+            ) {
+                if tags.len() == 1 {
+                    commit_range = Some(tag2.to_owned());
+                } else {
+                    commit_range = Some(format!("{tag1}..{tag2}"));
+                }
+            }
+        } else {
+            let mut tag_index = tags.len() - 2;
+            if args.current {
+                if let Some(current_tag_index) = repository.current_tag().as_ref().and_then(|tag| {
+                    tags.iter()
+                        .enumerate()
+                        .find(|(_, (_, v))| v.name == tag.name)
+                        .map(|(i, _)| i)
+                }) {
+                    match current_tag_index.checked_sub(1) {
+                        Some(i) => tag_index = i,
+                        None => {
+                            return Err(Error::ChangelogError(String::from(
+                                "No suitable tags found. Maybe run with '--topo-order'?",
+                            )));
+                        }
+                    }
+                } else {
+                    return Err(Error::ChangelogError(String::from(
+                        "No tag exists for the current commit",
+                    )));
+                }
+            }
+            if let (Some(tag1), Some(tag2)) = (
+                tags.get_index(tag_index).map(|(k, _)| k),
+                tags.get_index(tag_index + 1).map(|(k, _)| k),
+            ) {
+                commit_range = Some(format!("{tag1}..{tag2}"));
+            }
+        }
+    }
 
-	Ok(commit_range)
+    Ok(commit_range)
 }
 
 /// Process submodules and add commits to release.
 fn process_submodules(
-	repository: &'static Repository,
-	release: &mut Release,
-	topo_order_commits: bool,
+    repository: &'static Repository,
+    release: &mut Release,
+    topo_order_commits: bool,
 ) -> Result<()> {
-	// Retrieve first and last commit of a release to create a commit range.
-	let first_commit = release
-		.previous
-		.as_ref()
-		.and_then(|previous_release| previous_release.commit_id.clone())
-		.and_then(|commit_id| repository.find_commit(&commit_id));
-	let last_commit = release
-		.commit_id
-		.clone()
-		.and_then(|commit_id| repository.find_commit(&commit_id));
+    // Retrieve first and last commit of a release to create a commit range.
+    let first_commit = release
+        .previous
+        .as_ref()
+        .and_then(|previous_release| previous_release.commit_id.clone())
+        .and_then(|commit_id| repository.find_commit(&commit_id));
+    let last_commit = release
+        .commit_id
+        .clone()
+        .and_then(|commit_id| repository.find_commit(&commit_id));
 
-	trace!("Processing submodule commits in {first_commit:?}..{last_commit:?}");
+    trace!("Processing submodule commits in {first_commit:?}..{last_commit:?}");
 
-	// Query repository for submodule changes. For each submodule a
-	// SubmoduleRange is created, describing the range of commits in the context
-	// of that submodule.
-	if let Some(last_commit) = last_commit {
-		let submodule_ranges =
-			repository.submodules_range(first_commit, last_commit)?;
-		let submodule_commits =
-			submodule_ranges.iter().filter_map(|submodule_range| {
-				// For each submodule, the commit range is exploded into a list of
-				// commits.
-				let SubmoduleRange {
-					repository: sub_repo,
-					range: range_str,
-				} = submodule_range;
-				let commits = sub_repo
-					.commits(Some(range_str), None, None, topo_order_commits)
-					.ok()
-					.map(|commits| commits.iter().map(Commit::from).collect());
+    // Query repository for submodule changes. For each submodule a
+    // SubmoduleRange is created, describing the range of commits in the context
+    // of that submodule.
+    if let Some(last_commit) = last_commit {
+        let submodule_ranges = repository.submodules_range(first_commit, last_commit)?;
+        let submodule_commits = submodule_ranges.iter().filter_map(|submodule_range| {
+            // For each submodule, the commit range is exploded into a list of
+            // commits.
+            let SubmoduleRange {
+                repository: sub_repo,
+                range: range_str,
+            } = submodule_range;
+            let commits = sub_repo
+                .commits(Some(range_str), None, None, topo_order_commits)
+                .ok()
+                .map(|commits| commits.iter().map(Commit::from).collect());
 
-				let submodule_path = sub_repo.path().to_string_lossy().into_owned();
-				Some(submodule_path).zip(commits)
-			});
-		// Insert submodule commits into map.
-		for (submodule_path, commits) in submodule_commits {
-			release.submodule_commits.insert(submodule_path, commits);
-		}
-	}
-	Ok(())
+            let submodule_path = sub_repo.path().to_string_lossy().into_owned();
+            Some(submodule_path).zip(commits)
+        });
+        // Insert submodule commits into map.
+        for (submodule_path, commits) in submodule_commits {
+            release.submodule_commits.insert(submodule_path, commits);
+        }
+    }
+    Ok(())
 }
 
 /// Processes the tags and commits for creating release entries for the
@@ -181,274 +165,270 @@ fn process_submodules(
 /// This function uses the configuration and arguments to process the given
 /// repository individually.
 fn process_repository<'a>(
-	repository: &'static Repository,
-	config: &mut Config,
-	args: &Opt,
+    repository: &'static Repository,
+    config: &mut Config,
+    args: &Opt,
 ) -> Result<Vec<Release<'a>>> {
-	let mut tags = repository.tags(
-		&config.git.tag_pattern,
-		args.topo_order,
-		args.use_branch_tags,
-	)?;
-	let skip_regex = config.git.skip_tags.as_ref();
-	let ignore_regex = config.git.ignore_tags.as_ref();
-	let count_tags = config.git.count_tags.as_ref();
-	let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
-	tags.retain(|_, tag| {
-		let name = &tag.name;
+    let mut tags = repository.tags(
+        &config.git.tag_pattern,
+        args.topo_order,
+        args.use_branch_tags,
+    )?;
+    let skip_regex = config.git.skip_tags.as_ref();
+    let ignore_regex = config.git.ignore_tags.as_ref();
+    let count_tags = config.git.count_tags.as_ref();
+    let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
+    tags.retain(|_, tag| {
+        let name = &tag.name;
 
-		// Keep skip tags to drop commits in the later stage.
-		let skip = skip_regex.is_some_and(|r| r.is_match(name));
-		if skip {
-			return true;
-		}
+        // Keep skip tags to drop commits in the later stage.
+        let skip = skip_regex.is_some_and(|r| r.is_match(name));
+        if skip {
+            return true;
+        }
 
-		let count = count_tags.is_none_or(|r| {
-			let count_tag = r.is_match(name);
-			if count_tag {
-				trace!("Counting release: {}", name);
-			}
-			count_tag
-		});
+        let count = count_tags.is_none_or(|r| {
+            let count_tag = r.is_match(name);
+            if count_tag {
+                trace!("Counting release: {}", name);
+            }
+            count_tag
+        });
 
-		let ignore = ignore_regex.is_some_and(|r| {
-			if r.as_str().trim().is_empty() {
-				return false;
-			}
+        let ignore = ignore_regex.is_some_and(|r| {
+            if r.as_str().trim().is_empty() {
+                return false;
+            }
 
-			let ignore_tag = r.is_match(name);
-			if ignore_tag {
-				trace!("Ignoring release: {}", name);
-			}
-			ignore_tag
-		});
+            let ignore_tag = r.is_match(name);
+            if ignore_tag {
+                trace!("Ignoring release: {}", name);
+            }
+            ignore_tag
+        });
 
-		count && !ignore
-	});
+        count && !ignore
+    });
 
-	if !config.remote.is_any_set() {
-		match repository.upstream_remote() {
-			Ok(remote) => {
-				if !config.remote.github.is_set() {
-					debug!("No GitHub remote is set, using remote: {}", remote);
-					config.remote.github.owner = remote.owner;
-					config.remote.github.repo = remote.repo;
-					config.remote.github.is_custom = remote.is_custom;
-				} else if !config.remote.gitlab.is_set() {
-					debug!("No GitLab remote is set, using remote: {}", remote);
-					config.remote.gitlab.owner = remote.owner;
-					config.remote.gitlab.repo = remote.repo;
-					config.remote.gitlab.is_custom = remote.is_custom;
-				} else if !config.remote.gitea.is_set() {
-					debug!("No Gitea remote is set, using remote: {}", remote);
-					config.remote.gitea.owner = remote.owner;
-					config.remote.gitea.repo = remote.repo;
-					config.remote.gitea.is_custom = remote.is_custom;
-				} else if !config.remote.bitbucket.is_set() {
-					debug!("No Bitbucket remote is set, using remote: {}", remote);
-					config.remote.bitbucket.owner = remote.owner;
-					config.remote.bitbucket.repo = remote.repo;
-					config.remote.bitbucket.is_custom = remote.is_custom;
-				}
-			}
-			Err(e) => {
-				debug!("Failed to get remote from repository: {:?}", e);
-			}
-		}
-	}
-	if args.use_native_tls {
-		config.remote.enable_native_tls();
-	}
+    if !config.remote.is_any_set() {
+        match repository.upstream_remote() {
+            Ok(remote) => {
+                if !config.remote.github.is_set() {
+                    debug!("No GitHub remote is set, using remote: {}", remote);
+                    config.remote.github.owner = remote.owner;
+                    config.remote.github.repo = remote.repo;
+                    config.remote.github.is_custom = remote.is_custom;
+                } else if !config.remote.gitlab.is_set() {
+                    debug!("No GitLab remote is set, using remote: {}", remote);
+                    config.remote.gitlab.owner = remote.owner;
+                    config.remote.gitlab.repo = remote.repo;
+                    config.remote.gitlab.is_custom = remote.is_custom;
+                } else if !config.remote.gitea.is_set() {
+                    debug!("No Gitea remote is set, using remote: {}", remote);
+                    config.remote.gitea.owner = remote.owner;
+                    config.remote.gitea.repo = remote.repo;
+                    config.remote.gitea.is_custom = remote.is_custom;
+                } else if !config.remote.bitbucket.is_set() {
+                    debug!("No Bitbucket remote is set, using remote: {}", remote);
+                    config.remote.bitbucket.owner = remote.owner;
+                    config.remote.bitbucket.repo = remote.repo;
+                    config.remote.bitbucket.is_custom = remote.is_custom;
+                }
+            }
+            Err(e) => {
+                debug!("Failed to get remote from repository: {:?}", e);
+            }
+        }
+    }
+    if args.use_native_tls {
+        config.remote.enable_native_tls();
+    }
 
-	// Print debug information about configuration and arguments.
-	log::trace!("Arguments: {:#?}", args);
-	log::trace!("Config: {:#?}", config);
+    // Print debug information about configuration and arguments.
+    log::trace!("Arguments: {:#?}", args);
+    log::trace!("Config: {:#?}", config);
 
-	// Parse commits.
-	let commit_range = determine_commit_range(args, config, repository)?;
+    // Parse commits.
+    let commit_range = determine_commit_range(args, config, repository)?;
 
-	// Include only the current directory if not running from the root repository
-	let mut include_path = config.git.include_paths.clone();
-	if let Some(mut path_diff) =
-		pathdiff::diff_paths(repository.root_path()?, env::current_dir()?)
-	{
-		if args.workdir.is_none() &&
-			include_path.is_empty() &&
-			path_diff != Path::new("")
-		{
-			info!(
-				"Including changes from the current directory: {:?}",
-				path_diff.display()
-			);
-			path_diff.extend(["**", "*"]);
-			include_path = vec![Pattern::new(path_diff.to_string_lossy().as_ref())?];
-		}
-	}
+    // Include only the current directory if not running from the root repository
+    let mut include_path = config.git.include_paths.clone();
+    if let Some(mut path_diff) = pathdiff::diff_paths(repository.root_path()?, env::current_dir()?)
+    {
+        if args.workdir.is_none() && include_path.is_empty() && path_diff != Path::new("") {
+            info!(
+                "Including changes from the current directory: {:?}",
+                path_diff.display()
+            );
+            path_diff.extend(["**", "*"]);
+            include_path = vec![Pattern::new(path_diff.to_string_lossy().as_ref())?];
+        }
+    }
 
-	let include_path = (!include_path.is_empty()).then_some(include_path);
-	let exclude_path = (!config.git.exclude_paths.is_empty())
-		.then_some(config.git.exclude_paths.clone());
-	let mut commits = repository.commits(
-		commit_range.as_deref(),
-		include_path,
-		exclude_path,
-		config.git.topo_order_commits,
-	)?;
-	if let Some(commit_limit_value) = config.git.limit_commits {
-		commits.truncate(commit_limit_value);
-	}
+    let include_path = (!include_path.is_empty()).then_some(include_path);
+    let exclude_path =
+        (!config.git.exclude_paths.is_empty()).then_some(config.git.exclude_paths.clone());
+    let mut commits = repository.commits(
+        commit_range.as_deref(),
+        include_path,
+        exclude_path,
+        config.git.topo_order_commits,
+    )?;
+    if let Some(commit_limit_value) = config.git.limit_commits {
+        commits.truncate(commit_limit_value);
+    }
 
-	// Update tags.
-	let mut releases = vec![Release::default()];
-	let mut tag_timestamp = None;
-	if let Some(ref tag) = args.tag {
-		if let Some(commit_id) = commits.first().map(|c| c.id().to_string()) {
-			match tags.get(&commit_id) {
-				Some(tag) => {
-					warn!("There is already a tag ({}) for {}", tag.name, commit_id);
-					tag_timestamp = Some(commits[0].time().seconds());
-				}
-				None => {
-					tags.insert(commit_id, repository.resolve_tag(tag));
-				}
-			}
-		} else {
-			releases[0].version = Some(tag.to_string());
-			releases[0].timestamp = Some(
-				SystemTime::now()
-					.duration_since(UNIX_EPOCH)?
-					.as_secs()
-					.try_into()?,
-			);
-		}
-	}
+    // Update tags.
+    let mut releases = vec![Release::default()];
+    let mut tag_timestamp = None;
+    if let Some(ref tag) = args.tag {
+        if let Some(commit_id) = commits.first().map(|c| c.id().to_string()) {
+            match tags.get(&commit_id) {
+                Some(tag) => {
+                    warn!("There is already a tag ({}) for {}", tag.name, commit_id);
+                    tag_timestamp = Some(commits[0].time().seconds());
+                }
+                None => {
+                    tags.insert(commit_id, repository.resolve_tag(tag));
+                }
+            }
+        } else {
+            releases[0].version = Some(tag.to_string());
+            releases[0].timestamp = Some(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)?
+                    .as_secs()
+                    .try_into()?,
+            );
+        }
+    }
 
-	// Process releases.
-	let mut previous_release = Release::default();
-	let mut first_processed_tag = None;
-	let repository_path = repository.root_path()?.to_string_lossy().into_owned();
-	for git_commit in commits.iter().rev() {
-		let release = releases.last_mut().unwrap();
-		let commit = Commit::from(git_commit);
-		let commit_id = commit.id.to_string();
-		release.commits.push(commit);
-		release.repository = Some(repository_path.clone());
-		release.commit_id = Some(commit_id);
-		if let Some(tag) = tags.get(release.commit_id.as_ref().unwrap()) {
-			release.version = Some(tag.name.to_string());
-			release.message.clone_from(&tag.message);
-			release.timestamp = if args.tag.as_deref() == Some(tag.name.as_str()) {
-				match tag_timestamp {
-					Some(timestamp) => Some(timestamp),
-					None => Some(
-						SystemTime::now()
-							.duration_since(UNIX_EPOCH)?
-							.as_secs()
-							.try_into()?,
-					),
-				}
-			} else {
-				Some(git_commit.time().seconds())
-			};
-			if first_processed_tag.is_none() {
-				first_processed_tag = Some(tag);
-			}
-			previous_release.previous = None;
-			release.previous = Some(Box::new(previous_release));
-			previous_release = release.clone();
-			releases.push(Release::default());
-		}
-	}
+    // Process releases.
+    let mut previous_release = Release::default();
+    let mut first_processed_tag = None;
+    let repository_path = repository.root_path()?.to_string_lossy().into_owned();
+    for git_commit in commits.iter().rev() {
+        let release = releases.last_mut().unwrap();
+        let commit = Commit::from(git_commit);
+        let commit_id = commit.id.to_string();
+        release.commits.push(commit);
+        release.repository = Some(repository_path.clone());
+        release.commit_id = Some(commit_id);
+        if let Some(tag) = tags.get(release.commit_id.as_ref().unwrap()) {
+            release.version = Some(tag.name.to_string());
+            release.message.clone_from(&tag.message);
+            release.timestamp = if args.tag.as_deref() == Some(tag.name.as_str()) {
+                match tag_timestamp {
+                    Some(timestamp) => Some(timestamp),
+                    None => Some(
+                        SystemTime::now()
+                            .duration_since(UNIX_EPOCH)?
+                            .as_secs()
+                            .try_into()?,
+                    ),
+                }
+            } else {
+                Some(git_commit.time().seconds())
+            };
+            if first_processed_tag.is_none() {
+                first_processed_tag = Some(tag);
+            }
+            previous_release.previous = None;
+            release.previous = Some(Box::new(previous_release));
+            previous_release = release.clone();
+            releases.push(Release::default());
+        }
+    }
 
-	debug_assert!(!releases.is_empty());
+    debug_assert!(!releases.is_empty());
 
-	if releases.len() > 1 {
-		previous_release.previous = None;
-		releases.last_mut().unwrap().previous = Some(Box::new(previous_release));
-	}
+    if releases.len() > 1 {
+        previous_release.previous = None;
+        releases.last_mut().unwrap().previous = Some(Box::new(previous_release));
+    }
 
-	if args.sort == Sort::Newest {
-		for release in &mut releases {
-			release.commits.reverse();
-		}
-	}
+    if args.sort == Sort::Newest {
+        for release in &mut releases {
+            release.commits.reverse();
+        }
+    }
 
-	// Add custom commit messages to the latest release.
-	if let Some(custom_commits) = &args.with_commit {
-		releases
-			.last_mut()
-			.unwrap()
-			.commits
-			.extend(custom_commits.iter().cloned().map(Commit::from));
-	}
+    // Add custom commit messages to the latest release.
+    if let Some(custom_commits) = &args.with_commit {
+        releases
+            .last_mut()
+            .unwrap()
+            .commits
+            .extend(custom_commits.iter().cloned().map(Commit::from));
+    }
 
-	// Set the previous release if the first release does not have one set.
-	if releases[0]
-		.previous
-		.as_ref()
-		.and_then(|p| p.version.as_ref())
-		.is_none()
-	{
-		// Get the previous tag of the first processed tag in the release loop.
-		let first_tag = first_processed_tag
-			.map(|tag| {
-				tags.iter()
-					.enumerate()
-					.find(|(_, (_, v))| v.name == tag.name)
-					.and_then(|(i, _)| i.checked_sub(1))
-					.and_then(|i| tags.get_index(i))
-			})
-			.or_else(|| Some(tags.last()))
-			.flatten();
+    // Set the previous release if the first release does not have one set.
+    if releases[0]
+        .previous
+        .as_ref()
+        .and_then(|p| p.version.as_ref())
+        .is_none()
+    {
+        // Get the previous tag of the first processed tag in the release loop.
+        let first_tag = first_processed_tag
+            .map(|tag| {
+                tags.iter()
+                    .enumerate()
+                    .find(|(_, (_, v))| v.name == tag.name)
+                    .and_then(|(i, _)| i.checked_sub(1))
+                    .and_then(|i| tags.get_index(i))
+            })
+            .or_else(|| Some(tags.last()))
+            .flatten();
 
-		// Set the previous release if the first tag is found.
-		if let Some((commit_id, tag)) = first_tag {
-			let previous_release = Release {
-				commit_id: Some(commit_id.to_string()),
-				version: Some(tag.name.clone()),
-				timestamp: Some(
-					repository
-						.find_commit(commit_id)
-						.map(|v| v.time().seconds())
-						.unwrap_or_default(),
-				),
-				..Default::default()
-			};
-			releases[0].previous = Some(Box::new(previous_release));
-		}
-	}
+        // Set the previous release if the first tag is found.
+        if let Some((commit_id, tag)) = first_tag {
+            let previous_release = Release {
+                commit_id: Some(commit_id.to_string()),
+                version: Some(tag.name.clone()),
+                timestamp: Some(
+                    repository
+                        .find_commit(commit_id)
+                        .map(|v| v.time().seconds())
+                        .unwrap_or_default(),
+                ),
+                ..Default::default()
+            };
+            releases[0].previous = Some(Box::new(previous_release));
+        }
+    }
 
-	for release in &mut releases {
-		// Set the commit ranges for all releases
-		if !release.commits.is_empty() {
-			release.commit_range = Some(match args.sort {
-				Sort::Oldest => Range::new(
-					release.commits.first().unwrap(),
-					release.commits.last().unwrap(),
-				),
-				Sort::Newest => Range::new(
-					release.commits.last().unwrap(),
-					release.commits.first().unwrap(),
-				),
-			})
-		}
-		if recurse_submodules {
-			process_submodules(repository, release, config.git.topo_order_commits)?;
-		}
-	}
+    for release in &mut releases {
+        // Set the commit ranges for all releases
+        if !release.commits.is_empty() {
+            release.commit_range = Some(match args.sort {
+                Sort::Oldest => Range::new(
+                    release.commits.first().unwrap(),
+                    release.commits.last().unwrap(),
+                ),
+                Sort::Newest => Range::new(
+                    release.commits.last().unwrap(),
+                    release.commits.first().unwrap(),
+                ),
+            })
+        }
+        if recurse_submodules {
+            process_submodules(repository, release, config.git.topo_order_commits)?;
+        }
+    }
 
-	// Set custom message for the latest release.
-	if let Some(message) = &args.with_tag_message {
-		if let Some(latest_release) = releases
-			.iter_mut()
-			.filter(|release| !release.commits.is_empty())
-			.next_back()
-		{
-			latest_release.message = Some(message.to_owned());
-		}
-	}
+    // Set custom message for the latest release.
+    if let Some(message) = &args.with_tag_message {
+        if let Some(latest_release) = releases
+            .iter_mut()
+            .filter(|release| !release.commits.is_empty())
+            .next_back()
+        {
+            latest_release.message = Some(message.to_owned());
+        }
+    }
 
-	Ok(releases)
+    Ok(releases)
 }
 
 /// Runs `git-cliff`.
@@ -461,13 +441,13 @@ fn process_repository<'a>(
 /// use git_cliff_core::error::Result;
 ///
 /// fn main() -> Result<()> {
-/// 	let args = Opt::parse();
-/// 	git_cliff::run(args)?;
-/// 	Ok(())
+///     let args = Opt::parse();
+///     git_cliff::run(args)?;
+///     Ok(())
 /// }
 /// ```
 pub fn run(args: Opt) -> Result<()> {
-	run_with_changelog_modifier(args, |_| Ok(()))
+    run_with_changelog_modifier(args, |_| Ok(()))
 }
 
 /// Runs `git-cliff` with a changelog modifier.
@@ -483,351 +463,342 @@ pub fn run(args: Opt) -> Result<()> {
 /// use git_cliff_core::error::Result;
 ///
 /// fn main() -> Result<()> {
-/// 	let args = Opt::parse();
+///     let args = Opt::parse();
 ///
-/// 	git_cliff::run_with_changelog_modifier(args, |changelog| {
-/// 		println!("Releases: {:?}", changelog.releases);
-/// 		Ok(())
-/// 	})?;
+///     git_cliff::run_with_changelog_modifier(args, |changelog| {
+///         println!("Releases: {:?}", changelog.releases);
+///         Ok(())
+///     })?;
 ///
-/// 	Ok(())
+///     Ok(())
 /// }
 /// ```
 pub fn run_with_changelog_modifier(
-	mut args: Opt,
-	changelog_modifier: impl FnOnce(&mut Changelog) -> Result<()>,
+    mut args: Opt,
+    changelog_modifier: impl FnOnce(&mut Changelog) -> Result<()>,
 ) -> Result<()> {
-	// Check if there is a new version available.
-	#[cfg(feature = "update-informer")]
-	check_new_version();
+    // Check if there is a new version available.
+    #[cfg(feature = "update-informer")]
+    check_new_version();
 
-	// Create the configuration file if init flag is given.
-	if let Some(init_config) = args.init {
-		let contents = match init_config {
-			Some(ref name) => BuiltinConfig::get_config(name.to_string())?,
-			None => EmbeddedConfig::get_config()?,
-		};
+    // Create the configuration file if init flag is given.
+    if let Some(init_config) = args.init {
+        let contents = match init_config {
+            Some(ref name) => BuiltinConfig::get_config(name.to_string())?,
+            None => EmbeddedConfig::get_config()?,
+        };
 
-		let config_path = if args.config == PathBuf::from(DEFAULT_CONFIG) {
-			PathBuf::from(DEFAULT_CONFIG)
-		} else {
-			args.config.clone()
-		};
+        let config_path = if args.config == PathBuf::from(DEFAULT_CONFIG) {
+            PathBuf::from(DEFAULT_CONFIG)
+        } else {
+            args.config.clone()
+        };
 
-		info!(
-			"Saving the configuration file{} to {:?}",
-			init_config.map(|v| format!(" ({v})")).unwrap_or_default(),
-			config_path
-		);
-		fs::write(config_path, contents)?;
-		return Ok(());
-	}
+        info!(
+            "Saving the configuration file{} to {:?}",
+            init_config.map(|v| format!(" ({v})")).unwrap_or_default(),
+            config_path
+        );
+        fs::write(config_path, contents)?;
+        return Ok(());
+    }
 
-	// Retrieve the built-in configuration.
-	let builtin_config =
-		BuiltinConfig::parse(args.config.to_string_lossy().to_string());
+    // Retrieve the built-in configuration.
+    let builtin_config = BuiltinConfig::parse(args.config.to_string_lossy().to_string());
 
-	// Set the working directory.
-	if let Some(ref workdir) = args.workdir {
-		args.config = workdir.join(args.config);
-		match args.repository.as_mut() {
-			Some(repository) => {
-				repository
-					.iter_mut()
-					.for_each(|r| *r = workdir.join(r.clone()));
-			}
-			None => args.repository = Some(vec![workdir.clone()]),
-		}
-		if let Some(changelog) = args.prepend {
-			args.prepend = Some(workdir.join(changelog));
-		}
-	}
+    // Set the working directory.
+    if let Some(ref workdir) = args.workdir {
+        args.config = workdir.join(args.config);
+        match args.repository.as_mut() {
+            Some(repository) => {
+                repository
+                    .iter_mut()
+                    .for_each(|r| *r = workdir.join(r.clone()));
+            }
+            None => args.repository = Some(vec![workdir.clone()]),
+        }
+        if let Some(changelog) = args.prepend {
+            args.prepend = Some(workdir.join(changelog));
+        }
+    }
 
-	// Set path for the configuration file.
-	let mut path = args.config.clone();
-	if !path.exists() {
-		if let Some(config_path) = dirs::config_dir()
-			.map(|dir| dir.join(env!("CARGO_PKG_NAME")).join(DEFAULT_CONFIG))
-		{
-			path = config_path;
-		}
-	}
+    // Set path for the configuration file.
+    let mut path = args.config.clone();
+    if !path.exists() {
+        if let Some(config_path) =
+            dirs::config_dir().map(|dir| dir.join(env!("CARGO_PKG_NAME")).join(DEFAULT_CONFIG))
+        {
+            path = config_path;
+        }
+    }
 
-	// Parse the configuration file.
-	// Load the default configuration if necessary.
-	let mut config = if let Some(url) = &args.config_url {
-		debug!("Using configuration file from: {url}");
-		#[cfg(feature = "remote")]
-		{
-			reqwest::blocking::get(url.clone())?
-				.error_for_status()?
-				.text()?
-				.parse()?
-		}
-		#[cfg(not(feature = "remote"))]
-		unreachable!(
-			"This option is not available without the 'remote' build-time feature"
-		);
-	} else if let Ok((config, name)) = builtin_config {
-		info!("Using built-in configuration file: {name}");
-		config
-	} else if path.exists() {
-		Config::load(&path)?
-	} else if let Some(contents) = Config::read_from_manifest()? {
-		contents.parse()?
-	} else if let Some(discovered_path) =
-		env::current_dir()?.ancestors().find_map(|dir| {
-			let path = dir.join(DEFAULT_CONFIG);
-			if path.is_file() { Some(path) } else { None }
-		}) {
-		info!(
-			"Using configuration from parent directory: {}",
-			discovered_path.display()
-		);
-		Config::load(&discovered_path)?
-	} else {
-		if !args.context {
-			warn!(
-				"{:?} is not found, using the default configuration.",
-				args.config
-			);
-		}
-		EmbeddedConfig::parse()?
-	};
+    // Parse the configuration file.
+    // Load the default configuration if necessary.
+    let mut config = if let Some(url) = &args.config_url {
+        debug!("Using configuration file from: {url}");
+        #[cfg(feature = "remote")]
+        {
+            reqwest::blocking::get(url.clone())?
+                .error_for_status()?
+                .text()?
+                .parse()?
+        }
+        #[cfg(not(feature = "remote"))]
+        unreachable!("This option is not available without the 'remote' build-time feature");
+    } else if let Ok((config, name)) = builtin_config {
+        info!("Using built-in configuration file: {name}");
+        config
+    } else if path.exists() {
+        Config::load(&path)?
+    } else if let Some(contents) = Config::read_from_manifest()? {
+        contents.parse()?
+    } else if let Some(discovered_path) = env::current_dir()?.ancestors().find_map(|dir| {
+        let path = dir.join(DEFAULT_CONFIG);
+        if path.is_file() { Some(path) } else { None }
+    }) {
+        info!(
+            "Using configuration from parent directory: {}",
+            discovered_path.display()
+        );
+        Config::load(&discovered_path)?
+    } else {
+        if !args.context {
+            warn!(
+                "{:?} is not found, using the default configuration.",
+                args.config
+            );
+        }
+        EmbeddedConfig::parse()?
+    };
 
-	// Update the configuration based on command line arguments and vice versa.
-	let output = args.output.clone().or(config.changelog.output.clone());
-	match args.strip {
-		Some(Strip::Header) => {
-			config.changelog.header = None;
-		}
-		Some(Strip::Footer) => {
-			config.changelog.footer = None;
-		}
-		Some(Strip::All) => {
-			config.changelog.header = None;
-			config.changelog.footer = None;
-		}
-		None => {}
-	}
-	if args.prepend.is_some() {
-		config.changelog.footer = None;
-		if !(args.unreleased || args.latest || args.range.is_some()) {
-			return Err(Error::ArgumentError(String::from(
-				"'-u' or '-l' is not specified",
-			)));
-		}
-	}
-	if output.is_some() &&
-		args.prepend.is_some() &&
-		output.as_ref() == args.prepend.as_ref()
-	{
-		return Err(Error::ArgumentError(String::from(
-			"'-o' and '-p' can only be used together if they point to different \
-			 files",
-		)));
-	}
-	if let Some(body) = args.body.clone() {
-		config.changelog.body = body;
-	}
-	if args.sort == Sort::Oldest {
-		args.sort = Sort::from_str(&config.git.sort_commits, true)
-			.expect("Incorrect config value for 'sort_commits'");
-	}
-	if !args.topo_order {
-		args.topo_order = config.git.topo_order;
-	}
+    // Update the configuration based on command line arguments and vice versa.
+    let output = args.output.clone().or(config.changelog.output.clone());
+    match args.strip {
+        Some(Strip::Header) => {
+            config.changelog.header = None;
+        }
+        Some(Strip::Footer) => {
+            config.changelog.footer = None;
+        }
+        Some(Strip::All) => {
+            config.changelog.header = None;
+            config.changelog.footer = None;
+        }
+        None => {}
+    }
+    if args.prepend.is_some() {
+        config.changelog.footer = None;
+        if !(args.unreleased || args.latest || args.range.is_some()) {
+            return Err(Error::ArgumentError(String::from(
+                "'-u' or '-l' is not specified",
+            )));
+        }
+    }
+    if output.is_some() && args.prepend.is_some() && output.as_ref() == args.prepend.as_ref() {
+        return Err(Error::ArgumentError(String::from(
+            "'-o' and '-p' can only be used together if they point to different files",
+        )));
+    }
+    if let Some(body) = args.body.clone() {
+        config.changelog.body = body;
+    }
+    if args.sort == Sort::Oldest {
+        args.sort = Sort::from_str(&config.git.sort_commits, true)
+            .expect("Incorrect config value for 'sort_commits'");
+    }
+    if !args.topo_order {
+        args.topo_order = config.git.topo_order;
+    }
 
-	if !args.use_branch_tags {
-		args.use_branch_tags = config.git.use_branch_tags;
-	}
+    if !args.use_branch_tags {
+        args.use_branch_tags = config.git.use_branch_tags;
+    }
 
-	if args.github_token.is_some() {
-		config.remote.github.token.clone_from(&args.github_token);
-	}
-	if args.gitlab_token.is_some() {
-		config.remote.gitlab.token.clone_from(&args.gitlab_token);
-	}
-	if args.gitea_token.is_some() {
-		config.remote.gitea.token.clone_from(&args.gitea_token);
-	}
-	if args.bitbucket_token.is_some() {
-		config
-			.remote
-			.bitbucket
-			.token
-			.clone_from(&args.bitbucket_token);
-	}
-	if let Some(ref remote) = args.github_repo {
-		config.remote.github.owner = remote.0.owner.to_string();
-		config.remote.github.repo = remote.0.repo.to_string();
-		config.remote.github.is_custom = true;
-	}
-	if let Some(ref remote) = args.gitlab_repo {
-		config.remote.gitlab.owner = remote.0.owner.to_string();
-		config.remote.gitlab.repo = remote.0.repo.to_string();
-		config.remote.gitlab.is_custom = true;
-	}
-	if let Some(ref remote) = args.bitbucket_repo {
-		config.remote.bitbucket.owner = remote.0.owner.to_string();
-		config.remote.bitbucket.repo = remote.0.repo.to_string();
-		config.remote.bitbucket.is_custom = true;
-	}
-	if let Some(ref remote) = args.gitea_repo {
-		config.remote.gitea.owner = remote.0.owner.to_string();
-		config.remote.gitea.repo = remote.0.repo.to_string();
-		config.remote.gitea.is_custom = true;
-	}
-	if args.no_exec {
-		config
-			.git
-			.commit_preprocessors
-			.iter_mut()
-			.for_each(|v| v.replace_command = None);
-		config
-			.changelog
-			.postprocessors
-			.iter_mut()
-			.for_each(|v| v.replace_command = None);
-	}
-	config.git.skip_tags = config.git.skip_tags.filter(|r| !r.as_str().is_empty());
-	if args.tag_pattern.is_some() {
-		config.git.tag_pattern.clone_from(&args.tag_pattern);
-	}
-	if args.tag.is_some() {
-		config.bump.initial_tag.clone_from(&args.tag);
-	}
-	if args.ignore_tags.is_some() {
-		config.git.ignore_tags.clone_from(&args.ignore_tags);
-	}
-	if args.count_tags.is_some() {
-		config.git.count_tags.clone_from(&args.count_tags);
-	}
-	if let Some(include_path) = &args.include_path {
-		config
-			.git
-			.include_paths
-			.extend(include_path.iter().cloned());
-	}
-	if let Some(exclude_path) = &args.exclude_path {
-		config
-			.git
-			.exclude_paths
-			.extend(exclude_path.iter().cloned());
-	}
+    if args.github_token.is_some() {
+        config.remote.github.token.clone_from(&args.github_token);
+    }
+    if args.gitlab_token.is_some() {
+        config.remote.gitlab.token.clone_from(&args.gitlab_token);
+    }
+    if args.gitea_token.is_some() {
+        config.remote.gitea.token.clone_from(&args.gitea_token);
+    }
+    if args.bitbucket_token.is_some() {
+        config
+            .remote
+            .bitbucket
+            .token
+            .clone_from(&args.bitbucket_token);
+    }
+    if let Some(ref remote) = args.github_repo {
+        config.remote.github.owner = remote.0.owner.to_string();
+        config.remote.github.repo = remote.0.repo.to_string();
+        config.remote.github.is_custom = true;
+    }
+    if let Some(ref remote) = args.gitlab_repo {
+        config.remote.gitlab.owner = remote.0.owner.to_string();
+        config.remote.gitlab.repo = remote.0.repo.to_string();
+        config.remote.gitlab.is_custom = true;
+    }
+    if let Some(ref remote) = args.bitbucket_repo {
+        config.remote.bitbucket.owner = remote.0.owner.to_string();
+        config.remote.bitbucket.repo = remote.0.repo.to_string();
+        config.remote.bitbucket.is_custom = true;
+    }
+    if let Some(ref remote) = args.gitea_repo {
+        config.remote.gitea.owner = remote.0.owner.to_string();
+        config.remote.gitea.repo = remote.0.repo.to_string();
+        config.remote.gitea.is_custom = true;
+    }
+    if args.no_exec {
+        config
+            .git
+            .commit_preprocessors
+            .iter_mut()
+            .for_each(|v| v.replace_command = None);
+        config
+            .changelog
+            .postprocessors
+            .iter_mut()
+            .for_each(|v| v.replace_command = None);
+    }
+    config.git.skip_tags = config.git.skip_tags.filter(|r| !r.as_str().is_empty());
+    if args.tag_pattern.is_some() {
+        config.git.tag_pattern.clone_from(&args.tag_pattern);
+    }
+    if args.tag.is_some() {
+        config.bump.initial_tag.clone_from(&args.tag);
+    }
+    if args.ignore_tags.is_some() {
+        config.git.ignore_tags.clone_from(&args.ignore_tags);
+    }
+    if args.count_tags.is_some() {
+        config.git.count_tags.clone_from(&args.count_tags);
+    }
+    if let Some(include_path) = &args.include_path {
+        config
+            .git
+            .include_paths
+            .extend(include_path.iter().cloned());
+    }
+    if let Some(exclude_path) = &args.exclude_path {
+        config
+            .git
+            .exclude_paths
+            .extend(exclude_path.iter().cloned());
+    }
 
-	// Process commits and releases for the changelog.
-	if let Some(BumpOption::Specific(bump_type)) = args.bump {
-		config.bump.bump_type = Some(bump_type);
-	}
+    // Process commits and releases for the changelog.
+    if let Some(BumpOption::Specific(bump_type)) = args.bump {
+        config.bump.bump_type = Some(bump_type);
+    }
 
-	// Generate changelog from context.
-	let mut changelog: Changelog = if let Some(context_path) = args.from_context {
-		let mut input: Box<dyn io::Read> = if context_path == Path::new("-") {
-			Box::new(io::stdin())
-		} else {
-			Box::new(File::open(context_path)?)
-		};
-		let mut changelog = Changelog::from_context(&mut input, &config)?;
-		changelog.add_remote_context()?;
-		changelog
-	} else {
-		// Process the repositories.
-		let repositories =
-			args.repository.clone().unwrap_or(vec![env::current_dir()?]);
-		let mut releases = Vec::<Release>::new();
-		let mut commit_range = None;
-		for repository in repositories {
-			// Skip commits
-			let mut skip_list = Vec::new();
-			let ignore_file = repository.join(IGNORE_FILE);
-			if ignore_file.exists() {
-				let contents = fs::read_to_string(ignore_file)?;
-				let commits = contents
-					.lines()
-					.filter(|v| !(v.starts_with('#') || v.trim().is_empty()))
-					.map(|v| String::from(v.trim()))
-					.collect::<Vec<String>>();
-				skip_list.extend(commits);
-			}
-			if let Some(ref skip_commit) = args.skip_commit {
-				skip_list.extend(skip_commit.clone());
-			}
-			for sha1 in skip_list {
-				config.git.commit_parsers.insert(0, CommitParser {
-					sha: Some(sha1.to_string()),
-					skip: Some(true),
-					..Default::default()
-				});
-			}
+    // Generate changelog from context.
+    let mut changelog: Changelog = if let Some(context_path) = args.from_context {
+        let mut input: Box<dyn io::Read> = if context_path == Path::new("-") {
+            Box::new(io::stdin())
+        } else {
+            Box::new(File::open(context_path)?)
+        };
+        let mut changelog = Changelog::from_context(&mut input, &config)?;
+        changelog.add_remote_context()?;
+        changelog
+    } else {
+        // Process the repositories.
+        let repositories = args.repository.clone().unwrap_or(vec![env::current_dir()?]);
+        let mut releases = Vec::<Release>::new();
+        let mut commit_range = None;
+        for repository in repositories {
+            // Skip commits
+            let mut skip_list = Vec::new();
+            let ignore_file = repository.join(IGNORE_FILE);
+            if ignore_file.exists() {
+                let contents = fs::read_to_string(ignore_file)?;
+                let commits = contents
+                    .lines()
+                    .filter(|v| !(v.starts_with('#') || v.trim().is_empty()))
+                    .map(|v| String::from(v.trim()))
+                    .collect::<Vec<String>>();
+                skip_list.extend(commits);
+            }
+            if let Some(ref skip_commit) = args.skip_commit {
+                skip_list.extend(skip_commit.clone());
+            }
+            for sha1 in skip_list {
+                config.git.commit_parsers.insert(0, CommitParser {
+                    sha: Some(sha1.to_string()),
+                    skip: Some(true),
+                    ..Default::default()
+                });
+            }
 
-			// Process the repository.
-			let repository = Repository::init(repository)?;
+            // Process the repository.
+            let repository = Repository::init(repository)?;
 
-			// The commit range, used for determining the remote commits to include
-			// in the changelog, doesn't make sense if multiple repositories are
-			// specified. As such, pick the commit range from the last given
-			// repository.
-			commit_range = determine_commit_range(&args, &config, &repository)?;
+            // The commit range, used for determining the remote commits to include
+            // in the changelog, doesn't make sense if multiple repositories are
+            // specified. As such, pick the commit range from the last given
+            // repository.
+            commit_range = determine_commit_range(&args, &config, &repository)?;
 
-			releases.extend(process_repository(
-				Box::leak(Box::new(repository)),
-				&mut config,
-				&args,
-			)?);
-		}
-		Changelog::new(releases, &config, commit_range.as_deref())?
-	};
-	changelog_modifier(&mut changelog)?;
+            releases.extend(process_repository(
+                Box::leak(Box::new(repository)),
+                &mut config,
+                &args,
+            )?);
+        }
+        Changelog::new(releases, &config, commit_range.as_deref())?
+    };
+    changelog_modifier(&mut changelog)?;
 
-	// Print the result.
-	let mut out: Box<dyn io::Write> = if let Some(path) = &output {
-		if path == Path::new("-") {
-			Box::new(io::stdout())
-		} else {
-			Box::new(io::BufWriter::new(File::create(path)?))
-		}
-	} else {
-		Box::new(io::stdout())
-	};
-	if args.bump.is_some() || args.bumped_version {
-		let next_version = if let Some(next_version) = changelog.bump_version()? {
-			next_version
-		} else if let Some(last_version) =
-			changelog.releases.first().cloned().and_then(|v| v.version)
-		{
-			warn!("There is nothing to bump.");
-			last_version
-		} else if changelog.releases.is_empty() {
-			config.bump.get_initial_tag()
-		} else {
-			return Ok(());
-		};
-		if let Some(tag_pattern) = &config.git.tag_pattern {
-			if !tag_pattern.is_match(&next_version) {
-				return Err(Error::ChangelogError(format!(
-					"Next version ({}) does not match the tag pattern: {}",
-					next_version, tag_pattern
-				)));
-			}
-		}
-		if args.bumped_version {
-			writeln!(out, "{next_version}")?;
-			return Ok(());
-		}
-	}
-	if args.context {
-		changelog.write_context(&mut out)?;
-		return Ok(());
-	}
-	if let Some(path) = &args.prepend {
-		let changelog_before = fs::read_to_string(path)?;
-		let mut out = io::BufWriter::new(File::create(path)?);
-		changelog.prepend(changelog_before, &mut out)?;
-	}
-	if output.is_some() || args.prepend.is_none() {
-		changelog.generate(&mut out)?;
-	}
+    // Print the result.
+    let mut out: Box<dyn io::Write> = if let Some(path) = &output {
+        if path == Path::new("-") {
+            Box::new(io::stdout())
+        } else {
+            Box::new(io::BufWriter::new(File::create(path)?))
+        }
+    } else {
+        Box::new(io::stdout())
+    };
+    if args.bump.is_some() || args.bumped_version {
+        let next_version = if let Some(next_version) = changelog.bump_version()? {
+            next_version
+        } else if let Some(last_version) =
+            changelog.releases.first().cloned().and_then(|v| v.version)
+        {
+            warn!("There is nothing to bump.");
+            last_version
+        } else if changelog.releases.is_empty() {
+            config.bump.get_initial_tag()
+        } else {
+            return Ok(());
+        };
+        if let Some(tag_pattern) = &config.git.tag_pattern {
+            if !tag_pattern.is_match(&next_version) {
+                return Err(Error::ChangelogError(format!(
+                    "Next version ({}) does not match the tag pattern: {}",
+                    next_version, tag_pattern
+                )));
+            }
+        }
+        if args.bumped_version {
+            writeln!(out, "{next_version}")?;
+            return Ok(());
+        }
+    }
+    if args.context {
+        changelog.write_context(&mut out)?;
+        return Ok(());
+    }
+    if let Some(path) = &args.prepend {
+        let changelog_before = fs::read_to_string(path)?;
+        let mut out = io::BufWriter::new(File::create(path)?);
+        changelog.prepend(changelog_before, &mut out)?;
+    }
+    if output.is_some() || args.prepend.is_none() {
+        changelog.generate(&mut out)?;
+    }
 
-	Ok(())
+    Ok(())
 }

--- a/git-cliff/src/logger.rs
+++ b/git-cliff/src/logger.rs
@@ -17,58 +17,58 @@ static MAX_MODULE_WIDTH: AtomicUsize = AtomicUsize::new(0);
 
 /// Wrapper for the padded values.
 struct Padded<T> {
-	value: T,
-	width: usize,
+    value: T,
+    width: usize,
 }
 
 impl<T: fmt::Display> fmt::Display for Padded<T> {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{: <width$}", self.value, width = self.width)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{: <width$}", self.value, width = self.width)
+    }
 }
 
 /// Returns the max width of the target.
 fn max_target_width(target: &str) -> usize {
-	let max_width = MAX_MODULE_WIDTH.load(Ordering::Relaxed);
-	if max_width < target.len() {
-		MAX_MODULE_WIDTH.store(target.len(), Ordering::Relaxed);
-		target.len()
-	} else {
-		max_width
-	}
+    let max_width = MAX_MODULE_WIDTH.load(Ordering::Relaxed);
+    if max_width < target.len() {
+        MAX_MODULE_WIDTH.store(target.len(), Ordering::Relaxed);
+        target.len()
+    } else {
+        max_width
+    }
 }
 
 /// Adds colors to the given level and returns it.
 fn colored_level(style: &mut Style, level: Level) -> StyledValue<'_, &'static str> {
-	match level {
-		Level::Trace => style.set_color(Color::Magenta).value("TRACE"),
-		Level::Debug => style.set_color(Color::Blue).value("DEBUG"),
-		Level::Info => style.set_color(Color::Green).value("INFO "),
-		Level::Warn => style.set_color(Color::Yellow).value("WARN "),
-		Level::Error => style.set_color(Color::Red).value("ERROR"),
-	}
+    match level {
+        Level::Trace => style.set_color(Color::Magenta).value("TRACE"),
+        Level::Debug => style.set_color(Color::Blue).value("DEBUG"),
+        Level::Info => style.set_color(Color::Green).value("INFO "),
+        Level::Warn => style.set_color(Color::Yellow).value("WARN "),
+        Level::Error => style.set_color(Color::Red).value("ERROR"),
+    }
 }
 
 #[cfg(feature = "remote")]
 lazy_static::lazy_static! {
-	/// Lazily initialized progress bar.
-	pub static ref PROGRESS_BAR: ProgressBar = {
-		let progress_bar = ProgressBar::new_spinner();
-		progress_bar.set_style(
-			ProgressStyle::with_template("{spinner:.green} {msg}")
-				.unwrap()
-				.tick_strings(&[
-					"▹▹▹▹▹",
-					"▸▹▹▹▹",
-					"▹▸▹▹▹",
-					"▹▹▸▹▹",
-					"▹▹▹▸▹",
-					"▹▹▹▹▸",
-					"▪▪▪▪▪",
-				]),
-		);
-		progress_bar
-	};
+    /// Lazily initialized progress bar.
+    pub static ref PROGRESS_BAR: ProgressBar = {
+        let progress_bar = ProgressBar::new_spinner();
+        progress_bar.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg}")
+                .unwrap()
+                .tick_strings(&[
+                    "▹▹▹▹▹",
+                    "▸▹▹▹▹",
+                    "▹▸▹▹▹",
+                    "▹▹▸▹▹",
+                    "▹▹▹▸▹",
+                    "▹▹▹▹▸",
+                    "▪▪▪▪▪",
+                ]),
+        );
+        progress_bar
+    };
 }
 
 /// Initializes the global logger.
@@ -77,99 +77,81 @@ lazy_static::lazy_static! {
 /// by the network operations that are related to GitHub.
 #[allow(unreachable_code, clippy::needless_return)]
 pub fn init() -> Result<()> {
-	let mut builder = Builder::new();
-	builder.format(move |f, record| {
-		let target = record.target();
-		let max_width = max_target_width(target);
+    let mut builder = Builder::new();
+    builder.format(move |f, record| {
+        let target = record.target();
+        let max_width = max_target_width(target);
 
-		let mut style = f.style();
-		let level = colored_level(&mut style, record.level());
+        let mut style = f.style();
+        let level = colored_level(&mut style, record.level());
 
-		let mut style = f.style();
-		let target = style.set_bold(true).value(Padded {
-			value: target,
-			width: max_width,
-		});
+        let mut style = f.style();
+        let target = style.set_bold(true).value(Padded {
+            value: target,
+            width: max_width,
+        });
 
-		#[cfg(feature = "github")]
-		{
-			let message = record.args().to_string();
-			if message
-				.starts_with(git_cliff_core::remote::github::START_FETCHING_MSG)
-			{
-				PROGRESS_BAR
-					.enable_steady_tick(std::time::Duration::from_millis(80));
-				PROGRESS_BAR.set_message(message);
-				return Ok(());
-			} else if message
-				.starts_with(git_cliff_core::remote::github::FINISHED_FETCHING_MSG)
-			{
-				PROGRESS_BAR.finish_and_clear();
-				return Ok(());
-			}
-		}
+        #[cfg(feature = "github")]
+        {
+            let message = record.args().to_string();
+            if message.starts_with(git_cliff_core::remote::github::START_FETCHING_MSG) {
+                PROGRESS_BAR.enable_steady_tick(std::time::Duration::from_millis(80));
+                PROGRESS_BAR.set_message(message);
+                return Ok(());
+            } else if message.starts_with(git_cliff_core::remote::github::FINISHED_FETCHING_MSG) {
+                PROGRESS_BAR.finish_and_clear();
+                return Ok(());
+            }
+        }
 
-		#[cfg(feature = "gitlab")]
-		{
-			let message = record.args().to_string();
-			if message
-				.starts_with(git_cliff_core::remote::gitlab::START_FETCHING_MSG)
-			{
-				PROGRESS_BAR
-					.enable_steady_tick(std::time::Duration::from_millis(80));
-				PROGRESS_BAR.set_message(message);
-				return Ok(());
-			} else if message
-				.starts_with(git_cliff_core::remote::gitlab::FINISHED_FETCHING_MSG)
-			{
-				PROGRESS_BAR.finish_and_clear();
-				return Ok(());
-			}
-		}
+        #[cfg(feature = "gitlab")]
+        {
+            let message = record.args().to_string();
+            if message.starts_with(git_cliff_core::remote::gitlab::START_FETCHING_MSG) {
+                PROGRESS_BAR.enable_steady_tick(std::time::Duration::from_millis(80));
+                PROGRESS_BAR.set_message(message);
+                return Ok(());
+            } else if message.starts_with(git_cliff_core::remote::gitlab::FINISHED_FETCHING_MSG) {
+                PROGRESS_BAR.finish_and_clear();
+                return Ok(());
+            }
+        }
 
-		#[cfg(feature = "gitea")]
-		{
-			let message = record.args().to_string();
-			if message.starts_with(git_cliff_core::remote::gitea::START_FETCHING_MSG)
-			{
-				PROGRESS_BAR
-					.enable_steady_tick(std::time::Duration::from_millis(80));
-				PROGRESS_BAR.set_message(message);
-				return Ok(());
-			} else if message
-				.starts_with(git_cliff_core::remote::gitea::FINISHED_FETCHING_MSG)
-			{
-				PROGRESS_BAR.finish_and_clear();
-				return Ok(());
-			}
-		}
+        #[cfg(feature = "gitea")]
+        {
+            let message = record.args().to_string();
+            if message.starts_with(git_cliff_core::remote::gitea::START_FETCHING_MSG) {
+                PROGRESS_BAR.enable_steady_tick(std::time::Duration::from_millis(80));
+                PROGRESS_BAR.set_message(message);
+                return Ok(());
+            } else if message.starts_with(git_cliff_core::remote::gitea::FINISHED_FETCHING_MSG) {
+                PROGRESS_BAR.finish_and_clear();
+                return Ok(());
+            }
+        }
 
-		#[cfg(feature = "bitbucket")]
-		{
-			let message = record.args().to_string();
-			if message
-				.starts_with(git_cliff_core::remote::bitbucket::START_FETCHING_MSG)
-			{
-				PROGRESS_BAR
-					.enable_steady_tick(std::time::Duration::from_millis(80));
-				PROGRESS_BAR.set_message(message);
-				return Ok(());
-			} else if message.starts_with(
-				git_cliff_core::remote::bitbucket::FINISHED_FETCHING_MSG,
-			) {
-				PROGRESS_BAR.finish_and_clear();
-				return Ok(());
-			}
-		}
+        #[cfg(feature = "bitbucket")]
+        {
+            let message = record.args().to_string();
+            if message.starts_with(git_cliff_core::remote::bitbucket::START_FETCHING_MSG) {
+                PROGRESS_BAR.enable_steady_tick(std::time::Duration::from_millis(80));
+                PROGRESS_BAR.set_message(message);
+                return Ok(());
+            } else if message.starts_with(git_cliff_core::remote::bitbucket::FINISHED_FETCHING_MSG)
+            {
+                PROGRESS_BAR.finish_and_clear();
+                return Ok(());
+            }
+        }
 
-		writeln!(f, " {} {} > {}", level, target, record.args())
-	});
+        writeln!(f, " {} {} > {}", level, target, record.args())
+    });
 
-	if let Ok(var) = env::var(LOGGER_ENV) {
-		builder.parse_filters(&var);
-	}
+    if let Ok(var) = env::var(LOGGER_ENV) {
+        builder.parse_filters(&var);
+    }
 
-	builder
-		.try_init()
-		.map_err(|e| Error::LoggerError(e.to_string()))
+    builder
+        .try_init()
+        .map_err(|e| Error::LoggerError(e.to_string()))
 }

--- a/git-cliff/src/main.rs
+++ b/git-cliff/src/main.rs
@@ -10,42 +10,42 @@ use git_cliff_core::error::Result;
 mod profiler;
 
 fn main() -> Result<()> {
-	// Parse the command line arguments
-	let args = Opt::parse();
-	if args.verbose == 1 {
-		unsafe { env::set_var("RUST_LOG", "debug") };
-	} else if args.verbose > 1 {
-		unsafe { env::set_var("RUST_LOG", "trace") };
-	} else if env::var_os("RUST_LOG").is_none() {
-		unsafe { env::set_var("RUST_LOG", "info") };
-	}
-	logger::init()?;
+    // Parse the command line arguments
+    let args = Opt::parse();
+    if args.verbose == 1 {
+        unsafe { env::set_var("RUST_LOG", "debug") };
+    } else if args.verbose > 1 {
+        unsafe { env::set_var("RUST_LOG", "trace") };
+    } else if env::var_os("RUST_LOG").is_none() {
+        unsafe { env::set_var("RUST_LOG", "info") };
+    }
+    logger::init()?;
 
-	// Initialize the profiler guard if the feature is enabled
-	let mut _profiler_guard = None;
-	#[cfg(feature = "profiler")]
-	{
-		_profiler_guard = profiler::start_profiling();
-	}
-	#[cfg(not(feature = "profiler"))]
-	{
-		_profiler_guard = Some(());
-	}
+    // Initialize the profiler guard if the feature is enabled
+    let mut _profiler_guard = None;
+    #[cfg(feature = "profiler")]
+    {
+        _profiler_guard = profiler::start_profiling();
+    }
+    #[cfg(not(feature = "profiler"))]
+    {
+        _profiler_guard = Some(());
+    }
 
-	// Run git-cliff
-	let exit_code = match git_cliff::run(args) {
-		Ok(()) => 0,
-		Err(e) => {
-			log::error!("{}", e);
-			1
-		}
-	};
+    // Run git-cliff
+    let exit_code = match git_cliff::run(args) {
+        Ok(()) => 0,
+        Err(e) => {
+            log::error!("{}", e);
+            1
+        }
+    };
 
-	// Report the profiler if the feature is enabled
-	#[cfg(feature = "profiler")]
-	{
-		profiler::finish_profiling(_profiler_guard)?;
-	}
+    // Report the profiler if the feature is enabled
+    #[cfg(feature = "profiler")]
+    {
+        profiler::finish_profiling(_profiler_guard)?;
+    }
 
-	process::exit(exit_code);
+    process::exit(exit_code);
 }

--- a/git-cliff/src/profiler.rs
+++ b/git-cliff/src/profiler.rs
@@ -2,51 +2,49 @@ use git_cliff_core::error::Result;
 
 /// Creates a profiler guard and returns it.
 pub(crate) fn start_profiling() -> Option<pprof::ProfilerGuard<'static>> {
-	match pprof::ProfilerGuardBuilder::default()
-		.frequency(1000)
-		.blocklist(&["libc", "libgcc", "pthread", "vdso"])
-		.build()
-	{
-		Ok(guard) => Some(guard),
-		Err(e) => {
-			log::error!("failed to build profiler guard: {e}");
-			None
-		}
-	}
+    match pprof::ProfilerGuardBuilder::default()
+        .frequency(1000)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+    {
+        Ok(guard) => Some(guard),
+        Err(e) => {
+            log::error!("failed to build profiler guard: {e}");
+            None
+        }
+    }
 }
 
 /// Reports the profiling results.
-pub(crate) fn finish_profiling(
-	profiler_guard: Option<pprof::ProfilerGuard>,
-) -> Result<()> {
-	match profiler_guard
-		.expect("failed to retrieve profiler guard")
-		.report()
-		.build()
-	{
-		Ok(report) => {
-			#[cfg(feature = "profiler-flamegraph")]
-			{
-				use std::fs::File;
-				let random = rand::random::<u64>();
-				let file = File::create(format!(
-					"{}.{random}.flamegraph.svg",
-					env!("CARGO_PKG_NAME"),
-				))?;
-				if let Err(e) = report.flamegraph(file) {
-					log::error!("failed to create flamegraph file: {e}");
-				}
-			}
+pub(crate) fn finish_profiling(profiler_guard: Option<pprof::ProfilerGuard>) -> Result<()> {
+    match profiler_guard
+        .expect("failed to retrieve profiler guard")
+        .report()
+        .build()
+    {
+        Ok(report) => {
+            #[cfg(feature = "profiler-flamegraph")]
+            {
+                use std::fs::File;
+                let random = rand::random::<u64>();
+                let file = File::create(format!(
+                    "{}.{random}.flamegraph.svg",
+                    env!("CARGO_PKG_NAME"),
+                ))?;
+                if let Err(e) = report.flamegraph(file) {
+                    log::error!("failed to create flamegraph file: {e}");
+                }
+            }
 
-			#[cfg(not(feature = "profiler-flamegraph"))]
-			{
-				log::info!("profiling report: {:?}", &report);
-			}
-		}
-		Err(e) => {
-			log::error!("failed to build profiler report: {e}");
-		}
-	}
+            #[cfg(not(feature = "profiler-flamegraph"))]
+            {
+                log::info!("profiling report: {:?}", &report);
+            }
+        }
+        Err(e) => {
+            log::error!("failed to build profiler report: {e}");
+        }
+    }
 
-	Ok(())
+    Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,18 +1,16 @@
 edition = "2024"
-max_width = 85
+max_width = 100
 newline_style = "Unix"
-hard_tabs = true
-tab_spaces = 4
-use_field_init_shorthand = true
 reorder_imports = true
+use_field_init_shorthand = true
 
-# Unstable options
+# unstable options that require rust nightly
 binop_separator = "Back"
+comment_width = 100
 format_code_in_doc_comments = true
 format_strings = true
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
 normalize_doc_attributes = true
 overflow_delimited_expr = true
-struct_field_align_threshold = 20
 wrap_comments = true


### PR DESCRIPTION
chore: update formatting rules

Use spaces instead of tabs for indentation, wrap at 100 characters, and
remove the setting that aligns struct fields vertically as this
generally harms readability.

These changes make the code more consistent with the Rust community's
conventions and improve readability by not truncating lines too early.

---
Justification:

https://www.youtube.com/watch\?v\=V7PLxL8jIl8

This brings things more in line with pretty much every rust project out there. Hard tabs are used in around 0.1% of rust projects:
- `hard_tabs = true`: https://github.com/search?q=path%3A%22rustfmt.toml%22+%22hard_tabs+%3D+true%22+AND+%28NOT+is%3Afork%29&type=code (1.9k results)
- projects with a rustfmt.toml: https://github.com/search?q=path%3A%22rustfmt.toml%22+AND+%28NOT+is%3Afork%29&type=code (14.6k results)
- rust projects: https://github.com/search?q=path%3A%2F%28%5E%7C%5C%2F%29cargo%5C.toml%24%2F+AND+%28NOT+is%3Afork%29&type=code (1.4M results)