### PR TITLE
feat: group remote-related CLI arguments under REMOTE OPTIONS heading

### DIFF
--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -253,9 +253,6 @@ pub struct Opt {
 		default_value_t = Sort::Oldest
 	)]
     pub sort: Sort,
-    /// Sets the commit range to process.
-    #[arg(value_name = "RANGE", help_heading = Some("ARGS"))]
-    pub range: Option<String>,
     /// Sets the GitHub API token.
     #[arg(
 		long,
@@ -336,6 +333,9 @@ pub struct Opt {
 		hide = !cfg!(feature = "bitbucket"),
 	)]
     pub bitbucket_repo: Option<RemoteValue>,
+    /// Sets the commit range to process.
+    #[arg(value_name = "RANGE", help_heading = Some("ARGS"))]
+    pub range: Option<String>,
     /// Load TLS certificates from the native certificate store.
     #[arg(long, help_heading = Some("FLAGS"), hide = !cfg!(feature = "remote"))]
     pub use_native_tls: bool,

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -258,83 +258,83 @@ pub struct Opt {
     pub range: Option<String>,
     /// Sets the GitHub API token.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITHUB_TOKEN",
-  value_name = "TOKEN",
-  hide_env_values = true,
-  hide = !cfg!(feature = "github"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITHUB_TOKEN",
+		value_name = "TOKEN",
+		hide_env_values = true,
+		hide = !cfg!(feature = "github"),
+	)]
     pub github_token: Option<SecretString>,
     /// Sets the GitHub repository.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITHUB_REPO",
-  value_parser = clap::value_parser!(RemoteValue),
-  value_name = "OWNER/REPO",
-  hide = !cfg!(feature = "github"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITHUB_REPO",
+		value_parser = clap::value_parser!(RemoteValue),
+		value_name = "OWNER/REPO",
+		hide = !cfg!(feature = "github"),
+	)]
     pub github_repo: Option<RemoteValue>,
     /// Sets the GitLab API token.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITLAB_TOKEN",
-  value_name = "TOKEN",
-  hide_env_values = true,
-  hide = !cfg!(feature = "gitlab"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITLAB_TOKEN",
+		value_name = "TOKEN",
+		hide_env_values = true,
+		hide = !cfg!(feature = "gitlab"),
+	)]
     pub gitlab_token: Option<SecretString>,
     /// Sets the GitLab repository.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITLAB_REPO",
-  value_parser = clap::value_parser!(RemoteValue),
-  value_name = "OWNER/REPO",
-  hide = !cfg!(feature = "gitlab"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITLAB_REPO",
+		value_parser = clap::value_parser!(RemoteValue),
+		value_name = "OWNER/REPO",
+		hide = !cfg!(feature = "gitlab"),
+	)]
     pub gitlab_repo: Option<RemoteValue>,
     /// Sets the Gitea API token.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITEA_TOKEN",
-  value_name = "TOKEN",
-  hide_env_values = true,
-  hide = !cfg!(feature = "gitea"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITEA_TOKEN",
+		value_name = "TOKEN",
+		hide_env_values = true,
+		hide = !cfg!(feature = "gitea"),
+	)]
     pub gitea_token: Option<SecretString>,
     /// Sets the Gitea repository.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "GITEA_REPO",
-  value_parser = clap::value_parser!(RemoteValue),
-  value_name = "OWNER/REPO",
-  hide = !cfg!(feature = "gitea"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GITEA_REPO",
+		value_parser = clap::value_parser!(RemoteValue),
+		value_name = "OWNER/REPO",
+		hide = !cfg!(feature = "gitea"),
+	)]
     pub gitea_repo: Option<RemoteValue>,
     /// Sets the Bitbucket API token.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "BITBUCKET_TOKEN",
-  value_name = "TOKEN",
-  hide_env_values = true,
-  hide = !cfg!(feature = "bitbucket"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "BITBUCKET_TOKEN",
+		value_name = "TOKEN",
+		hide_env_values = true,
+		hide = !cfg!(feature = "bitbucket"),
+	)]
     pub bitbucket_token: Option<SecretString>,
     /// Sets the Bitbucket repository.
     #[arg(
-  long,
-  help_heading = "REMOTE OPTIONS",
-  env = "BITBUCKET_REPO",
-  value_parser = clap::value_parser!(RemoteValue),
-  value_name = "OWNER/REPO",
-  hide = !cfg!(feature = "bitbucket"),
- )]
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "BITBUCKET_REPO",
+		value_parser = clap::value_parser!(RemoteValue),
+		value_name = "OWNER/REPO",
+		hide = !cfg!(feature = "bitbucket"),
+	)]
     pub bitbucket_repo: Option<RemoteValue>,
     /// Load TLS certificates from the native certificate store.
     #[arg(long, help_heading = Some("FLAGS"), hide = !cfg!(feature = "remote"))]

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -258,75 +258,83 @@ pub struct Opt {
     pub range: Option<String>,
     /// Sets the GitHub API token.
     #[arg(
-		long,
-		env = "GITHUB_TOKEN",
-		value_name = "TOKEN",
-		hide_env_values = true,
-		hide = !cfg!(feature = "github"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITHUB_TOKEN",
+  value_name = "TOKEN",
+  hide_env_values = true,
+  hide = !cfg!(feature = "github"),
+ )]
     pub github_token: Option<SecretString>,
     /// Sets the GitHub repository.
     #[arg(
