### PR TITLE
fix: panic when remote API returns 403 (rate limit)

### DIFF
--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -169,7 +169,7 @@ pub trait RemoteClient {
     /// Callers are responsible for any additional processing of the deserialized data.
     async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
         log::debug!("Sending request to: {url}");
-        let response = self.client().get(url).send().await?.error_for_status()?;
+        let response = self.client().get(url).send().await?;
         let response_text = if response.status().is_success() {
             let text = response.text().await?;
             log::trace!("Response: {:?}", text);


### PR DESCRIPTION
## Description

Fix a regression where git-cliff panics when the remote API returns an HTTP 403 (e.g. rate limit exceeded) while retrieving remote metadata.

## Motivation and Context

Starting from v2.11.0, `git-cliff` may panic when the remote API responds with HTTP 403 (rate limit exceeded), due to error propagation via `error_for_status()` combined with `expect()` at the call site.

## How Has This Been Tested?

- Ran `git-cliff` locally without a `GITHUB_TOKEN` to reproduce GitHub API rate limit errors.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
