### PR TITLE
feat: support context json schema dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
  "dyn-clone",
  "expect-test",
  "futures",
- "git-conventional",
+ "git-conventional 0.12.9 (git+https://github.com/greenhat616/git-conventional)",
  "git2",
  "glob",
  "http-cache-reqwest",
@@ -1020,6 +1020,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "rust-embed",
+ "schemars",
  "secrecy",
  "semver",
  "serde",
@@ -1041,6 +1042,16 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6a949b7fcc81df22526032dcddb006e78c8575e47b0e7ba57d9960570a57bc4"
 dependencies = [
+ "unicase",
+ "winnow",
+]
+
+[[package]]
+name = "git-conventional"
+version = "0.12.9"
+source = "git+https://github.com/greenhat616/git-conventional#af796e07661317c82a495b9ad4b5d7134f09a4d9"
+dependencies = [
+ "schemars",
  "serde",
  "unicase",
  "winnow",
@@ -1830,7 +1841,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af0742157c04cea78f8643de0d0785a29d53c4dd08d985bc542cdd4d2ec9830"
 dependencies = [
- "git-conventional",
+ "git-conventional 0.12.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex",
  "semver",
 ]
@@ -2270,6 +2281,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "reflink-copy"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2551,6 +2582,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2675,17 @@ name = "serde_derive"
 version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-cliff-core"
-version = "2.10.1" # managed by release.sh
+version = "2.10.1"                                              # managed by release.sh
 description = "Core library of git-cliff"
 authors = ["git-cliff contributors <git-cliff@protonmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -75,6 +75,7 @@ urlencoding = "2.1.3"
 cacache = { version = "=13.0.0", features = ["mmap"], default-features = false }
 time = "0.3.37"
 chrono = { version = "0.4.41", features = ["serde"] }
+schemars = "1.0.4"
 
 [dependencies.git2]
 version = "0.20.2"
@@ -87,8 +88,9 @@ default-features = false
 features = ["toml", "yaml"]
 
 [dependencies.git-conventional]
-version = "0.12.7"
-features = ["serde"]
+# version = "0.12.7"
+git = "https://github.com/greenhat616/git-conventional"
+features = ["serde", "schemars"]
 
 [dependencies.rust-embed]
 version = "8.7.2"

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -217,8 +217,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref())
-                    == Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref()) ==
+                    Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -247,12 +247,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom
-            || self
-                .body_template
-                .contains_variable(github::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.github.is_custom ||
+            self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -300,12 +298,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom
-            || self
-                .body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitlab.is_custom ||
+            self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -360,12 +356,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom
-            || self
-                .body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.gitea.is_custom ||
+            self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -416,12 +410,10 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom
-            || self
-                .body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
-            || self
-                .footer_template
+        if self.config.remote.bitbucket.is_custom ||
+            self.body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
+            self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -1054,29 +1046,24 @@ mod test {
             timestamp: Some(50000000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(
-                String::from("submodule_one"),
-                vec![
-                    Commit::new(
-                        String::from("sub0jkl12"),
-                        String::from("chore(app): submodule_one do nothing"),
-                    ),
-                    Commit::new(
-                        String::from("subqwerty"),
-                        String::from("chore: submodule_one <preprocess>"),
-                    ),
-                    Commit::new(
-                        String::from("subqwertz"),
-                        String::from("feat!: submodule_one support breaking commits"),
-                    ),
-                    Commit::new(
-                        String::from("subqwert0"),
-                        String::from(
-                            "match(group): submodule_one support regex-replace for groups",
-                        ),
-                    ),
-                ],
-            )]),
+            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
+                Commit::new(
+                    String::from("sub0jkl12"),
+                    String::from("chore(app): submodule_one do nothing"),
+                ),
+                Commit::new(
+                    String::from("subqwerty"),
+                    String::from("chore: submodule_one <preprocess>"),
+                ),
+                Commit::new(
+                    String::from("subqwertz"),
+                    String::from("feat!: submodule_one support breaking commits"),
+                ),
+                Commit::new(
+                    String::from("subqwert0"),
+                    String::from("match(group): submodule_one support regex-replace for groups"),
+                ),
+            ])]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1185,20 +1172,14 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (
-                        String::from("submodule_one"),
-                        vec![
-                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                        ],
-                    ),
-                    (
-                        String::from("submodule_two"),
-                        vec![Commit::new(
-                            String::from("ab76ef"),
-                            String::from("sub_two bump"),
-                        )],
-                    ),
+                    (String::from("submodule_one"), vec![
+                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                    ]),
+                    (String::from("submodule_two"), vec![Commit::new(
+                        String::from("ab76ef"),
+                        String::from("sub_two bump"),
+                    )]),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use schemars::JsonSchema;
+
 use crate::commit::Commit;
 use crate::config::{Config, GitConfig};
 use crate::error::{Error, Result};
