### PR TITLE
refactor(remote): expose commits and PRs as streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1019,7 @@ dependencies = [
 name = "git-cliff-core"
 version = "2.10.1"
 dependencies = [
+ "async-stream",
  "bincode 2.0.1",
  "cacache",
  "chrono",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -24,6 +24,7 @@ remote = [
   "dep:reqwest-middleware",
   "dep:tokio",
   "dep:futures",
+  "dep:async-stream",
 ]
 ## Enable integration with GitHub.
 ## You can turn this off if you don't use GitHub and don't want
@@ -69,6 +70,7 @@ tokio = { version = "1.47.0", features = [
   "macros",
 ], optional = true }
 futures = { version = "0.3.31", optional = true }
+async-stream = { version = "0.3.6", optional = true }
 url.workspace = true
 dyn-clone = "1.0.17"
 urlencoding = "2.1.3"

--- a/git-cliff-core/src/remote/bitbucket.rs
+++ b/git-cliff-core/src/remote/bitbucket.rs
@@ -1,3 +1,5 @@
+use async_stream::stream as async_stream;
+use futures::{Stream, StreamExt, stream};
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 
@@ -39,31 +41,6 @@ impl RemoteCommit for BitbucketCommit {
 
     fn timestamp(&self) -> Option<i64> {
         Some(self.convert_to_unix_timestamp(self.date.clone().as_str()))
-    }
-}
-
-/// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#api-repositories-workspace-repo-slug-commits-get>
-impl RemoteEntry for BitbucketPagination<BitbucketCommit> {
-    fn url(_id: i64, api_url: &str, remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
-        let commit_page = page + 1;
-        let mut url = format!(
-            "{}/{}/{}/commits?pagelen={MAX_PAGE_SIZE}&page={commit_page}",
-            api_url, remote.owner, remote.repo
-        );
-
-        if let Some(ref_name) = ref_name {
-            url.push_str(&format!("&include={}", ref_name));
-        }
-
-        url
-    }
-
-    fn buffer_size() -> usize {
-        10
-    }
-
-    fn early_exit(&self) -> bool {
-        self.values.is_empty()
     }
 }
 
@@ -141,25 +118,6 @@ impl RemotePullRequest for BitbucketPullRequest {
     }
 }
 
-/// <https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-get>
-impl RemoteEntry for BitbucketPagination<BitbucketPullRequest> {
-    fn url(_id: i64, api_url: &str, remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
-        let pr_page = page + 1;
-        format!(
-            "{}/{}/{}/pullrequests?&pagelen={BITBUCKET_MAX_PAGE_PRS}&page={pr_page}&state=MERGED",
-            api_url, remote.owner, remote.repo
-        )
-    }
-
-    fn buffer_size() -> usize {
-        5
-    }
-
-    fn early_exit(&self) -> bool {
-        self.values.is_empty()
-    }
-}
-
 /// HTTP client for handling Bitbucket REST API requests.
 #[derive(Debug, Clone)]
 pub struct BitbucketClient {
@@ -191,32 +149,106 @@ impl RemoteClient for BitbucketClient {
     fn client(&self) -> ClientWithMiddleware {
         self.client.clone()
     }
+
+    fn commits_stream<'a>(&'a self) -> impl Stream<Item = Result<Box<dyn RemoteCommit>>> + 'a {
+        async_stream! {
+            let page_stream = stream::iter(0..)
+                .map(|page| async move {
+                    let commit_page = page + 1;
+                    let url = Self::commits_url(&self.api_url(), &self.remote().owner, &self.remote().repo, commit_page);
+                    self.get_json::<BitbucketPagination<BitbucketCommit>>(&url).await
+                })
+                .buffered(10);
+
+            let mut page_stream = Box::pin(page_stream);
+
+            while let Some(page_result) = page_stream.next().await {
+                match page_result {
+                    Ok(page) => {
+                        if page.values.is_empty() {
+                            break;
+                        }
+
+                        for commit in page.values {
+                            yield Ok(Box::new(commit) as Box<dyn RemoteCommit>);
+                        }
+                    }
+                    Err(e) => {
+                        yield Err(e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn pull_requests_stream<'a>(
+        &'a self,
+    ) -> impl Stream<Item = Result<Box<dyn RemotePullRequest>>> + 'a {
+        async_stream! {
+            let page_stream = stream::iter(0..)
+                .map(|page| async move {
+                    let pr_page = page + 1;
+                    let url = Self::pull_requests_url(&self.api_url(), &self.remote().owner, &self.remote().repo, pr_page);
+                    self.get_json::<BitbucketPagination<BitbucketPullRequest>>(&url).await
+                })
+                .buffered(5);
+
+            let mut page_stream = Box::pin(page_stream);
+
+            while let Some(page_result) = page_stream.next().await {
+                match page_result {
+                    Ok(page) => {
+                        if page.values.is_empty() {
+                            break;
+                        }
+
+                        for pr in page.values {
+                            yield Ok(Box::new(pr) as Box<dyn RemotePullRequest>);
+                        }
+                    }
+                    Err(e) => {
+                        yield Err(e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl BitbucketClient {
+    /// Constructs the URL for Bitbucket commits API.
+    fn commits_url(api_url: &str, owner: &str, repo: &str, page: i32) -> String {
+        format!(
+            "{}/{}/{}/commits?pagelen={MAX_PAGE_SIZE}&page={page}",
+            api_url, owner, repo
+        )
+    }
+
+    /// Constructs the URL for Bitbucket pull requests API.
+    fn pull_requests_url(api_url: &str, owner: &str, repo: &str, page: i32) -> String {
+        format!(
+            "{}/{}/{}/pullrequests?pagelen={BITBUCKET_MAX_PAGE_PRS}&page={page}&state=MERGED",
+            api_url, owner, repo
+        )
+    }
+
     /// Fetches the Bitbucket API and returns the commits.
-    pub async fn get_commits(&self, ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
-        Ok(self
-            .fetch_with_early_exit::<BitbucketPagination<BitbucketCommit>>(0, ref_name)
-            .await?
-            .into_iter()
-            .flat_map(|v| v.values)
-            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-            .collect())
+    pub async fn get_commits(&self, _ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        use futures::TryStreamExt;
+
+        self.commits_stream().try_collect().await
     }
 
     /// Fetches the Bitbucket API and returns the pull requests.
     pub async fn get_pull_requests(
         &self,
-        ref_name: Option<&str>,
+        _ref_name: Option<&str>,
     ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-        Ok(self
-            .fetch_with_early_exit::<BitbucketPagination<BitbucketPullRequest>>(0, ref_name)
-            .await?
-            .into_iter()
-            .flat_map(|v| v.values)
-            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-            .collect())
+        use futures::TryStreamExt;
+
+        self.pull_requests_stream().try_collect().await
     }
 }
 

--- a/git-cliff-core/src/remote/gitea.rs
+++ b/git-cliff-core/src/remote/gitea.rs
@@ -1,3 +1,5 @@
+use async_stream::stream as async_stream;
+use futures::{Stream, StreamExt, stream};
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 
@@ -36,29 +38,6 @@ impl RemoteCommit for GiteaCommit {
 
     fn timestamp(&self) -> Option<i64> {
         Some(self.convert_to_unix_timestamp(self.created.clone().as_str()))
-    }
-}
-
-impl RemoteEntry for GiteaCommit {
-    fn url(_id: i64, api_url: &str, remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
-        let mut url = format!(
-            "{}/api/v1/repos/{}/{}/commits?limit={MAX_PAGE_SIZE}&page={page}",
-            api_url, remote.owner, remote.repo
-        );
-
-        if let Some(ref_name) = ref_name {
-            url.push_str(&format!("&sha={}", ref_name));
-        }
-
-        url
-    }
-
-    fn buffer_size() -> usize {
-        10
-    }
-
-    fn early_exit(&self) -> bool {
-        false
     }
 }
 
@@ -108,23 +87,6 @@ impl RemotePullRequest for GiteaPullRequest {
     }
 }
 
-impl RemoteEntry for GiteaPullRequest {
-    fn url(_id: i64, api_url: &str, remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
-        format!(
-            "{}/api/v1/repos/{}/{}/pulls?limit={MAX_PAGE_SIZE}&page={page}&state=closed",
-            api_url, remote.owner, remote.repo
-        )
-    }
-
-    fn buffer_size() -> usize {
-        5
-    }
-
-    fn early_exit(&self) -> bool {
-        false
-    }
-}
-
 /// HTTP client for handling Gitea REST API requests.
 #[derive(Debug, Clone)]
 pub struct GiteaClient {
@@ -156,30 +118,108 @@ impl RemoteClient for GiteaClient {
     fn client(&self) -> ClientWithMiddleware {
         self.client.clone()
     }
+
+    fn commits_stream<'a>(&'a self) -> impl Stream<Item = Result<Box<dyn RemoteCommit>>> + 'a {
+        async_stream! {
+            let page_stream = stream::iter(0..)
+                .map(|page| async move {
+                    let url = Self::commits_url(&self.api_url(), &self.remote().owner, &self.remote().repo, page);
+                    self.get_json::<Vec<GiteaCommit>>(&url).await
+                })
+                .buffered(10);
+
+            let mut page_stream = Box::pin(page_stream);
+
+            while let Some(page_result) = page_stream.next().await {
+                match page_result {
+                    Ok(commits) => {
+                        if commits.is_empty() {
+                            break;
+                        }
+
+                        for commit in commits {
+                            yield Ok(Box::new(commit) as Box<dyn RemoteCommit>);
+                        }
+                    }
+                    Err(e) => {
+                        if let Error::PaginationError(_) = e {
+                            break;
+                        }
+                        yield Err(e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    fn pull_requests_stream<'a>(
+        &'a self,
+    ) -> impl Stream<Item = Result<Box<dyn RemotePullRequest>>> + 'a {
+        async_stream! {
+        let page_stream = stream::iter(0..)
+            .map(|page| async move {
+                let url = Self::pull_requests_url(&self.api_url(), &self.remote().owner, &self.remote().repo, page);
+                self.get_json::<Vec<GiteaPullRequest>>(&url).await
+            })
+            .buffered(5);
+
+        let mut page_stream = Box::pin(page_stream);
+
+        while let Some(page_result) = page_stream.next().await {
+            match page_result {
+                Ok(prs) => {
+                    if prs.is_empty() {
+                        break;
+                    }
+
+                    for pr in prs {
+                        yield Ok(Box::new(pr) as Box<dyn RemotePullRequest>);
+                    }
+                }
+                Err(e) => {
+                    if let Error::PaginationError(_) = e {
+                        break;
+                    }
+                    yield Err(e);
+                    break;
+                }
+            }
+        }
+            }
+    }
 }
 
 impl GiteaClient {
+    /// Constructs the URL for Gitea commits API.
+    fn commits_url(api_url: &str, owner: &str, repo: &str, page: usize) -> String {
+        format!(
+            "{}/api/v1/repos/{}/{}/commits?limit={MAX_PAGE_SIZE}&page={page}",
+            api_url, owner, repo
+        )
+    }
+
+    /// Constructs the URL for Gitea pull requests API.
+    fn pull_requests_url(api_url: &str, owner: &str, repo: &str, page: usize) -> String {
+        format!(
+            "{}/api/v1/repos/{}/{}/pulls?limit={MAX_PAGE_SIZE}&page={page}&state=closed",
+            api_url, owner, repo
+        )
+    }
+
     /// Fetches the Gitea API and returns the commits.
-    pub async fn get_commits(&self, ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
-        Ok(self
-            .fetch::<GiteaCommit>(0, ref_name)
-            .await?
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-            .collect())
+    pub async fn get_commits(&self, _ref_name: Option<&str>) -> Result<Vec<Box<dyn RemoteCommit>>> {
+        use futures::TryStreamExt;
+        self.commits_stream().try_collect().await
     }
 
     /// Fetches the Gitea API and returns the pull requests.
     pub async fn get_pull_requests(
         &self,
-        ref_name: Option<&str>,
+        _ref_name: Option<&str>,
     ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-        Ok(self
-            .fetch::<GiteaPullRequest>(0, ref_name)
-            .await?
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-            .collect())
+        use futures::TryStreamExt;
+        self.pull_requests_stream().try_collect().await
     }
 }
 

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -1,3 +1,5 @@
+use async_stream::stream as async_stream;
+use futures::{Stream, StreamExt, stream};
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 
@@ -33,31 +35,6 @@ pub struct GitLabProject {
     pub created_at: String,
     /// Default branch eg (main/master)
     pub default_branch: String,
-}
-
-impl RemoteEntry for GitLabProject {
-    fn url(
-        _id: i64,
-        api_url: &str,
-        remote: &Remote,
-        _ref_name: Option<&str>,
-        _page: i32,
-    ) -> String {
-        format!(
-            "{}/projects/{}%2F{}",
-            api_url,
-            urlencoding::encode(remote.owner.as_str()),
-            remote.repo
-        )
-    }
-
-    fn buffer_size() -> usize {
-        1
-    }
-
-    fn early_exit(&self) -> bool {
-        false
-    }
 }
 
 /// Representation of a single commit.
@@ -104,30 +81,6 @@ impl RemoteCommit for GitLabCommit {
 
     fn timestamp(&self) -> Option<i64> {
         Some(self.convert_to_unix_timestamp(self.committed_date.clone().as_str()))
-    }
-}
-
-impl RemoteEntry for GitLabCommit {
-    fn url(id: i64, api_url: &str, _remote: &Remote, ref_name: Option<&str>, page: i32) -> String {
-        let commit_page = page + 1;
-        let mut url = format!(
-            "{}/projects/{}/repository/commits?per_page={MAX_PAGE_SIZE}&page={commit_page}",
-            api_url, id
-        );
-
-        if let Some(ref_name) = ref_name {
-            url.push_str(&format!("&ref_name={}", ref_name));
-        }
-
-        url
-    }
-
-    fn buffer_size() -> usize {
-        10
-    }
-
-    fn early_exit(&self) -> bool {
-        false
     }
 }
 
@@ -178,27 +131,11 @@ impl RemotePullRequest for GitLabMergeRequest {
     }
 
     fn merge_commit(&self) -> Option<String> {
-        self.merge_commit_sha
-            .clone()
-            .or(self.squash_commit_sha.clone())
-            .or(Some(self.sha.clone()))
-    }
-}
-
-impl RemoteEntry for GitLabMergeRequest {
-    fn url(id: i64, api_url: &str, _remote: &Remote, _ref_name: Option<&str>, page: i32) -> String {
-        format!(
-            "{}/projects/{}/merge_requests?per_page={MAX_PAGE_SIZE}&page={page}&state=merged",
-            api_url, id
-        )
-    }
-
-    fn buffer_size() -> usize {
-        5
-    }
-
-    fn early_exit(&self) -> bool {
-        false
+        self.merge_commit_sha.clone().or_else(|| {
+            self.squash_commit_sha
+                .clone()
+                .or_else(|| Some(self.sha.clone()))
+        })
     }
 }
 
@@ -261,40 +198,149 @@ impl RemoteClient for GitLabClient {
     fn client(&self) -> ClientWithMiddleware {
         self.client.clone()
     }
+
+    fn commits_stream<'a>(&'a self) -> impl Stream<Item = Result<Box<dyn RemoteCommit>>> + 'a {
+        async_stream! {
+            match self.get_project(None).await {
+                Ok(project) => {
+                    let project_id = project.id;
+
+                    let page_stream = stream::iter(0..)
+                        .map(move |page| async move {
+                            let gitlab_page = page + 1;
+                            let url = Self::commits_url(&self.api_url(), project_id, gitlab_page);
+                            self.get_json::<Vec<GitLabCommit>>(&url).await
+                        })
+                        .buffered(10);
+
+                    let mut page_stream = Box::pin(page_stream);
+
+                    while let Some(page_result) = page_stream.next().await {
+                        match page_result {
+                            Ok(commits) => {
+                                if commits.is_empty() {
+                                    break;
+                                }
+
+                                for commit in commits {
+                                    yield Ok(Box::new(commit) as Box<dyn RemoteCommit>);
+                                }
+                            }
+                            Err(e) => {
+                                if let Error::PaginationError(_) = e {
+                                    break; // End of pages
+                                }
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    yield Err(e);
+                }
+            }
+        }
+    }
+
+    fn pull_requests_stream<'a>(
+        &'a self,
+    ) -> impl Stream<Item = Result<Box<dyn RemotePullRequest>>> + 'a {
+        async_stream! {
+            match self.get_project(None).await {
+                Ok(project) => {
+                    let project_id = project.id;
+
+                    let page_stream = stream::iter(0..)
+                        .map(move |page| async move {
+                            let gitlab_page = page + 1;
+                            let url = Self::merge_requests_url(&self.api_url(), project_id, gitlab_page);
+                            self.get_json::<Vec<GitLabMergeRequest>>(&url).await
+                        })
+                        .buffered(5);
+
+                    let mut page_stream = Box::pin(page_stream);
+
+                    while let Some(page_result) = page_stream.next().await {
+                        match page_result {
+                            Ok(mrs) => {
+                                if mrs.is_empty() {
+                                    break;
+                                }
+
+                                for mr in mrs {
+                                    yield Ok(Box::new(mr) as Box<dyn RemotePullRequest>);
+                                }
+                            }
+                            Err(e) => {
+                                if let Error::PaginationError(_) = e {
+                                    break; // End of pages
+                                }
+                                yield Err(e);
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    yield Err(e);
+                }
+            }
+        }
+    }
 }
 
 impl GitLabClient {
+    /// Constructs the URL for GitLab project API.
+    fn project_url(api_url: &str, owner: &str, repo: &str) -> String {
+        format!(
+            "{}/projects/{}%2F{}",
+            api_url,
+            urlencoding::encode(owner),
+            repo
+        )
+    }
+
+    /// Constructs the URL for GitLab commits API.
+    fn commits_url(api_url: &str, project_id: i64, page: i32) -> String {
+        format!(
+            "{}/projects/{}/repository/commits?page={}&per_page={MAX_PAGE_SIZE}",
+            api_url, project_id, page
+        )
+    }
+
+    /// Constructs the URL for GitLab merge requests API.
+    fn merge_requests_url(api_url: &str, project_id: i64, page: i32) -> String {
+        format!(
+            "{}/projects/{}/merge_requests?page={}&per_page={MAX_PAGE_SIZE}&state=merged",
+            api_url, project_id, page
+        )
+    }
+
     /// Fetches the GitLab API and returns the pull requests.
-    pub async fn get_project(&self, ref_name: Option<&str>) -> Result<GitLabProject> {
-        self.get_entry::<GitLabProject>(0, ref_name, 1).await
+    pub async fn get_project(&self, _ref_name: Option<&str>) -> Result<GitLabProject> {
+        let url = Self::project_url(&self.api_url(), &self.remote().owner, &self.remote().repo);
+        self.get_json::<GitLabProject>(&url).await
     }
 
     /// Fetches the GitLab API and returns the commits.
     pub async fn get_commits(
         &self,
-        project_id: i64,
-        ref_name: Option<&str>,
+        _project_id: i64,
+        _ref_name: Option<&str>,
     ) -> Result<Vec<Box<dyn RemoteCommit>>> {
-        Ok(self
-            .fetch::<GitLabCommit>(project_id, ref_name)
-            .await?
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
-            .collect())
+        use futures::TryStreamExt;
+        self.commits_stream().try_collect().await
     }
 
     /// Fetches the GitLab API and returns the pull requests.
     pub async fn get_merge_requests(
         &self,
-        project_id: i64,
-        ref_name: Option<&str>,
+        _project_id: i64,
+        _ref_name: Option<&str>,
     ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-        Ok(self
-            .fetch::<GitLabMergeRequest>(project_id, ref_name)
-            .await?
-            .into_iter()
-            .map(|v| Box::new(v) as Box<dyn RemotePullRequest>)
-            .collect())
+        use futures::TryStreamExt;
+        self.pull_requests_stream().try_collect().await
     }
 }
 #[cfg(test)]
@@ -304,11 +350,11 @@ mod test {
     use super::*;
 
     #[test]
-    fn gitlab_remote_encodes_owner() {
-        let remote = Remote::new("abc/def", "xyz1");
+    fn gitlab_project_url_encodes_owner() {
+        let url = GitLabClient::project_url("https://gitlab.test.com/api/v4", "abc/def", "xyz1");
         assert_eq!(
             "https://gitlab.test.com/api/v4/projects/abc%2Fdef%2Fxyz1",
-            GitLabProject::url(1, "https://gitlab.test.com/api/v4", &remote, None, 0)
+            url
         );
     }
 

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use dyn_clone::DynClone;
-use futures::{StreamExt, future, stream};
+use futures::Stream;
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -47,22 +47,6 @@ pub(crate) const REQUEST_KEEP_ALIVE: u64 = 60;
 
 /// Maximum number of entries to fetch in a single page.
 pub(crate) const MAX_PAGE_SIZE: usize = 100;
-
-/// Trait for handling the different entries returned from the remote.
-pub trait RemoteEntry {
-    /// Returns the API URL for fetching the entries at the specified page.
-    fn url(
-        project_id: i64,
-        api_url: &str,
-        remote: &Remote,
-        ref_name: Option<&str>,
-        page: i32,
-    ) -> String;
-    /// Returns the request buffer size.
-    fn buffer_size() -> usize;
-    /// Whether if exit early.
-    fn early_exit(&self) -> bool;
-}
 
 /// Trait for handling remote commits.
 pub trait RemoteCommit: DynClone {
@@ -177,21 +161,12 @@ pub trait RemoteClient {
     /// Returns the HTTP client for making requests.
     fn client(&self) -> ClientWithMiddleware;
 
-    /// Returns true if the client should early exit.
-    fn early_exit<T: DeserializeOwned + RemoteEntry>(&self, page: &T) -> bool {
-        page.early_exit()
-    }
-
-    /// Retrieves a single object.
-    async fn get_entry<T: DeserializeOwned + RemoteEntry>(
-        &self,
-        project_id: i64,
-        ref_name: Option<&str>,
-        page: i32,
-    ) -> Result<T> {
-        let url = T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
+    /// Performs a HTTP GET request, deserializes the JSON response, and returns the result.
+    /// This is the core HTTP request and JSON parsing logic shared by all API methods.
+    /// Callers are responsible for any additional processing of the deserialized data.
+    async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
         log::debug!("Sending request to: {url}");
-        let response = self.client().get(&url).send().await?;
+        let response = self.client().get(url).send().await?;
         let response_text = if response.status().is_success() {
             let text = response.text().await?;
             log::trace!("Response: {:?}", text);
@@ -204,94 +179,13 @@ pub trait RemoteClient {
         Ok(serde_json::from_str::<T>(&response_text)?)
     }
 
-    /// Retrieves a single page of entries.
-    async fn get_entries_with_page<T: DeserializeOwned + RemoteEntry>(
-        &self,
-        project_id: i64,
-        ref_name: Option<&str>,
-        page: i32,
-    ) -> Result<Vec<T>> {
-        let url = T::url(project_id, &self.api_url(), &self.remote(), ref_name, page);
-        log::debug!("Sending request to: {url}");
-        let response = self.client().get(&url).send().await?;
-        let response_text = if response.status().is_success() {
-            let text = response.text().await?;
-            log::trace!("Response: {:?}", text);
-            text
-        } else {
-            let text = response.text().await?;
-            log::error!("Request error: {}", text);
-            text
-        };
-        let response = serde_json::from_str::<Vec<T>>(&response_text)?;
-        if response.is_empty() {
-            Err(Error::PaginationError(String::from("end of entries")))
-        } else {
-            Ok(response)
-        }
-    }
+    /// Returns a stream of commits with buffered pagination.
+    fn commits_stream<'a>(&'a self) -> impl Stream<Item = Result<Box<dyn RemoteCommit>>> + 'a;
 
-    /// Fetches the remote API and returns the given entry.
-    ///
-    /// See `fetch_with_early_exit` for the early exit version of this method.
-    async fn fetch<T: DeserializeOwned + RemoteEntry>(
-        &self,
-        project_id: i64,
-        ref_name: Option<&str>,
-    ) -> Result<Vec<T>> {
-        let entries: Vec<Vec<T>> = stream::iter(0..)
-            .map(|i| self.get_entries_with_page(project_id, ref_name, i))
-            .buffered(T::buffer_size())
-            .take_while(|page| {
-                if let Err(e) = page {
-                    log::debug!("Error while fetching page: {:?}", e);
-                }
-                future::ready(page.is_ok())
-            })
-            .map(|page| match page {
-                Ok(v) => v,
-                Err(ref e) => {
-                    log::error!("{:#?}", e);
-                    page.expect("failed to fetch page: {}")
-                }
-            })
-            .collect()
-            .await;
-        Ok(entries.into_iter().flatten().collect())
-    }
-
-    /// Fetches the remote API and returns the given entry.
-    ///
-    /// Early exits based on the response.
-    async fn fetch_with_early_exit<T: DeserializeOwned + RemoteEntry>(
-        &self,
-        project_id: i64,
-        ref_name: Option<&str>,
-    ) -> Result<Vec<T>> {
-        let entries: Vec<T> = stream::iter(0..)
-            .map(|i| self.get_entry::<T>(project_id, ref_name, i))
-            .buffered(T::buffer_size())
-            .take_while(|page| {
-                let status = match page {
-                    Ok(v) => !self.early_exit(v),
-                    Err(e) => {
-                        log::debug!("Error while fetching page: {:?}", e);
-                        true
-                    }
-                };
-                future::ready(status && page.is_ok())
-            })
-            .map(|page| match page {
-                Ok(v) => v,
-                Err(ref e) => {
-                    log::error!("{:#?}", e);
-                    page.expect("failed to fetch page: {}")
-                }
-            })
-            .collect()
-            .await;
-        Ok(entries)
-    }
+    /// Returns a stream of pull requests with buffered pagination.
+    fn pull_requests_stream<'a>(
+        &'a self,
+    ) -> impl Stream<Item = Result<Box<dyn RemotePullRequest>>> + 'a;
 }
 
 /// Generates a function for updating the release metadata for a remote.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Refactors the `remote` module:
- The entire `RemoteEntry` trait has been deleted.
- URL construction logic has been moved into the provider implementations.
- Gets rid of the `fetch` and `fetch_with_early_exit`, `get_entry`, `get_entries_with_page` functions. Instead, provide a simple `get_json` that `GET`s the provided URL and parses the response JSON into the given type. That way, `RemoteClient` is just a dumb HTTP client until something implements the other functions in the trait.
- Adds the `commits_stream` and `pull_requests_stream` function signatures to the `RemoteClient` trait, making commits and PRs first-class abstractions instead of abstracting around generic, pageable resources the way `RemoteEntry` did.
- Instead of returning a vector of results or a single object that wraps around the result vector, abstract that away by exposing the results as a stream. That way, consumers of `RemoteClient` objects don't need to know the details of how the API responses are structured - all they see is a stream of results. This resolves the shenanigans around `fetch_with_early_exit`, `early_exit`, etc.
- Moves the response handling logic into the provider implementations instead of trying to do it generically in `RemoteClient`.


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I started out trying to address #422. There are a few ways to do that:
- Implement rate limiting controls.
- Try to be smarter about checking if someone has contributed before. For example, if you fetch a few pages of history and find that all the authors in the changelog have already contributed, you don't need to fetch the rest of the history.
- Only fetch the complete history if the template actually references `is_first_time`.

In trying to figure out how to implement any of those cleanly, I found the current abstractions to be a bit of a straight jacket. It seems like the intention was to reuse code, but it makes it difficult to modify behavior based on the different features provided by each provider's API.

This _should_ be a no-op: the provider implementations use the new stream functions, but they still collect the entire stream into a list like they did before. The refactor does add a marginal amount of code duplication, but hopefully it clears the way for further enhancements.

## How Has This Been Tested?

In addition to the existing tests, I ran a quick check with the GitHub integration and made sure that commit and PR count stayed the same after the refactor:
```
 DEBUG git_cliff_core::changelog   > Number of GitHub commits: 1519
 DEBUG git_cliff_core::changelog   > Number of GitHub pull requests: 925
```

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
