### PR TITLE
revert: "fix(repo): use the correct order while diffing paths (#1188)"

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -253,7 +253,7 @@ fn process_repository<'a>(
 
     // Include only the current directory if not running from the root repository
     let mut include_path = config.git.include_paths.clone();
-    if let Some(mut path_diff) = pathdiff::diff_paths(repository.root_path()?, env::current_dir()?)
+    if let Some(mut path_diff) = pathdiff::diff_paths(env::current_dir()?, repository.root_path()?)
     {
         if args.workdir.is_none() && include_path.is_empty() && path_diff != Path::new("") {
             info!(


### PR DESCRIPTION
## Description

This PR reverts the change introduced in [#1188](https://github.com/orhun/git-cliff/pull/1188),  
which modified the argument order of `pathdiff::diff_paths`.

The revert restores the previous behavior before commit `ff6c3105012b5827145ba4bf2bb660cce0b9c7bf`.

## Motivation and Context

This PR fixes

 - [#1240](https://github.com/orhun/git-cliff/issues/1240) and
 - [#1243](https://github.com/orhun/git-cliff/issues/1243) by reverting the change

fixes #1240 
fixes #1243

introduced in #1188.

## How Has This Been Tested?

- Ran `cargo test`
- Verified that all tests passed and changelog generation behaves as expected

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