@@ -215,8 +217,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref()) ==
-                    Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref())
+                    == Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -245,10 +247,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom ||
-            self.body_template
-                .contains_variable(github::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.github.is_custom
+            || self
+                .body_template
+                .contains_variable(github::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -296,10 +300,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom ||
-            self.body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitlab.is_custom
+            || self
+                .body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -354,10 +360,12 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom ||
-            self.body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitea.is_custom
+            || self
+                .body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -408,10 +416,12 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom ||
-            self.body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.bitbucket.is_custom
+            || self
+                .body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -611,6 +621,18 @@ impl<'a> Changelog<'a> {
         .as_json()?;
         writeln!(out, "{output}")?;
         Ok(())
+    }
+
+    /// Returns the context json schema for the releases.
+    pub fn context_schema() -> Result<String> {
+        use schemars::schema_for;
+        #[derive(JsonSchema)]
+        #[repr(transparent)]
+        /// Context for the changelog.
+        struct Context<'a>(Vec<Release<'a>>);
+        let schema = schema_for!(Context);
+        let schema_json = serde_json::to_string_pretty(&schema)?;
+        Ok(schema_json)
     }
 }
 
@@ -1032,24 +1054,29 @@ mod test {
             timestamp: Some(50000000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
-                Commit::new(
-                    String::from("sub0jkl12"),
-                    String::from("chore(app): submodule_one do nothing"),
-                ),
-                Commit::new(
-                    String::from("subqwerty"),
-                    String::from("chore: submodule_one <preprocess>"),
-                ),
-                Commit::new(
-                    String::from("subqwertz"),
-                    String::from("feat!: submodule_one support breaking commits"),
-                ),
-                Commit::new(
-                    String::from("subqwert0"),
-                    String::from("match(group): submodule_one support regex-replace for groups"),
-                ),
-            ])]),
+            submodule_commits: HashMap::from([(
+                String::from("submodule_one"),
+                vec![
+                    Commit::new(
+                        String::from("sub0jkl12"),
+                        String::from("chore(app): submodule_one do nothing"),
+                    ),
+                    Commit::new(
+                        String::from("subqwerty"),
+                        String::from("chore: submodule_one <preprocess>"),
+                    ),
+                    Commit::new(
+                        String::from("subqwertz"),
+                        String::from("feat!: submodule_one support breaking commits"),
+                    ),
+                    Commit::new(
+                        String::from("subqwert0"),
+                        String::from(
+                            "match(group): submodule_one support regex-replace for groups",
+                        ),
+                    ),
+                ],
+            )]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1158,14 +1185,20 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (String::from("submodule_one"), vec![
-                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                    ]),
-                    (String::from("submodule_two"), vec![Commit::new(
-                        String::from("ab76ef"),
-                        String::from("sub_two bump"),
-                    )]),
+                    (
+                        String::from("submodule_one"),
+                        vec![
+                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                        ],
+                    ),
+                    (
+                        String::from("submodule_two"),
+                        vec![Commit::new(
+                            String::from("ab76ef"),
+                            String::from("sub_two bump"),
+                        )],
+                    ),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -54,8 +54,6 @@ pub fn run(command: &str, input: Option<String>, envs: Vec<(&str, &str)>) -> Res
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     #[cfg(target_family = "unix")]
     fn run_os_command() -> Result<()> {

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -260,8 +260,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false)
-            && !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
+        parser.skip.unwrap_or(false) &&
+            !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -2,6 +2,7 @@ use git_conventional::{Commit as ConventionalCommit, Footer as ConventionalFoote
 #[cfg(feature = "repo")]
 use git2::{Commit as GitCommit, Signature as CommitSignature};
 use lazy_regex::{Lazy, Regex, lazy_regex};
+use schemars::JsonSchema;
 use serde::ser::{SerializeStruct, Serializer};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
@@ -14,7 +15,7 @@ use crate::error::{Error as AppError, Result};
 static SHA1_REGEX: Lazy<Regex> = lazy_regex!(r#"^\b([a-f0-9]{40})\b (.*)$"#);
 
 /// Object representing a link
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Link {
     /// Text of the link.
@@ -24,7 +25,7 @@ pub struct Link {
 }
 
 /// A conventional commit footer.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 struct Footer<'a> {
     /// Token of the footer.
     ///
@@ -53,7 +54,7 @@ impl<'a> From<&'a ConventionalFooter<'a>> for Footer<'a> {
 }
 
 /// Commit signature that indicates authorship.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Signature {
     /// Name on the signature.
     pub name: Option<String>,
@@ -75,7 +76,7 @@ impl<'a> From<CommitSignature<'a>> for Signature {
 }
 
 /// Commit range (from..to)
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Range {
     /// Full commit SHA the range starts at
     from: String,
@@ -94,7 +95,7 @@ impl Range {
 }
 
 /// Common commit object that is parsed from a repository.
-#[derive(Debug, Default, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Commit<'a> {
     /// Commit ID.
@@ -259,8 +260,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false) &&
-            !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
+        parser.skip.unwrap_or(false)
+            && !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.

--- a/git-cliff-core/src/contributor.rs
+++ b/git-cliff-core/src/contributor.rs
@@ -1,9 +1,10 @@
 use std::hash::{Hash, Hasher};
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Representation of a remote contributor.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct RemoteContributor {
     /// Username.
     pub username: Option<String>,

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
 use next_version::{NextVersion, VersionUpdater};
+use schemars::JsonSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
-use schemars::JsonSchema;
 
 use crate::commit::{Commit, Range, commits_to_conventional_commits};
 use crate::config::{Bump, BumpType};

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -4,6 +4,7 @@ use next_version::{NextVersion, VersionUpdater};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
+use schemars::JsonSchema;
 
 use crate::commit::{Commit, Range, commits_to_conventional_commits};
 use crate::config::{Bump, BumpType};
@@ -16,7 +17,7 @@ use crate::{
 };
 
 /// Representation of a release.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all(serialize = "camelCase"))]
 pub struct Release<'a> {
     /// Release version, git tag.

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -24,6 +24,7 @@ use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheO
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use schemars::JsonSchema;
 use secrecy::ExposeSecret;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -100,7 +101,7 @@ dyn_clone::clone_trait_object!(RemotePullRequest);
 pub type RemoteMetadata = (Vec<Box<dyn RemoteCommit>>, Vec<Box<dyn RemotePullRequest>>);
 
 /// Metadata of a remote release.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct RemoteReleaseMetadata {
     /// Contributors.
     pub contributors: Vec<RemoteContributor>,
@@ -321,8 +322,8 @@ macro_rules! update_release_metadata {
                     {
                         let sha_short = Some(v.id().clone().chars().take(12).collect());
                         let pull_request = pull_requests.iter().find(|pr| {
-                            pr.merge_commit() == Some(v.id().clone()) ||
-                                pr.merge_commit() == sha_short
+                            pr.merge_commit() == Some(v.id().clone())
+                                || pr.merge_commit() == sha_short
                         });
                         commit.$remote.username = v.username();
                         commit.$remote.pr_number = pull_request.map(|v| v.number());
@@ -362,8 +363,8 @@ macro_rules! update_release_metadata {
                                 // if current release is unreleased no need to filter
                                 // commits or filter commits that are from
                                 // newer releases
-                                self.timestamp == None ||
-                                    commit.timestamp() < release_commit_timestamp
+                                self.timestamp == None
+                                    || commit.timestamp() < release_commit_timestamp
                             })
                             .map(|v| v.username())
                             .any(|login| login == v.username);

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -322,8 +322,8 @@ macro_rules! update_release_metadata {
                     {
                         let sha_short = Some(v.id().clone().chars().take(12).collect());
                         let pull_request = pull_requests.iter().find(|pr| {
-                            pr.merge_commit() == Some(v.id().clone())
-                                || pr.merge_commit() == sha_short
+                            pr.merge_commit() == Some(v.id().clone()) ||
+                                pr.merge_commit() == sha_short
                         });
                         commit.$remote.username = v.username();
                         commit.$remote.pr_number = pull_request.map(|v| v.number());
@@ -363,8 +363,8 @@ macro_rules! update_release_metadata {
                                 // if current release is unreleased no need to filter
                                 // commits or filter commits that are from
                                 // newer releases
-                                self.timestamp == None
-                                    || commit.timestamp() < release_commit_timestamp
+                                self.timestamp == None ||
+                                    commit.timestamp() < release_commit_timestamp
                             })
                             .map(|v| v.username())
                             .any(|login| login == v.username);

--- a/git-cliff-core/src/statistics.rs
+++ b/git-cliff-core/src/statistics.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
 use chrono::{TimeZone, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::release::Release;
 
 /// Aggregated information about how many times a specific link appeared in
 /// commit messages.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkCount {
     /// Text of the link.
@@ -19,7 +20,7 @@ pub struct LinkCount {
 }
 
 /// Aggregated statistics about commits in the release.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Statistics {
     /// The total number of commits included in the release.
     pub commit_count: usize,

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -232,6 +232,14 @@ pub struct Opt {
     /// Disables the external command execution.
     #[arg(long, help_heading = Some("FLAGS"))]
     pub no_exec: bool,
+    #[arg(long,
+        global = true,
+        value_name = "PATH",
+        value_parser = Opt::parse_dir,
+        help = "Dump the context schema to a file"
+    )]
+    /// Dumps the context schema to a file.
+    pub dump_context_schema: Option<PathBuf>,
     /// Prints changelog context as JSON.
     #[arg(short = 'x', long, help_heading = Some("FLAGS"))]
     pub context: bool,

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -720,11 +720,14 @@ pub fn run_with_changelog_modifier(
                 skip_list.extend(skip_commit.clone());
             }
             for sha1 in skip_list {
-                config.git.commit_parsers.insert(0, CommitParser {
-                    sha: Some(sha1.to_string()),
-                    skip: Some(true),
-                    ..Default::default()
-                });
+                config.git.commit_parsers.insert(
+                    0,
+                    CommitParser {
+                        sha: Some(sha1.to_string()),
+                        skip: Some(true),
+                        ..Default::default()
+                    },
+                );
             }
 
             // Process the repository.
@@ -795,5 +798,11 @@ pub fn run_with_changelog_modifier(
         changelog.generate(&mut out)?;
     }
 
+    Ok(())
+}
+
+pub fn dump_context_schema(path: &Path) -> Result<()> {
+    let schema_json = Changelog::context_schema()?;
+    fs::write(path, schema_json)?;
     Ok(())
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -720,14 +720,11 @@ pub fn run_with_changelog_modifier(
                 skip_list.extend(skip_commit.clone());
             }
             for sha1 in skip_list {
-                config.git.commit_parsers.insert(
-                    0,
-                    CommitParser {
-                        sha: Some(sha1.to_string()),
-                        skip: Some(true),
-                        ..Default::default()
-                    },
-                );
+                config.git.commit_parsers.insert(0, CommitParser {
+                    sha: Some(sha1.to_string()),
+                    skip: Some(true),
+                    ..Default::default()
+                });
             }
 
             // Process the repository.

--- a/git-cliff/src/main.rs
+++ b/git-cliff/src/main.rs
@@ -32,6 +32,11 @@ fn main() -> Result<()> {
         _profiler_guard = Some(());
     }
 
+    if let Some(path) = args.dump_context_schema {
+        git_cliff::dump_context_schema(&path)?;
+        return Ok(());
+    }
+
     // Run git-cliff
     let exit_code = match git_cliff::run(args) {
         Ok(()) => 0,


### PR DESCRIPTION
## Description

Close #1294. Add JSON Schema dump feature.

Current blocked by https://github.com/crate-ci/git-conventional/pull/88.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add a gloabl opt `--dump-context-schema` to dump current version `Context` JSON Schema.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
