### PR TITLE
fix(bump): write bumped version to stdout even when output config is set

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -10,10 +10,11 @@ pub mod args;
 /// Custom logger implementation.
 pub mod logger;
 
+use std::env;
 use std::fs::{self, File};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
-use std::{env, io};
 
 use args::{BumpOption, Opt, Sort, Strip};
 use clap::ValueEnum;
@@ -805,7 +806,11 @@ pub fn run_with_changelog_modifier(
             }
         }
         if args.bumped_version {
-            writeln!(out, "{next_version}")?;
+            if config.changelog.output.is_none() {
+                writeln!(out, "{next_version}")?;
+            } else {
+                writeln!(io::stdout(), "{next_version}")?;
+            }
             return Ok(());
         }
     }


### PR DESCRIPTION
## Description

When the output is configured in `cliff.toml` the `--bumped-version` overrides the output file.

This is not intuitive... so now we always print to stdout even though `[changelog].output` is configured.

`git cliff --bumped-version --output test` keeps working as expected.

## Motivation and Context

fixes #1204

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
