### PR TITLE
feat(changelog): implement commit processing order as set of steps

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -204,9 +204,9 @@ impl<'a> Changelog<'a> {
             .filter_map(|commit| {
                 let mut commit_into_conventional = Ok(commit.clone());
                 if git_config.conventional_commits {
-                    if !git_config.require_conventional
-                        && git_config.filter_unconventional
-                        && !git_config.split_commits
+                    if !git_config.require_conventional &&
+                        git_config.filter_unconventional &&
+                        !git_config.split_commits
                     {
                         commit_into_conventional = commit.clone().into_conventional();
                     } else if let Ok(conv_commit) = commit.clone().into_conventional() {
@@ -397,8 +397,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref())
-                    == Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -427,12 +427,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom
-            || self
-                .body_template
-                .contains_variable(github::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -479,12 +477,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom
-            || self
-                .body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -538,12 +534,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom
-            || self
-                .body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -593,12 +587,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom
-            || self
-                .body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -646,12 +638,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::azure_devops;
-        if self.config.remote.azure_devops.is_custom
-            || self
-                .body_template
-                .contains_variable(azure_devops::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.azure_devops.is_custom ||
+            self.body_template
+                .contains_variable(azure_devops::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(azure_devops::TEMPLATE_VARIABLES))
         {
@@ -1299,29 +1289,24 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(
-                String::from("submodule_one"),
-                vec![
-                    Commit::new(
-                        String::from("sub0jkl12"),
-                        String::from("chore(app): submodule_one do nothing"),
-                    ),
-                    Commit::new(
-                        String::from("subqwerty"),
-                        String::from("chore: submodule_one <preprocess>"),
-                    ),
-                    Commit::new(
-                        String::from("subqwertz"),
-                        String::from("feat!: submodule_one support breaking commits"),
-                    ),
-                    Commit::new(
-                        String::from("subqwert0"),
-                        String::from(
-                            "match(group): submodule_one support regex-replace for groups",
-                        ),
-                    ),
-                ],
-            )]),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1434,20 +1419,14 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (
-                        String::from("submodule_one"),
-                        vec![
-                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                        ],
-                    ),
-                    (
-                        String::from("submodule_two"),
-                        vec![Commit::new(
-                            String::from("ab76ef"),
-                            String::from("sub_two bump"),
-                        )],
-                    ),
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -162,8 +162,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref())
-                    == Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -192,12 +192,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom
-            || self
-                .body_template
-                .contains_variable(github::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -244,12 +242,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom
-            || self
-                .body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -303,12 +299,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom
-            || self
-                .body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -358,12 +352,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom
-            || self
-                .body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -411,12 +403,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::azure_devops;
-        if self.config.remote.azure_devops.is_custom
-            || self
-                .body_template
-                .contains_variable(azure_devops::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.azure_devops.is_custom ||
+            self.body_template
+                .contains_variable(azure_devops::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(azure_devops::TEMPLATE_VARIABLES))
         {
@@ -1065,29 +1055,24 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(
-                String::from("submodule_one"),
-                vec![
-                    Commit::new(
-                        String::from("sub0jkl12"),
-                        String::from("chore(app): submodule_one do nothing"),
-                    ),
-                    Commit::new(
-                        String::from("subqwerty"),
-                        String::from("chore: submodule_one <preprocess>"),
-                    ),
-                    Commit::new(
-                        String::from("subqwertz"),
-                        String::from("feat!: submodule_one support breaking commits"),
-                    ),
-                    Commit::new(
-                        String::from("subqwert0"),
-                        String::from(
-                            "match(group): submodule_one support regex-replace for groups",
-                        ),
-                    ),
-                ],
-            )]),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1200,20 +1185,14 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (
-                        String::from("submodule_one"),
-                        vec![
-                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                        ],
-                    ),
-                    (
-                        String::from("submodule_two"),
-                        vec![Commit::new(
-                            String::from("ab76ef"),
-                            String::from("sub_two bump"),
-                        )],
-                    ),
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -204,9 +204,9 @@ impl<'a> Changelog<'a> {
             .filter_map(|commit| {
                 let mut commit_into_conventional = Ok(commit.clone());
                 if git_config.conventional_commits {
-                    if !git_config.require_conventional &&
-                        git_config.filter_unconventional &&
-                        !git_config.split_commits
+                    if !git_config.require_conventional
+                        && git_config.filter_unconventional
+                        && !git_config.split_commits
                     {
                         commit_into_conventional = commit.clone().into_conventional();
                     } else if let Ok(conv_commit) = commit.clone().into_conventional() {
@@ -397,8 +397,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref()) ==
-                    Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref())
+                    == Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -427,10 +427,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom ||
-            self.body_template
-                .contains_variable(github::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.github.is_custom
+            || self
+                .body_template
+                .contains_variable(github::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -477,10 +479,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom ||
-            self.body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitlab.is_custom
+            || self
+                .body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -534,10 +538,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom ||
-            self.body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitea.is_custom
+            || self
+                .body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -587,10 +593,12 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom ||
-            self.body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.bitbucket.is_custom
+            || self
+                .body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -1291,24 +1299,29 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
-                Commit::new(
-                    String::from("sub0jkl12"),
-                    String::from("chore(app): submodule_one do nothing"),
-                ),
-                Commit::new(
-                    String::from("subqwerty"),
-                    String::from("chore: submodule_one <preprocess>"),
-                ),
-                Commit::new(
-                    String::from("subqwertz"),
-                    String::from("feat!: submodule_one support breaking commits"),
-                ),
-                Commit::new(
-                    String::from("subqwert0"),
-                    String::from("match(group): submodule_one support regex-replace for groups"),
-                ),
-            ])]),
+            submodule_commits: HashMap::from([(
+                String::from("submodule_one"),
+                vec![
+                    Commit::new(
+                        String::from("sub0jkl12"),
+                        String::from("chore(app): submodule_one do nothing"),
+                    ),
+                    Commit::new(
+                        String::from("subqwerty"),
+                        String::from("chore: submodule_one <preprocess>"),
+                    ),
+                    Commit::new(
+                        String::from("subqwertz"),
+                        String::from("feat!: submodule_one support breaking commits"),
+                    ),
+                    Commit::new(
+                        String::from("subqwert0"),
+                        String::from(
+                            "match(group): submodule_one support regex-replace for groups",
+                        ),
+                    ),
+                ],
+            )]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1421,14 +1434,20 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (String::from("submodule_one"), vec![
-                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                    ]),
-                    (String::from("submodule_two"), vec![Commit::new(
-                        String::from("ab76ef"),
-                        String::from("sub_two bump"),
-                    )]),
+                    (
+                        String::from("submodule_one"),
+                        vec![
+                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                        ],
+                    ),
+                    (
+                        String::from("submodule_two"),
+                        vec![Commit::new(
+                            String::from("ab76ef"),
+                            String::from("sub_two bump"),
+                        )],
+                    ),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]
@@ -1591,6 +1610,13 @@ mod test {
     #[test]
     fn changelog_generator_split_commits() -> Result<()> {
         let (mut config, mut releases) = get_test_data();
+        config.git.processing_order.order = vec![
+            ProcessingStep::CommitPreprocessors,
+            ProcessingStep::SplitCommits,
+            ProcessingStep::IntoConventional,
+            ProcessingStep::CommitParsers,
+            ProcessingStep::LinkParsers,
+        ];
         config.git.split_commits = true;
         config.git.filter_unconventional = false;
         config.git.protect_breaking_commits = true;
@@ -1634,8 +1660,7 @@ style: make awesome stuff look better
         releases[2].commits.push(Commit {
             id: String::from("123abc"),
             message: String::from(
-                "merge(deps): bump some deps
-
+                "chore(deps): bump some deps
 chore(deps): bump some more deps
 chore(deps): fix broken deps
 ",
@@ -1668,6 +1693,7 @@ chore(deps): fix broken deps
 			- document zyx
 
 			#### deps
+			- bump some deps
 			- bump some more deps
 			- fix broken deps
 
@@ -1680,9 +1706,9 @@ chore(deps): fix broken deps
 
 			### Commit Statistics
 
-			- 7 commit(s) contributed to the release.
+			- 8 commit(s) contributed to the release.
 			- 6 day(s) passed between the first and last commit.
-			- 7 commit(s) parsed as conventional.
+			- 8 commit(s) parsed as conventional.
 			- 1 linked issue(s) detected in commits.
 			  - [#5](https://github.com/5) (referenced 1 time(s))
 			- -578 day(s) passed between releases.
@@ -1729,8 +1755,6 @@ chore(deps): fix broken deps
 			#### other
 			- support unconventional commits
 			- this commit is preprocessed
-			- use footer
-			- footer text
 			- make awesome stuff look better
 
 			#### ui
@@ -1738,9 +1762,9 @@ chore(deps): fix broken deps
 
 			### Commit Statistics
 
-			- 20 commit(s) contributed to the release.
-			- 13 day(s) passed between the first and last commit.
-			- 19 commit(s) parsed as conventional.
+			- 18 commit(s) contributed to the release.
+			- 12 day(s) passed between the first and last commit.
+			- 17 commit(s) parsed as conventional.
 			- 1 linked issue(s) detected in commits.
 			  - [#3](https://github.com/3) (referenced 1 time(s))
 			-- total releases: 2 --

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -204,9 +204,9 @@ impl<'a> Changelog<'a> {
             .filter_map(|commit| {
                 let mut commit_into_conventional = Ok(commit.clone());
                 if git_config.conventional_commits {
-                    if !git_config.require_conventional
-                        && git_config.filter_unconventional
-                        && !git_config.split_commits
+                    if !git_config.require_conventional &&
+                        git_config.filter_unconventional &&
+                        !git_config.split_commits
                     {
                         commit_into_conventional = commit.clone().into_conventional();
                     } else if let Ok(conv_commit) = commit.clone().into_conventional() {
@@ -397,8 +397,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref())
-                    == Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -427,12 +427,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom
-            || self
-                .body_template
-                .contains_variable(github::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -479,12 +477,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom
-            || self
-                .body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -538,12 +534,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom
-            || self
-                .body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -593,12 +587,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom
-            || self
-                .body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -1299,30 +1291,24 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(
-                String::from("submodule_one"),
-                vec![
-                    Commit::new(
-                        String::from("sub0jkl12"),
-                        String::from("chore(app): submodule_one do nothing"),
-                    ),
-                    Commit::new(
-                        String::from("subqwerty"),
-                        String::from("chore: submodule_one <preprocess>"),
-                    ),
-                    Commit::new(
-                        String::from("subqwertz"),
-                        String::from("feat!: submodule_one support breaking commits"),
-                    ),
-                    Commit::new(
-                        String::from("subqwert0"),
-                        String::from(
-                            "match(group): submodule_one support regex-replace for \
-							 groups",
-                        ),
-                    ),
-                ],
-            )]),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1435,20 +1421,14 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (
-                        String::from("submodule_one"),
-                        vec![
-                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                        ],
-                    ),
-                    (
-                        String::from("submodule_two"),
-                        vec![Commit::new(
-                            String::from("ab76ef"),
-                            String::from("sub_two bump"),
-                        )],
-                    ),
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -218,8 +218,8 @@ impl Commit<'_> {
     //     let mut commit = self.clone();
     //     commit = commit.preprocess(&config.commit_preprocessors)?;
     //     if config.conventional_commits {
-    //         if !config.require_conventional && config.filter_unconventional && !config.split_commits
-    //         {
+    //         if !config.require_conventional && config.filter_unconventional &&
+    // !config.split_commits         {
     //             commit = commit.into_conventional()?;
     //         } else if let Ok(conv_commit) = commit.clone().into_conventional() {
     //             commit = conv_commit;
@@ -268,8 +268,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false)
-            && !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
+        parser.skip.unwrap_or(false) &&
+            !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.
@@ -709,9 +709,9 @@ fn apply_into_conventional<'a>(
         .filter_map(|commit| {
             let mut commit_into_conventional = Ok(commit.clone());
             if git_config.conventional_commits {
-                if !git_config.require_conventional
-                    && git_config.filter_unconventional
-                    && !git_config.split_commits
+                if !git_config.require_conventional &&
+                    git_config.filter_unconventional &&
+                    !git_config.split_commits
                 {
                     commit_into_conventional = commit.clone().into_conventional();
                 } else if let Ok(conv_commit) = commit.clone().into_conventional() {
@@ -816,7 +816,7 @@ mod test {
                 String::from("123124"),
                 String::from(
                     "fix(commit): break stuff\n\nBREAKING CHANGE: This commit breaks \
-                         stuff\nSigned-off-by: Test User <test@example.com>",
+                     stuff\nSigned-off-by: Test User <test@example.com>",
                 ),
             ),
         ];

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -266,8 +266,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false) &&
-            !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
+        parser.skip.unwrap_or(false)
+            && !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.
@@ -349,13 +349,20 @@ impl Commit<'_> {
                     }
                 }
             }
+            if parser.group == Some(String::from("Footer")) {
+                // println!("{:?}", self);
+                println!("Inside commit --> {:?}", self.message);
+            }
             if parser.sha.clone().map(|v| v.to_lowercase()).as_deref() == Some(&self.id) {
                 if self.skip_commit(parser, protect_breaking) {
+                    println!("  Skipping commit --> {}", self.message);
                     return Err(AppError::GroupError(String::from("Skipping commit")));
                 } else {
                     self.group = parser.group.clone().or(self.group);
                     self.scope = parser.scope.clone().or(self.scope);
                     self.default_scope = parser.default_scope.clone().or(self.default_scope);
+
+                    println!("Returning commit --> {}", self.message);
                     return Ok(self);
                 }
             }

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -266,8 +266,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false)
-            && !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
+        parser.skip.unwrap_or(false) &&
+            !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.
@@ -349,10 +349,8 @@ impl Commit<'_> {
                     }
                 }
             }
-            if parser.group == Some(String::from("Footer")) {
-                // println!("{:?}", self);
-                println!("Inside commit --> {:?}", self.message);
-            }
+            println!("Proccessing commit --> {:?}", self.message);
+
             if parser.sha.clone().map(|v| v.to_lowercase()).as_deref() == Some(&self.id) {
                 if self.skip_commit(parser, protect_breaking) {
                     println!("  Skipping commit --> {}", self.message);
@@ -362,7 +360,6 @@ impl Commit<'_> {
                     self.scope = parser.scope.clone().or(self.scope);
                     self.default_scope = parser.default_scope.clone().or(self.default_scope);
 
-                    println!("Returning commit --> {}", self.message);
                     return Ok(self);
                 }
             }

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -2,12 +2,14 @@ use git_conventional::{Commit as ConventionalCommit, Footer as ConventionalFoote
 #[cfg(feature = "repo")]
 use git2::{Commit as GitCommit, Signature as CommitSignature};
 use lazy_regex::{Lazy, Regex, lazy_regex};
+use log::{debug, trace};
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
 
-use crate::config::{CommitParser, GitConfig, LinkParser, TextProcessor};
+use crate::config::{CommitParser, GitConfig, LinkParser, ProcessingStep, TextProcessor};
 use crate::error::{Error as AppError, Result};
+use crate::summary::Summary;
 
 /// Regular expression for matching SHA1 and a following commit message
 /// separated by a whitespace.
@@ -25,7 +27,7 @@ pub struct Link {
 
 /// A conventional commit footer.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
-struct Footer<'a> {
+pub struct Footer<'a> {
     /// Token of the footer.
     ///
     /// This is the part of the footer preceding the separator. For example, for
@@ -207,33 +209,33 @@ impl Commit<'_> {
         self.raw_message.as_deref().unwrap_or(&self.message)
     }
 
-    /// Processes the commit.
-    ///
-    /// * converts commit to a conventional commit
-    /// * sets the group for the commit
-    /// * extracts links and generates URLs
-    pub fn process(&self, config: &GitConfig) -> Result<Self> {
-        let mut commit = self.clone();
-        commit = commit.preprocess(&config.commit_preprocessors)?;
-        if config.conventional_commits {
-            if !config.require_conventional && config.filter_unconventional && !config.split_commits
-            {
-                commit = commit.into_conventional()?;
-            } else if let Ok(conv_commit) = commit.clone().into_conventional() {
-                commit = conv_commit;
-            }
-        }
+    // /// Processes the commit.
+    // ///
+    // /// * converts commit to a conventional commit
+    // /// * sets the group for the commit
+    // /// * extracts links and generates URLs
+    // pub fn process(&self, config: &GitConfig) -> Result<Self> {
+    //     let mut commit = self.clone();
+    //     commit = commit.preprocess(&config.commit_preprocessors)?;
+    //     if config.conventional_commits {
+    //         if !config.require_conventional && config.filter_unconventional && !config.split_commits
+    //         {
+    //             commit = commit.into_conventional()?;
+    //         } else if let Ok(conv_commit) = commit.clone().into_conventional() {
+    //             commit = conv_commit;
+    //         }
+    //     }
 
-        commit = commit.parse(
-            &config.commit_parsers,
-            config.protect_breaking_commits,
-            config.filter_commits,
-        )?;
+    //     commit = commit.parse(
+    //         &config.commit_parsers,
+    //         config.protect_breaking_commits,
+    //         config.filter_commits,
+    //     )?;
 
-        commit = commit.parse_links(&config.link_parsers);
+    //     commit = commit.parse_links(&config.link_parsers);
 
-        Ok(commit)
-    }
+    //     Ok(commit)
+    // }
 
     /// Returns the commit with its conventional type set.
     pub fn into_conventional(mut self) -> Result<Self> {
@@ -266,8 +268,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false) &&
-            !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
+        parser.skip.unwrap_or(false)
+            && !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.
@@ -349,7 +351,7 @@ impl Commit<'_> {
                     }
                 }
             }
-            println!("Proccessing commit --> {:?}", self.message);
+            println!("Proccessing commit --> {}", self.message);
 
             if parser.sha.clone().map(|v| v.to_lowercase()).as_deref() == Some(&self.id) {
                 if self.skip_commit(parser, protect_breaking) {
@@ -519,6 +521,239 @@ pub(crate) fn commits_to_conventional_commits<'de, 'a, D: Deserializer<'de>>(
     Ok(commits)
 }
 
+/// Checks the commits and returns an error if any unconventional commits
+/// are found.
+fn check_conventional_commits(commits: &Vec<Commit<'_>>) -> Result<()> {
+    log::debug!("Verifying that all commits are conventional");
+    let mut unconventional_count = 0;
+    commits.iter().for_each(|commit| {
+        if commit.conv.is_none() {
+            log::error!(
+                "Commit {id} is not conventional:\n{message}",
+                id = &commit.id[..7],
+                message = commit
+                    .message
+                    .lines()
+                    .map(|line| { format!("    | {}", line.trim()) })
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            );
+            unconventional_count += 1;
+        }
+    });
+
+    if unconventional_count > 0 {
+        return Err(AppError::UnconventionalCommitsError(unconventional_count));
+    }
+
+    Ok(())
+}
+
+/// Checks the commits and returns an error if any commits are not matched
+/// by any commit parser.
+fn check_unmatched_commits(commits: &Vec<Commit<'_>>) -> Result<()> {
+    log::debug!("Verifying that no commits are unmatched by commit parsers");
+    let mut unmatched_count = 0;
+    commits.iter().for_each(|commit| {
+        let is_unmatched = commit.group.is_none();
+        if is_unmatched {
+            log::error!(
+                "Commit {id} was not matched by any commit parser:\n{message}",
+                id = &commit.id[..7],
+                message = commit
+                    .message
+                    .lines()
+                    .map(|line| { format!("    | {}", line.trim()) })
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            );
+            unmatched_count += 1;
+        }
+    });
+
+    if unmatched_count > 0 {
+        return Err(AppError::UnmatchedCommitsError(unmatched_count));
+    }
+
+    Ok(())
+}
+
+/// Processes the commit list based on the processing order defined in the
+/// configuration.
+pub fn process_commit_list(
+    commits: &mut Vec<Commit<'_>>,
+    git_config: &GitConfig,
+    summary: &mut Summary,
+) -> Result<()> {
+    for step in &git_config.processing_order.order {
+        match step {
+            ProcessingStep::CommitParsers => {
+                debug!("Applying commit parsers...");
+                *commits = apply_commit_parsers(commits, git_config, summary);
+            }
+            ProcessingStep::CommitPreprocessors => {
+                debug!("Applying commit preprocessors...");
+                *commits = apply_commit_preprocessors(commits, git_config, summary);
+            }
+            ProcessingStep::IntoConventional => {
+                debug!("Converting commits to conventional format...");
+                *commits = apply_into_conventional(commits, git_config, summary);
+            }
+            ProcessingStep::LinkParsers => {
+                debug!("Applying link parsers...");
+                *commits = apply_link_parsers(commits, git_config);
+            }
+            ProcessingStep::SplitCommits => {
+                debug!("Splitting commits...");
+                if git_config.split_commits {
+                    *commits = apply_split_commits(commits);
+                } else {
+                    debug!("Split commits is disabled, skipping...");
+                }
+            }
+        }
+    }
+
+    if git_config.require_conventional {
+        check_conventional_commits(commits)?;
+    }
+
+    if git_config.fail_on_unmatched_commit {
+        check_unmatched_commits(commits)?;
+    }
+
+    Ok(())
+}
+
+/// Splits the commits by their message lines.
+/// Returns a new vector of commits with each line as a separate commit.
+fn apply_split_commits<'a>(commits: &mut Vec<Commit<'a>>) -> Vec<Commit<'a>> {
+    let mut split_commits = Vec::new();
+    for commit in commits {
+        commit.message.lines().for_each(|line| {
+            let mut c = commit.clone();
+            c.message = line.to_string();
+            c.links.clear();
+            if !c.message.is_empty() {
+                split_commits.push(c)
+            };
+        })
+    }
+    split_commits
+}
+
+/// Applies the commit parsers to the commits and returns the parsed
+/// commits.
+fn apply_commit_parsers<'a>(
+    commits: &Vec<Commit<'a>>,
+    git_config: &crate::config::GitConfig,
+    summary: &mut Summary,
+) -> Vec<Commit<'a>> {
+    commits
+        .iter()
+        .filter_map(|commit| {
+            match commit.clone().parse(
+                &git_config.commit_parsers,
+                git_config.protect_breaking_commits,
+                git_config.filter_commits,
+            ) {
+                Ok(commit) => {
+                    summary.record_ok();
+                    Some(commit)
+                }
+                Err(e) => {
+                    summary.record_err(&e);
+                    on_step_err(commit.clone(), e);
+                    None
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Applies the commit preprocessors to the commits and returns the
+/// preprocessed commits.
+fn apply_commit_preprocessors<'a>(
+    commits: &mut Vec<Commit<'a>>,
+    git_config: &crate::config::GitConfig,
+    summary: &mut Summary,
+) -> Vec<Commit<'a>> {
+    commits
+        .iter()
+        .filter_map(|commit| {
+            // Apply commit parsers
+            match commit.clone().preprocess(&git_config.commit_preprocessors) {
+                Ok(commit) => {
+                    summary.record_ok();
+                    Some(commit)
+                }
+                Err(e) => {
+                    summary.record_err(&e);
+                    on_step_err(commit.clone(), e);
+                    None
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Converts the commits into conventional format if the configuration
+/// requires it.
+fn apply_into_conventional<'a>(
+    commits: &mut Vec<Commit<'a>>,
+    git_config: &crate::config::GitConfig,
+    summary: &mut Summary,
+) -> Vec<Commit<'a>> {
+    commits
+        .iter()
+        .filter_map(|commit| {
+            let mut commit_into_conventional = Ok(commit.clone());
+            if git_config.conventional_commits {
+                if !git_config.require_conventional
+                    && git_config.filter_unconventional
+                    && !git_config.split_commits
+                {
+                    commit_into_conventional = commit.clone().into_conventional();
+                } else if let Ok(conv_commit) = commit.clone().into_conventional() {
+                    commit_into_conventional = Ok(conv_commit);
+                };
+            };
+            match commit_into_conventional {
+                Ok(commit) => {
+                    summary.record_ok();
+                    Some(commit)
+                }
+                Err(e) => {
+                    summary.record_err(&e);
+                    on_step_err(commit.clone(), e);
+                    None
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Applies the link parsers to the commits and returns the parsed commits.
+fn apply_link_parsers<'a>(
+    commits: &mut Vec<Commit<'a>>,
+    git_config: &crate::config::GitConfig,
+) -> Vec<Commit<'a>> {
+    commits
+        .iter()
+        .map(|commit| commit.clone().parse_links(&git_config.link_parsers))
+        .collect::<Vec<_>>()
+}
+
+/// Logs the error of a failed step from a single commit.
+fn on_step_err(commit: Commit<'_>, error: AppError) {
+    trace!(
+        "{} - {} ({})",
+        commit.id.chars().take(7).collect::<String>(),
+        error,
+        commit.message.lines().next().unwrap_or_default().trim()
+    );
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -570,48 +805,48 @@ mod test {
             conventional_commits: true,
             ..Default::default()
         };
-        let test_cases = vec![
-            (
-                Commit::new(
-                    String::from("123123"),
-                    String::from(
-                        "test(commit): add test\n\nSigned-off-by: Test User <test@example.com>",
-                    ),
+        let mut commits = vec![
+            Commit::new(
+                String::from("123123"),
+                String::from(
+                    "test(commit): add test\n\nSigned-off-by: Test User <test@example.com>",
                 ),
-                vec![Footer {
+            ),
+            Commit::new(
+                String::from("123124"),
+                String::from(
+                    "fix(commit): break stuff\n\nBREAKING CHANGE: This commit breaks \
+                         stuff\nSigned-off-by: Test User <test@example.com>",
+                ),
+            ),
+        ];
+        let footers = [
+            vec![Footer {
+                token: "Signed-off-by",
+                separator: ":",
+                value: "Test User <test@example.com>",
+                breaking: false,
+            }],
+            vec![
+                Footer {
+                    token: "BREAKING CHANGE",
+                    separator: ":",
+                    value: "This commit breaks stuff",
+                    breaking: true,
+                },
+                Footer {
                     token: "Signed-off-by",
                     separator: ":",
                     value: "Test User <test@example.com>",
                     breaking: false,
-                }],
-            ),
-            (
-                Commit::new(
-                    String::from("123124"),
-                    String::from(
-                        "fix(commit): break stuff\n\nBREAKING CHANGE: This commit breaks \
-                         stuff\nSigned-off-by: Test User <test@example.com>",
-                    ),
-                ),
-                vec![
-                    Footer {
-                        token: "BREAKING CHANGE",
-                        separator: ":",
-                        value: "This commit breaks stuff",
-                        breaking: true,
-                    },
-                    Footer {
-                        token: "Signed-off-by",
-                        separator: ":",
-                        value: "Test User <test@example.com>",
-                        breaking: false,
-                    },
-                ],
-            ),
+                },
+            ],
         ];
 
-        for (commit, footers) in &test_cases {
-            let commit = commit.process(&cfg).expect("commit should process");
+        // let mut commits: Vec<_> = test_cases.iter().map(|(c, _)| c.to_owned()).collect();
+        process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
+
+        for (commit, footers) in commits.iter().zip(footers.iter()) {
             assert_eq!(&commit.footers().collect::<Vec<_>>(), footers);
         }
     }

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -82,9 +82,54 @@ pub struct ChangelogConfig {
     pub output: Option<PathBuf>,
 }
 
+/// Processing steps for the commits
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessingStep {
+    /// Split commits on newlines, treating each line as an individual commit.
+    SplitCommits,
+    /// An array of regex based parsers to modify commit messages prior to
+    /// further processing.
+    CommitPreprocessors,
+    /// Try to parse commits according to the conventional commits
+    /// specification.
+    IntoConventional,
+    /// An array of regex based parsers for extracting data from the commit
+    /// message.
+    CommitParsers,
+    /// An array of regex based parsers to extract links from the commit message
+    /// and add them to the commit's context.
+    LinkParsers,
+}
+
+/// Processing order for the changelog.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessingOrder {
+    /// The order in which the changelog should be processed.
+    pub order: Vec<ProcessingStep>,
+}
+
+impl Default for ProcessingOrder {
+    /// Returns the default processing order.
+    fn default() -> Self {
+        Self {
+            order: vec![
+                ProcessingStep::CommitPreprocessors,
+                ProcessingStep::SplitCommits,
+                ProcessingStep::IntoConventional,
+                ProcessingStep::CommitParsers,
+                ProcessingStep::LinkParsers,
+            ],
+        }
+    }
+}
+
 /// Git configuration
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct GitConfig {
+    /// Defines the processing order of the commits.
+    #[serde(default)]
+    pub processing_order: ProcessingOrder,
     /// Parse commits according to the conventional commits specification.
     pub conventional_commits: bool,
     /// Require all commits to be conventional.

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -39,6 +39,7 @@ fn generate_changelog() -> Result<()> {
         output: None,
     };
     let git_config = GitConfig {
+        processing_order: Default::default(),
         conventional_commits: true,
         require_conventional: false,
         filter_unconventional: true,


### PR DESCRIPTION
## Description

Currently each commit in the commit list is processed before splitting. This causes an issue when `split_commit` is set to true. Commits in the description are not being processed if the commit message contains a skipped type set in the `commit_parsers`. For instance if the output of a squash and merge start with a `chore:` and the `chore:` is set to skip in the `commit_parsers` the description won't be parsed even if it contains `feat:` or `fix:` or any other non skipped field.

```
// Squash and merge Commit Sample
chore(ci): Update ci runners

fix(ci): a fix --> This is never parsed
chore(ci): another chore --> This is never parsed
```

## Motivation and Context

When working with squash and merge it is useful to have the message of the commit as the overview of the changes and the description as the details of the changes. However it should be possible to skip parsing the message as the description of the commit contains all the info, so trying to avoid repetitions.

## How Has This Been Tested?

I have adjusted the current unit test to reflect the scenario that I am describing

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