-		long,
-		env = "GITHUB_REPO",
-		value_parser = clap::value_parser!(RemoteValue),
-		value_name = "OWNER/REPO",
-		hide = !cfg!(feature = "github"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITHUB_REPO",
+  value_parser = clap::value_parser!(RemoteValue),
+  value_name = "OWNER/REPO",
+  hide = !cfg!(feature = "github"),
+ )]
     pub github_repo: Option<RemoteValue>,
     /// Sets the GitLab API token.
     #[arg(
-		long,
-		env = "GITLAB_TOKEN",
-		value_name = "TOKEN",
-		hide_env_values = true,
-		hide = !cfg!(feature = "gitlab"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITLAB_TOKEN",
+  value_name = "TOKEN",
+  hide_env_values = true,
+  hide = !cfg!(feature = "gitlab"),
+ )]
     pub gitlab_token: Option<SecretString>,
     /// Sets the GitLab repository.
     #[arg(
-		long,
-		env = "GITLAB_REPO",
-		value_parser = clap::value_parser!(RemoteValue),
-		value_name = "OWNER/REPO",
-		hide = !cfg!(feature = "gitlab"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITLAB_REPO",
+  value_parser = clap::value_parser!(RemoteValue),
+  value_name = "OWNER/REPO",
+  hide = !cfg!(feature = "gitlab"),
+ )]
     pub gitlab_repo: Option<RemoteValue>,
     /// Sets the Gitea API token.
     #[arg(
-		long,
-		env = "GITEA_TOKEN",
-		value_name = "TOKEN",
-		hide_env_values = true,
-		hide = !cfg!(feature = "gitea"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITEA_TOKEN",
+  value_name = "TOKEN",
+  hide_env_values = true,
+  hide = !cfg!(feature = "gitea"),
+ )]
     pub gitea_token: Option<SecretString>,
     /// Sets the Gitea repository.
     #[arg(
-		long,
-		env = "GITEA_REPO",
-		value_parser = clap::value_parser!(RemoteValue),
-		value_name = "OWNER/REPO",
-		hide = !cfg!(feature = "gitea"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "GITEA_REPO",
+  value_parser = clap::value_parser!(RemoteValue),
+  value_name = "OWNER/REPO",
+  hide = !cfg!(feature = "gitea"),
+ )]
     pub gitea_repo: Option<RemoteValue>,
     /// Sets the Bitbucket API token.
     #[arg(
-		long,
-		env = "BITBUCKET_TOKEN",
-		value_name = "TOKEN",
-		hide_env_values = true,
-		hide = !cfg!(feature = "bitbucket"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "BITBUCKET_TOKEN",
+  value_name = "TOKEN",
+  hide_env_values = true,
+  hide = !cfg!(feature = "bitbucket"),
+ )]
     pub bitbucket_token: Option<SecretString>,
     /// Sets the Bitbucket repository.
     #[arg(
-		long,
-		env = "BITBUCKET_REPO",
-		value_parser = clap::value_parser!(RemoteValue),
-		value_name = "OWNER/REPO",
-		hide = !cfg!(feature = "bitbucket"),
-	)]
+  long,
+  help_heading = "REMOTE OPTIONS",
+  env = "BITBUCKET_REPO",
+  value_parser = clap::value_parser!(RemoteValue),
+  value_name = "OWNER/REPO",
+  hide = !cfg!(feature = "bitbucket"),
+ )]
     pub bitbucket_repo: Option<RemoteValue>,
     /// Load TLS certificates from the native certificate store.
     #[arg(long, help_heading = Some("FLAGS"), hide = !cfg!(feature = "remote"))]

--- a/website/docs/usage/args.md
+++ b/website/docs/usage/args.md
@@ -49,6 +49,11 @@ git-cliff [FLAGS] [OPTIONS] [--] [RANGE]
     --from-context <PATH>          Generates changelog from a JSON context [env: GIT_CLIFF_CONTEXT=]
 -s, --strip <PART>                 Strips the given parts from the changelog [possible values: header, footer, all]
     --sort <SORT>                  Sets sorting of the commits inside sections [default: oldest] [possible values: oldest, newest]
+```
+
+## Remote Options
+
+```
     --github-token <TOKEN>         Sets the GitHub API token [env: GITHUB_TOKEN]
     --github-repo <OWNER/REPO>     Sets the GitHub repository [env: GITHUB_REPO=]
     --gitlab-token <TOKEN>         Sets the GitLab API token [env: GITLAB_TOKEN]


### PR DESCRIPTION
## Description

Added `help_heading = "REMOTE OPTIONS"` to all remote-related CLI arguments (`--github-token`, `--github-repo`, `--gitlab-token`, `--gitlab-repo`, `--gitea-token`, `--gitea-repo`, `--bitbucket-token`, `--bitbucket-repo`) to group them under a dedicated "REMOTE OPTIONS" section in the help output. 

## Motivation and Context

Fixes #1270

## How Has This Been Tested?

- Built the project successfully using `cargo build`
- Ran `git-cliff -h` to verify the help output shows the new "REMOTE OPTIONS" section
- Confirmed all remote arguments are properly grouped under the new heading
- Ran `cargo test` to ensure CLI argument parsing tests pass (the `verify_cli` test validates the argument structure)

## Screenshots / Logs (if applicable)


## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
