### PR TITLE
feat(cli): honor XDG_CONFIG_HOME on macOS

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -492,7 +492,6 @@ impl Config {
     ///
     /// If the config file is not found in its standard locations, [`None`] is returned.
     pub fn retrieve_config_path() -> Option<PathBuf> {
-        let mut path: Option<PathBuf> = None;
         for supported_path in [
             #[cfg(target_os = "macos")]
             Some(Config::retrieve_xdg_config_on_macos().join(DEFAULT_CONFIG)),
@@ -502,12 +501,11 @@ impl Config {
         .filter_map(|v| v.as_ref())
         {
             if supported_path.exists() {
-                path = Some(supported_path.to_path_buf());
                 debug!("Using configuration file from: {:?}", supported_path);
-                break;
+                return Some(supported_path.to_path_buf());
             }
         }
-        path
+        None
     }
 }
 

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt, fs};
@@ -482,7 +481,7 @@ impl Config {
     /// If it is not set, it will fall back to `~/.config`
     #[cfg(target_os = "macos")]
     pub fn retrieve_xdg_config_on_macos() -> PathBuf {
-        let config_dir = env::var("XDG_CONFIG_HOME").map_or_else(
+        let config_dir = std::env::var("XDG_CONFIG_HOME").map_or_else(
             |_| dirs::home_dir().unwrap_or_default().join(".config"),
             PathBuf::from,
         );

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "macos")]
+use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt, fs};
@@ -468,6 +470,22 @@ impl Config {
             .add_source(config::Environment::with_prefix("GIT_CLIFF").separator("__"))
             .build()?
             .try_deserialize()?)
+    }
+
+    /// Find a special config path on macOS.
+    ///
+    /// The `dirs` crate ignores the `XDG_CONFIG_HOME` env var on macOS and only considers
+    /// `Library/Application Support` as the config dir, which is primarily used by GUI apps.
+    ///
+    /// This function determines the config path and honors the `XDG_CONFIG_HOME` env var.
+    /// If it is not set, it will fall back to `~/.config`
+    #[cfg(target_os = "macos")]
+    pub fn retrieve_xdg_config_on_macos() -> PathBuf {
+        let config_dir = env::var("XDG_CONFIG_HOME").map_or_else(
+            |_| dirs::home_dir().unwrap_or_default().join(".config"),
+            PathBuf::from,
+        );
+        config_dir.join("git-cliff")
     }
 }
 

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -9,9 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
-use crate::{command, error};
-
-use crate::DEFAULT_CONFIG;
+use crate::{DEFAULT_CONFIG, command, error};
 
 /// Default initial tag.
 const DEFAULT_INITIAL_TAG: &str = "0.1.0";

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -490,7 +490,7 @@ impl Config {
 
     /// Find the path of the config file.
     ///
-    /// If the config file is not found in its standard locations, None is returned.
+    /// If the config file is not found in its standard locations, [`None`] is returned.
     pub fn retrieve_config_path() -> Option<PathBuf> {
         let mut path: Option<PathBuf> = None;
         for supported_path in [

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -525,20 +525,9 @@ pub fn run_with_changelog_modifier(
     // Set path for the configuration file.
     let mut path = args.config.clone();
     if !path.exists() {
-        for possible_path in [
-            #[cfg(target_os = "macos")]
-            Some(Config::retrieve_xdg_config_on_macos().join(DEFAULT_CONFIG)),
-            dirs::config_dir().map(|dir| dir.join(env!("CARGO_PKG_NAME")).join(DEFAULT_CONFIG)),
-        ]
-        .iter()
-        .filter_map(|v| v.as_ref())
-        {
-            if possible_path.exists() {
-                path = possible_path.to_path_buf();
-                break;
-            }
+        if let Some(config_path) = Config::retrieve_config_path() {
+            path = config_path;
         }
-        debug!("Using configuration file from: {:?}", path);
     }
 
     // Parse the configuration file.


### PR DESCRIPTION
## Description

git-cliff ignores the `XDG_CONFIG_HOME` env var on macOS and only considers `Library/Application Support` as the config dir, which is primarily used by GUI apps.

This change allows the default config file to be placed in the following 3 locations on macOS:

- `XDG_CONFIG_HOME/git-cliff/cliff.toml`
- `~/.config/git-cliff/cliff.toml`
- `~/Library/Application Support/git-cliff/cliff.toml`

The first one found is used.

<!--- Describe your changes in detail -->

## Motivation and Context
see https://github.com/orhun/git-cliff/pull/1249#issuecomment-3301875097

## How Has This Been Tested?

manually and with debug output

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
