### PR TITLE
docs(config): correct comment for topo_order_commits in cliff.toml

### DIFF
--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -85,7 +85,7 @@ link_parsers = []
 use_branch_tags = false
 # Order releases topologically instead of chronologically.
 topo_order = false
-# Order releases topologically instead of chronologically.
+# Order commits topologically instead of chronologically.
 topo_order_commits = true
 # Order of commits in each group/release within the changelog.
 # Allowed values: newest, oldest


### PR DESCRIPTION
## Description

I noticed the comment was incorrect!

Also, thanks for the awesome repo :smile: 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
