### PR TITLE
fix: guard include path when running outside repo

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -156,6 +156,19 @@ fn process_submodules(
     Ok(())
 }
 
+fn relative_subdirectory_path(current_dir: &Path, repository_root: &Path) -> Option<PathBuf> {
+    if !current_dir.starts_with(repository_root) {
+        return None;
+    }
+    pathdiff::diff_paths(current_dir, repository_root).and_then(|relative| {
+        if relative.as_os_str().is_empty() {
+            None
+        } else {
+            Some(relative)
+        }
+    })
+}
+
 /// Processes the tags and commits for creating release entries for the
 /// changelog.
 ///
@@ -250,15 +263,17 @@ fn process_repository<'a>(
 
     // Include only the current directory if not running from the root repository
     let mut include_path = config.git.include_paths.clone();
-    if let Some(mut path_diff) = pathdiff::diff_paths(env::current_dir()?, repository.root_path()?)
-    {
-        if args.workdir.is_none() && include_path.is_empty() && path_diff != Path::new("") {
+    if args.workdir.is_none() && include_path.is_empty() {
+        let current_dir = env::current_dir()?;
+        let repository_root = repository.root_path()?;
+        if let Some(mut relative_path) = relative_subdirectory_path(&current_dir, &repository_root)
+        {
             log::info!(
                 "Including changes from the current directory: {:?}",
-                path_diff.display()
+                relative_path.display()
             );
-            path_diff.extend(["**", "*"]);
-            include_path = vec![Pattern::new(path_diff.to_string_lossy().as_ref())?];
+            relative_path.extend(["**", "*"]);
+            include_path = vec![Pattern::new(relative_path.to_string_lossy().as_ref())?];
         }
     }
 
@@ -796,4 +811,41 @@ pub fn run_with_changelog_modifier(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::relative_subdirectory_path;
+
+    #[test]
+    fn detects_relative_subdirectory_when_inside_repository() {
+        let repository_root = PathBuf::from("repo");
+        let current_dir = repository_root.join("apps").join("mobile");
+        let expected = PathBuf::from("apps").join("mobile");
+        assert_eq!(
+            relative_subdirectory_path(&current_dir, &repository_root),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn returns_none_when_at_repository_root() {
+        let repository_root = PathBuf::from("repo");
+        assert_eq!(
+            relative_subdirectory_path(&repository_root, &repository_root),
+            None
+        );
+    }
+
+    #[test]
+    fn returns_none_when_outside_repository() {
+        let repository_root = PathBuf::from("repo");
+        let current_dir = PathBuf::from("other");
+        assert_eq!(
+            relative_subdirectory_path(&current_dir, &repository_root),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Description

  - add `relative_subdirectory_path` helper and unit tests to guard the monorepo auto-include logic
  - only append an `include_path` glob when the current working directory is inside the repository root
  - keep existing behaviour for callers launched from a subdirectory while avoiding `../…/**/*` matches that hide every commit

  ## Motivation and Context

  Fixes #1248 — running `git-cliff` from a workspace root (e.g. Android’s `repo` checkout) started returning an empty changelog
  in v2.8 because the inferred include glob pointed outside the repo. This change retains the improvement for monorepos without
  breaking that workflow.

  ## How Has This Been Tested?

  - `cargo test`
  - `cargo run --bin git-cliff -- --config ../cliff.toml --repository ../android-sim -- sh/25.2.12..sh/25.3.0`

  ## Screenshots / Logs (if applicable)

  N/A

  ## Types of Changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation (no code change)
  - [ ] Refactor (refactoring production code)
  - [ ] Other <!--- (provide information) -->

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [ ] I have updated the documentation accordingly.
  - [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.