### PR TITLE
fix(log): display correct repository paths in log

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -270,7 +270,7 @@ fn process_repository<'a>(
 	// Include only the current directory if not running from the root repository
 	let mut include_path = config.git.include_paths.clone();
 	if let Some(mut path_diff) =
-		pathdiff::diff_paths(env::current_dir()?, repository.root_path()?)
+		pathdiff::diff_paths(repository.root_path()?, env::current_dir()?)
 	{
 		if args.workdir.is_none() &&
 			include_path.is_empty() &&


### PR DESCRIPTION
## Description

Base path is second parameter of `pathdiff::diff_paths`.

## Motivation and Context

_Partially_ f*xes #1187 

## How Has This Been Tested?

Just vibes

## Screenshots / Logs (if applicable)


```
cargo run -- --repository ../ratatui ../mousefood
```

Before:
```
 INFO  git_cliff > Including changes from the current directory: "../git-cliff"
 INFO  git_cliff > Including changes from the current directory: "../git-cliff"
```
After:
```
 INFO  git_cliff > Including changes from the current directory: "../ratatui"
 INFO  git_cliff > Including changes from the current directory: "../mousefood"
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
