### PR TITLE
Fix GitLab Author Metadata: Use `username` Instead of `author_name`, …

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -551,6 +551,7 @@ mod test {
 					merge_commit_sha: Some(String::from(
 						"1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
 					)),
+					user:             None,
 					labels:           vec![PullRequestLabel {
 						name: String::from("rust"),
 					}],
@@ -561,6 +562,7 @@ mod test {
 					merge_commit_sha: Some(String::from(
 						"21f6aa587fcb772de13f2fde0e92697c51f84162",
 					)),
+					user:             None,
 					labels:           vec![PullRequestLabel {
 						name: String::from("rust"),
 					}],
@@ -571,6 +573,7 @@ mod test {
 					merge_commit_sha: Some(String::from(
 						"35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973",
 					)),
+					user:             None,
 					labels:           vec![PullRequestLabel {
 						name: String::from("deps"),
 					}],
@@ -581,6 +584,7 @@ mod test {
 					merge_commit_sha: Some(String::from(
 						"4d3ffe4753b923f4d7807c490e650e6624a12074",
 					)),
+					user:             None,
 					labels:           vec![PullRequestLabel {
 						name: String::from("deps"),
 					}],
@@ -591,6 +595,7 @@ mod test {
 					merge_commit_sha: Some(String::from(
 						"5a55e92e5a62dc5bf9872ffb2566959fad98bd05",
 					)),
+					user:             None,
 					labels:           vec![PullRequestLabel {
 						name: String::from("github"),
 					}],

--- a/git-cliff-core/src/remote/bitbucket.rs
+++ b/git-cliff-core/src/remote/bitbucket.rs
@@ -149,6 +149,10 @@ impl RemotePullRequest for BitbucketPullRequest {
 	fn merge_commit(&self) -> Option<String> {
 		Some(self.merge_commit.hash.clone())
 	}
+
+	fn author_username(&self) -> Option<String> {
+		self.author.login.clone()
+	}
 }
 
 /// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-get>

--- a/git-cliff-core/src/remote/github.rs
+++ b/git-cliff-core/src/remote/github.rs
@@ -95,6 +95,13 @@ pub struct GitHubCommitAuthor {
 	pub login: Option<String>,
 }
 
+/// Author of the pull request.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GitHubPullRequestUser {
+	/// Username.
+	pub login: Option<String>,
+}
+
 /// Label of the pull request.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -112,6 +119,8 @@ pub struct GitHubPullRequest {
 	pub title:            Option<String>,
 	/// SHA of the merge commit.
 	pub merge_commit_sha: Option<String>,
+	/// Author of the pull request.
+	pub user:             Option<GitHubPullRequestUser>,
 	/// Labels of the pull request.
 	pub labels:           Vec<PullRequestLabel>,
 }
@@ -131,6 +140,10 @@ impl RemotePullRequest for GitHubPullRequest {
 
 	fn merge_commit(&self) -> Option<String> {
 		self.merge_commit_sha.clone()
+	}
+
+	fn author_username(&self) -> Option<String> {
+		self.user.clone().and_then(|v| v.login)
 	}
 }
 

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -194,6 +194,10 @@ impl RemotePullRequest for GitLabMergeRequest {
 			.or(self.squash_commit_sha.clone())
 			.or(Some(self.sha.clone()))
 	}
+
+	fn author_username(&self) -> Option<String> {
+		Some(self.author.username.clone())
+	}
 }
 
 impl RemoteEntry for GitLabMergeRequest {

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -115,6 +115,10 @@ pub trait RemotePullRequest: DynClone {
 	fn labels(&self) -> Vec<String>;
 	/// Merge commit SHA.
 	fn merge_commit(&self) -> Option<String>;
+	/// Username of the author of the pull request.
+	fn author_username(&self) -> Option<String> {
+		None
+	}
 }
 
 dyn_clone::clone_trait_object!(RemotePullRequest);
@@ -354,7 +358,10 @@ macro_rules! update_release_metadata {
 							pr.merge_commit() == Some(v.id().clone()) ||
 								pr.merge_commit() == sha_short
 						});
-						commit.$remote.username = v.username();
+						let username = pull_request
+							.and_then(|pr| pr.author_username())
+							.or_else(|| v.username());
+						commit.$remote.username = username.clone();
 						commit.$remote.pr_number = pull_request.map(|v| v.number());
 						commit.$remote.pr_title =
 							pull_request.and_then(|v| v.title().clone());


### PR DESCRIPTION
…Add `author_username` Trait, and Improve Release Metadata Extraction (#1)

## Description

This pull request introduces support for retrieving the author's username from pull requests across different remote platforms (GitHub, GitLab, and Bitbucket). It also updates the release metadata logic to incorporate this new functionality. Below is a summary of the most important changes:

### Enhancements to `RemotePullRequest` Trait:

* Added a new method `author_username` to the `RemotePullRequest` trait, which returns the username of the pull request's author. A default implementation returning `None` is provided for backward compatibility. (`git-cliff-core/src/remote/mod.rs`, [git-cliff-core/src/remote/mod.rsR118-R121](diffhunk://#diff-9d830e0be5fc20135aee3ba39934c06263208881475d426a20c85a3b7dbba385R118-R121))

### Platform-Specific Implementations:

* **GitHub**: 
  - Introduced a new struct `GitHubPullRequestUser` to represent the pull request author.
  - Updated the `GitHubPullRequest` struct to include a `user` field of type `Option<GitHubPullRequestUser>`.
  - Implemented the `author_username` method for `GitHubPullRequest` to return the author's username. (`git-cliff-core/src/remote/github.rs`, [[1]](diffhunk://#diff-a9ca597c71fe138c7f11d73a4b7696b61f7a47feeacde88f640e8349518b1a03R98-R104) [[2]](diffhunk://#diff-a9ca597c71fe138c7f11d73a4b7696b61f7a47feeacde88f640e8349518b1a03R122-R123) [[3]](diffhunk://#diff-a9ca597c71fe138c7f11d73a4b7696b61f7a47feeacde88f640e8349518b1a03R144-R147)

* **GitLab**: Implemented the `author_username` method for `GitLabMergeRequest` to return the author's username. (`git-cliff-core/src/remote/gitlab.rs`, [git-cliff-core/src/remote/gitlab.rsR197-R200](diffhunk://#diff-26d62ab23081d1553984f3abec6f6f59d168d32493c43dbc7162431c7239f1b8R197-R200))

* **Bitbucket**: Implemented the `author_username` method for `BitbucketPullRequest` to return the author's username. (`git-cliff-core/src/remote/bitbucket.rs`, [git-cliff-core/src/remote/bitbucket.rsR152-R155](diffhunk://#diff-66cced4c6dfbc084d1fa09a0ca9cf2ea6f5c60957f8767fc9a4ee0473d1421aaR152-R155))

### Updates to Release Metadata Logic:

* Modified the `update_release_metadata` macro to use the `author_username` method when setting the username in release metadata. This ensures that the author's username is correctly captured from the associated pull request, falling back to the existing logic if unavailable. (`git-cliff-core/src/remote/mod.rs`, [git-cliff-core/src/remote/mod.rsL357-R364](diffhunk://#diff-9d830e0be5fc20135aee3ba39934c06263208881475d426a20c85a3b7dbba385L357-R364))

### Test Adjustments:

* Updated test cases in `git-cliff-core/src/release.rs` to include the `user` field with a `None` value for pull requests, ensuring compatibility with the new `GitHubPullRequest` structure. (`git-cliff-core/src/release.rs`, [[1]](diffhunk://#diff-56d2e9b48d9c6d1fee904b269749489630519d3cfd9c2fc6e746057316c6a09dR554) [[2]](diffhunk://#diff-56d2e9b48d9c6d1fee904b269749489630519d3cfd9c2fc6e746057316c6a09dR565) [[3]](diffhunk://#diff-56d2e9b48d9c6d1fee904b269749489630519d3cfd9c2fc6e746057316c6a09dR576) [[4]](diffhunk://#diff-56d2e9b48d9c6d1fee904b269749489630519d3cfd9c2fc6e746057316c6a09dR587) [[5]](diffhunk://#diff-56d2e9b48d9c6d1fee904b269749489630519d3cfd9c2fc6e746057316c6a09dR598)

## Motivation and Context

The primary motivation was to resolve the issue with loading metadata from GitLab.

#810, #687

## How Has This Been Tested?

I’m not much of a programmer—especially not in Rust—but I was able to identify the root of the issue. The tests still need to be completed, and a proper code review is required. (There may be other things as well, but I’m probably not equipped to handle those.)

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->