### PR TITLE
docs: add commit and pr strategy section in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Learn how to use **git-cliff** from the [official documentation](https://git-cliff.org/docs).
 
 - [Installation](https://git-cliff.org/docs/installation/)
-- [Usage](https://git-cliff.org/docs/usage/examples)
+- [Usage](https://git-cliff.org/docs/usage/)
 - [Configuration](https://git-cliff.org/docs/configuration)
 - [Templating](https://git-cliff.org/docs/category/templating)
 

--- a/website/docs/usage/adding-commits.md
+++ b/website/docs/usage/adding-commits.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Adding custom commits

--- a/website/docs/usage/adding-tag-messages.md
+++ b/website/docs/usage/adding-tag-messages.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Adding version (tag) message

--- a/website/docs/usage/bump-version.md
+++ b/website/docs/usage/bump-version.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Bump version

--- a/website/docs/usage/commit-and-pr-strategy.md
+++ b/website/docs/usage/commit-and-pr-strategy.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 3
+---
+
+# Commit and PR Strategy
+
+## How should I write my commits?
+
+**git-cliff** can generate [changelog](https://en.wikipedia.org/wiki/Changelog) files from the [Git](https://git-scm.com/) history by utilizing [Conventional Commits](https://git-cliff.org/docs/configuration/git#conventional_commits) as well as regex-powered [custom parsers](https://git-cliff.org/docs/configuration/git#commit_parsers).
+
+We recommend using a [Git](https://git-scm.com/) history that follows the [Conventional Commits](https://git-cliff.org/docs/configuration/git#conventional_commits) specification as the primary strategy.
+This convention provides a widely adopted standard for categorizing and grouping commits in a meaningful and predictable way.
+
+**git-cliff**’s [default configuration](https://github.com/orhun/git-cliff/blob/main/config/cliff.toml) is built around this convention, making it easy to generate clear, structured, and consistent [changelog](https://en.wikipedia.org/wiki/Changelog)s with minimal customization—by grouping commits (e.g., `feat`, `fix`, `docs`) according to industry best practices.
+The most important prefixes you should have in mind are:
+
+* `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
+* `feat:` which represents a new feature, and correlates to a SemVer minor.
+* `feat!:`,  or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
+
+In addition to commit messages, **git-cliff** also supports parsing [remote metadata](https://git-cliff.org/docs/configuration/remote) from supported [Git](https://git-scm.com/) hosting services—such as pull request titles, numbers, and authors—using customizable regular expressions.
+This makes it possible to group commits by PR, author, or other metadata, offering greater flexibility in how [changelog](https://en.wikipedia.org/wiki/Changelog)s are structured.
+For example, [GitHub pull request labels can be used as grouping keys](https://git-cliff.org/docs/tips-and-tricks#use-github-pr-labels-as-groups), allowing [changelog](https://en.wikipedia.org/wiki/Changelog)s to be organized based on custom categories such as `breaking-change`, `type/enhancement`, or `area/documentation`.
+
+## How should I manage PRs?
+
+When working with a [pull request (PR)](https://en.wikipedia.org/wiki/Fork_and_pull_model)-based development flow, it’s important to adopt a merge strategy that preserves a clean and readable [Git](https://git-scm.com/) history—especially when [changelog](https://en.wikipedia.org/wiki/Changelog)s are automatically generated from commit metadata.
+
+We recommend using **squash merges** for integrating [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model)s into the main branch. This approach has several benefits:
+* Linear Git history — [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model)s are merged as single commits, making the history easier to read and traverse.
+* Simplified [changelog](https://en.wikipedia.org/wiki/Changelog) generation — Redundant or interim commits (e.g. `fix: typo`, `test: update`, `revert: feat: something`, etc.) within the [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model) won’t pollute the [changelog](https://en.wikipedia.org/wiki/Changelog).
+* Easier bug tracking — Tools like **git bisect** become more effective with a linear history.
+* Better compatibility with **git-cliff** — Since **git-cliff** generates [changelog](https://en.wikipedia.org/wiki/Changelog)s from commit messages, using **squash merges** helps ensure that each [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model) corresponds to a single, coherent commit. This improves the consistency of [changelog](https://en.wikipedia.org/wiki/Changelog) entries and allows for better association of [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model) metadata such as titles, descriptions, and issue references. Other merge strategies, such as rebase merges or merge commits, may fail to consistently associate [PR](https://en.wikipedia.org/wiki/Fork_and_pull_model)-level context (e.g., title, description, issue references) with a single commit.

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Examples

--- a/website/docs/usage/jujutsu.md
+++ b/website/docs/usage/jujutsu.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # Jujutsu

--- a/website/docs/usage/load-context.md
+++ b/website/docs/usage/load-context.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # Load context

--- a/website/docs/usage/monorepos.md
+++ b/website/docs/usage/monorepos.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Monorepos

--- a/website/docs/usage/multiple-repos.md
+++ b/website/docs/usage/multiple-repos.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Multiple repositories

--- a/website/docs/usage/print-context.md
+++ b/website/docs/usage/print-context.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Print context

--- a/website/docs/usage/skipping-commits.md
+++ b/website/docs/usage/skipping-commits.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Skipping commits

--- a/website/docs/usage/submodules.md
+++ b/website/docs/usage/submodules.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Submodules


### PR DESCRIPTION
## Description

Adds documentation describing the project's commit message and pull request strategy.

## Motivation and Context

This change documents the limitations of using the rebase strategy when generating changelogs. In particular, it clarifies that:

 - With rebase or merge commit strategies, it is not possible to reliably trace a commit on the main branch back to its associated PR.

To address this, we recommend a consistent commit/PR strategy based on squash merging and Conventional Commits, which enables git-cliff to generate clear, contextual release notes. This documentation aims to guide contributors and maintainers toward that goal and provide a practical, opinionated baseline.

Relates to #1177 (does not close)

## How Has This Been Tested?

N/A

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
