### PR TITLE
feat: improve repository/directory path resolution

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -286,8 +286,8 @@ impl Repository {
                 changed_files.iter().any(|path| {
                     include_pattern
                         .iter()
-                        .any(|pattern| pattern.matches_path(path))
-                        && !exclude_pattern
+                        .any(|pattern| pattern.matches_path(path)) &&
+                        !exclude_pattern
                             .iter()
                             .any(|pattern| pattern.matches_path(path))
                 })
@@ -460,8 +460,8 @@ impl Repository {
     fn should_include_tag(&self, head_commit: &Commit, tag_commit: &Commit) -> Result<bool> {
         Ok(self
             .inner
-            .graph_descendant_of(head_commit.id(), tag_commit.id())?
-            || head_commit.id() == tag_commit.id())
+            .graph_descendant_of(head_commit.id(), tag_commit.id())? ||
+            head_commit.id() == tag_commit.id())
     }
 
     /// Parses and returns a commit-tag map.
@@ -488,13 +488,10 @@ impl Repository {
                     continue;
                 }
 
-                tags.push((
-                    commit,
-                    Tag {
-                        name,
-                        message: None,
-                    },
-                ));
+                tags.push((commit, Tag {
+                    name,
+                    message: None,
+                }));
             } else if let Some(tag) = obj.as_tag() {
                 if let Some(commit) = tag
                     .target()
@@ -504,15 +501,12 @@ impl Repository {
                     if use_branch_tags && !self.should_include_tag(&head_commit, &commit)? {
                         continue;
                     }
-                    tags.push((
-                        commit,
-                        Tag {
-                            name: tag.name().map(String::from).unwrap_or(name),
-                            message: tag
-                                .message()
-                                .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
-                        },
-                    ));
+                    tags.push((commit, Tag {
+                        name: tag.name().map(String::from).unwrap_or(name),
+                        message: tag
+                            .message()
+                            .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
+                    }));
                 }
             }
         }
@@ -1035,13 +1029,10 @@ mod test {
             Repository::normalize_pattern(Pattern::new(input).expect("valid pattern"))
         };
 
-        let first_commit = create_commit_with_files(
-            &repo,
-            vec![
-                ("initial.txt", "initial content"),
-                ("dir/initial.txt", "initial content"),
-            ],
-        );
+        let first_commit = create_commit_with_files(&repo, vec![
+            ("initial.txt", "initial content"),
+            ("dir/initial.txt", "initial content"),
+        ]);
 
         {
             let retain =
@@ -1049,15 +1040,12 @@ mod test {
             assert!(retain, "include: dir/");
         }
 
-        let commit = create_commit_with_files(
-            &repo,
-            vec![
-                ("file1.txt", "content1"),
-                ("file2.txt", "content2"),
-                ("dir/file3.txt", "content3"),
-                ("dir/subdir/file4.txt", "content4"),
-            ],
-        );
+        let commit = create_commit_with_files(&repo, vec![
+            ("file1.txt", "content1"),
+            ("file2.txt", "content2"),
+            ("dir/file3.txt", "content3"),
+            ("dir/subdir/file4.txt", "content4"),
+        ]);
 
         {
             let retain = repo.should_retain_commit(&commit, &None, &None);

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -264,11 +264,11 @@ fn process_repository<'a>(
     let cwd = env::current_dir()?;
     let mut include_path = config.git.include_paths.clone();
     if let Ok(root) = repository.root_path() {
-        if cwd.starts_with(&root)
-            && cwd != root
-            && args.repository.as_ref().is_none_or(|r| r.is_empty())
-            && args.workdir.is_none()
-            && include_path.is_empty()
+        if cwd.starts_with(&root) &&
+            cwd != root &&
+            args.repository.as_ref().is_none_or(|r| r.is_empty()) &&
+            args.workdir.is_none() &&
+            include_path.is_empty()
         {
             let path = cwd.join("**").join("*");
             if let Ok(stripped) = path.strip_prefix(root) {
@@ -750,14 +750,11 @@ pub fn run_with_changelog_modifier(
                 skip_list.extend(skip_commit.clone());
             }
             for sha1 in skip_list {
-                config.git.commit_parsers.insert(
-                    0,
-                    CommitParser {
-                        sha: Some(sha1.to_string()),
-                        skip: Some(true),
-                        ..Default::default()
-                    },
-                );
+                config.git.commit_parsers.insert(0, CommitParser {
+                    sha: Some(sha1.to_string()),
+                    skip: Some(true),
+                    ..Default::default()
+                });
             }
 
             // The commit range, used for determining the remote commits to include


### PR DESCRIPTION
## Description

This PR includes the previous work related to include_path handling and improves repository path resolution logic.
Closes #1264 .

### Changes

1. Added `Repository::open`.

Previously, even when the `--repository` option was provided, the program still attempted to discover a repository by traversing parent directories from the given path. This behavior was error-prone, so `--repository` now strictly accepts only a repository path (not a child directory).

2. Revised `--include_path` default behavior (when unspecified).

Several reported issues related to cwd handling have been addressed:

 - https://github.com/orhun/git-cliff/issues/1264
 
The new logic ensures correct behavior when all of the following are true:

 - `cwd` is a child of the repository root but not the root itself
 - `args.repository` is either None or empty
 - `args.workdir` is None
 - `include_path` is currently empty
 
Previously, this was implemented via `pathdiff::diff_paths`, which could introduce unintended path components like `.` or `..`. The new implementation uses absolute path–based resolution to eliminate those inconsistencies.

## Motivation and Context

Previously, repository and include path resolution had several issues:

 - `--repository` could ambiguously accept a child path of a repository, leading to error-prone behavior.
 - `--include_path` default handling (when unspecified) could produce incorrect paths due to `pathdiff::diff_paths`, especially when `.` or `..` were involved.

This PR resolves these issues by:

 - Introducing `Repository::open` to strictly enforce valid repository paths.
 - Switching `--include_path` handling to absolute path–based resolution to ensure consistent and predictable behavior.

These changes improve reliability and reduce subtle path-related errors in the tool.

## How Has This Been Tested?

1. All changes have been tested locally.
2. Environments reproducing the following tracked issues were set up and tested:

 - [x] https://github.com/orhun/git-cliff/issues/1187
 - [x] https://github.com/orhun/git-cliff/issues/1248
  - The logs referenced in the original issue do not match the conditions described in the issue, making the exact problem unclear. However, this PR reproduces the behavior of the OP's original PR against the issue.
 - [x] https://github.com/orhun/git-cliff/issues/1251
 - [x] https://github.com/orhun/git-cliff/issues/1255
  - This issue should be addressed in: https://github.com/orhun/git-cliff/pull/1293

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
