### PR TITLE
fix(config): link to tree for first tag

### DIFF
--- a/examples/keepachangelog.toml
+++ b/examples/keepachangelog.toml
@@ -35,6 +35,10 @@ footer = """
             [{{ release.version | trim_start_matches(pat="v") }}]: \
                 https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
                     /compare/{{ release.previous.version }}..{{ release.version }}
+        {% else -%}
+            [{{ release.version | trim_start_matches(pat="v") }}]: \
+                https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+                    /tree/{{ release.version }}
         {% endif -%}
     {% else -%}
         [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\


### PR DESCRIPTION
## Description
In the `keepachangelog` config template, if there is not a prior tag, then link the first tag to the tree at that tag instead of not emitting a link at all.

## Motivation and Context
This fixes the first release version in the `keepachangelog` format not being linkified.

## How Has This Been Tested?
I ran this against a test repo locally.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.