### PR TITLE
docs: mention the side-bar

### DIFF
--- a/website/docs/installation/index.md
+++ b/website/docs/installation/index.md
@@ -3,6 +3,8 @@ sidebar_position: 2
 ---
 # Installation
 
+Please see the side-bar to navigate to a specific installation mechanism. This page has information about the packaging status from repo-ology.
+
 <details>
   <summary>Packaging status</summary>
 


### PR DESCRIPTION
## Description

Adds some blurb to the main installation page, as it is the default navigated page from the docs if I click installation.

## Motivation and Context

I Cannot be the only person that thought "why is there a blank installation page". The other pages are really good too!

I'm totally cool if this cannot be merged, but I was really expecting cargo install or install binaries to be on this page, so it caused a momentary disconnect that I had to look for where to find the information, instead of it being right there for me.

A list of links might be nice, but; for-now, this would at least allow continuous flow.

## How Has This Been Tested?

I just wrote text in a docs page.

## Screenshots / Logs (if applicable)

Just what the page looks like for me when I visited.

<img width="2940" height="2042" alt="Original installation page" src="https://github.com/user-attachments/assets/2a63133d-a07d-455a-8b2c-6b35a58fb55f" />

## Types of Changes

- [X] Documentation (no code change)

## Checklist:

- [X] I have updated the documentation accordingly.
