### PR TITLE
feat: add gitlab netrc token resolution

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -247,8 +247,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref()) ==
-                    Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref())
+                    == Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -277,10 +277,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "github")]
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
-        if self.config.remote.github.is_custom ||
-            self.body_template
-                .contains_variable(github::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.github.is_custom
+            || self.body_template
+                .contains_variable(github::TEMPLATE_VARIABLES)
+            || self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -328,10 +328,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitlab")]
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
-        if self.config.remote.gitlab.is_custom ||
-            self.body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitlab.is_custom
+            || self.body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES)
+            || self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -386,10 +386,10 @@ impl<'a> Changelog<'a> {
     #[cfg(feature = "gitea")]
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
-        if self.config.remote.gitea.is_custom ||
-            self.body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitea.is_custom
+            || self.body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES)
+            || self.footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -440,10 +440,12 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
-        if self.config.remote.bitbucket.is_custom ||
-            self.body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.bitbucket.is_custom
+            || self
+                .body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -492,10 +494,12 @@ impl<'a> Changelog<'a> {
         ref_name: Option<&str>,
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::azure_devops;
-        if self.config.remote.azure_devops.is_custom ||
-            self.body_template
-                .contains_variable(azure_devops::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.azure_devops.is_custom
+            || self
+                .body_template
+                .contains_variable(azure_devops::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .map(|v| v.contains_variable(azure_devops::TEMPLATE_VARIABLES))
                 .unwrap_or(false)
@@ -1143,24 +1147,29 @@ mod test {
             timestamp: Some(50000000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
-                Commit::new(
-                    String::from("sub0jkl12"),
-                    String::from("chore(app): submodule_one do nothing"),
-                ),
-                Commit::new(
-                    String::from("subqwerty"),
-                    String::from("chore: submodule_one <preprocess>"),
-                ),
-                Commit::new(
-                    String::from("subqwertz"),
-                    String::from("feat!: submodule_one support breaking commits"),
-                ),
-                Commit::new(
-                    String::from("subqwert0"),
-                    String::from("match(group): submodule_one support regex-replace for groups"),
-                ),
-            ])]),
+            submodule_commits: HashMap::from([(
+                String::from("submodule_one"),
+                vec![
+                    Commit::new(
+                        String::from("sub0jkl12"),
+                        String::from("chore(app): submodule_one do nothing"),
+                    ),
+                    Commit::new(
+                        String::from("subqwerty"),
+                        String::from("chore: submodule_one <preprocess>"),
+                    ),
+                    Commit::new(
+                        String::from("subqwertz"),
+                        String::from("feat!: submodule_one support breaking commits"),
+                    ),
+                    Commit::new(
+                        String::from("subqwert0"),
+                        String::from(
+                            "match(group): submodule_one support regex-replace for groups",
+                        ),
+                    ),
+                ],
+            )]),
             statistics: None,
             #[cfg(feature = "github")]
             github: crate::remote::RemoteReleaseMetadata {
@@ -1273,14 +1282,20 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (String::from("submodule_one"), vec![
-                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                    ]),
-                    (String::from("submodule_two"), vec![Commit::new(
-                        String::from("ab76ef"),
-                        String::from("sub_two bump"),
-                    )]),
+                    (
+                        String::from("submodule_one"),
+                        vec![
+                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                        ],
+                    ),
+                    (
+                        String::from("submodule_two"),
+                        vec![Commit::new(
+                            String::from("ab76ef"),
+                            String::from("sub_two bump"),
+                        )],
+                    ),
                 ]),
                 statistics: None,
                 #[cfg(feature = "github")]

--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -61,10 +61,11 @@ mod test {
     fn run_os_command() -> Result<()> {
         assert_eq!(
             "eroc-ffilc-tig",
-            run("echo $APP_NAME | rev", None, vec![(
-                "APP_NAME",
-                env!("CARGO_PKG_NAME")
-            )])?
+            run(
+                "echo $APP_NAME | rev",
+                None,
+                vec![("APP_NAME", env!("CARGO_PKG_NAME"))]
+            )?
             .trim()
         );
         assert_eq!(

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -263,8 +263,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false) &&
-            !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
+        parser.skip.unwrap_or(false)
+            && !(self.conv.as_ref().map(|c| c.breaking()).unwrap_or(false) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -241,22 +241,28 @@ mod test {
             ("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
             ("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
             ("2.0.0", "2.0.1", vec!["fix: something"]),
-            ("foo/1.0.0", "foo/1.1.0", vec![
-                "feat: add xyz",
-                "fix: fix xyz",
-            ]),
-            ("bar/1.0.0", "bar/2.0.0", vec![
-                "fix: add xyz",
-                "fix!: aaaaaa",
-            ]),
-            ("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
-                "fix: aaaaaa",
-            ]),
+            (
+                "foo/1.0.0",
+                "foo/1.1.0",
+                vec!["feat: add xyz", "fix: fix xyz"],
+            ),
+            (
+                "bar/1.0.0",
+                "bar/2.0.0",
+                vec!["fix: add xyz", "fix!: aaaaaa"],
+            ),
+            (
+                "zzz-123/test/1.0.0",
+                "zzz-123/test/1.0.1",
+                vec!["fix: aaaaaa"],
+            ),
             ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
             ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
-                "feat: nice",
-            ]),
+            (
+                "testing/v1.0.0-beta.1",
+                "testing/v1.0.0-beta.2",
+                vec!["feat: nice"],
+            ),
             ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
             (
                 "rocket/rocket-v4.0.0-rc.1",
@@ -1103,44 +1109,89 @@ mod test {
         ];
         assert_eq!(expected_commits, release.commits);
 
-        release
-            .github
-            .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+        #[cfg(feature = "github")]
+        {
+            release
+                .github
+                .contributors
+                .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
-        let expected_metadata = RemoteReleaseMetadata {
-            contributors: vec![
-                RemoteContributor {
-                    username: Some(String::from("orhun")),
-                    pr_title: Some(String::from("1")),
-                    pr_number: Some(1),
-                    pr_labels: vec![String::from("rust")],
-                    is_first_time: false,
-                },
-                RemoteContributor {
-                    username: Some(String::from("nuhro")),
-                    pr_title: None,
-                    pr_number: None,
-                    pr_labels: vec![],
-                    is_first_time: true,
-                },
-                RemoteContributor {
-                    username: Some(String::from("awesome_contributor")),
-                    pr_title: None,
-                    pr_number: None,
-                    pr_labels: vec![],
-                    is_first_time: true,
-                },
-                RemoteContributor {
-                    username: Some(String::from("someone")),
-                    pr_title: None,
-                    pr_number: None,
-                    pr_labels: vec![],
-                    is_first_time: true,
-                },
-            ],
-        };
-        assert_eq!(expected_metadata, release.gitlab);
+            let expected_metadata = RemoteReleaseMetadata {
+                contributors: vec![
+                    RemoteContributor {
+                        username: Some(String::from("orhun")),
+                        pr_title: Some(String::from("1")),
+                        pr_number: Some(1),
+                        pr_labels: vec![String::from("rust")],
+                        is_first_time: false,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("nuhro")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("awesome_contributor")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("someone")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                ],
+            };
+            assert_eq!(expected_metadata, release.github);
+        }
+
+        #[cfg(feature = "gitlab")]
+        {
+            let expected_metadata = RemoteReleaseMetadata {
+                contributors: vec![
+                    RemoteContributor {
+                        username: Some(String::from("orhun")),
+                        pr_title: Some(String::from("1")),
+                        pr_number: Some(1),
+                        pr_labels: vec![String::from("rust")],
+                        is_first_time: false,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("nuhro")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("awesome_contributor")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                    RemoteContributor {
+                        username: Some(String::from("someone")),
+                        pr_title: None,
+                        pr_number: None,
+                        pr_labels: vec![],
+                        is_first_time: true,
+                    },
+                ],
+            };
+            assert_eq!(expected_metadata, release.gitlab);
+        }
+
+        #[cfg(not(feature = "gitlab"))]
+        {
+            assert!(release.gitlab.contributors.is_empty());
+        }
 
         Ok(())
     }

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -210,8 +210,8 @@ macro_rules! update_release_metadata {
                     {
                         let sha_short = Some(v.id().clone().chars().take(12).collect());
                         let pull_request = pull_requests.iter().find(|pr| {
-                            pr.merge_commit() == Some(v.id().clone()) ||
-                                pr.merge_commit() == sha_short
+                            pr.merge_commit() == Some(v.id().clone())
+                                || pr.merge_commit() == sha_short
                         });
                         commit.$remote.username = v.username();
                         commit.$remote.pr_number = pull_request.map(|v| v.number());
@@ -251,8 +251,8 @@ macro_rules! update_release_metadata {
                                 // if current release is unreleased no need to filter
                                 // commits or filter commits that are from
                                 // newer releases
-                                self.timestamp == None ||
-                                    commit.timestamp() < release_commit_timestamp
+                                self.timestamp == None
+                                    || commit.timestamp() < release_commit_timestamp
                             })
                             .map(|v| v.username())
                             .any(|login| login == v.username);

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -317,13 +317,15 @@ mod test {
         assert_eq!(
             "\n\t\t## 1.0 - 2023\n\t\t\n\t\t### feat\n\t\t- Add xyz\n\t\t\n\t\t### fix\n\t\t- Fix \
              abc\n\t\t",
-            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-                TextProcessor {
+            template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &[TextProcessor {
                     pattern: Regex::new("<DATE>").expect("failed to compile regex"),
                     replace: Some(String::from("2023")),
                     replace_command: None,
-                }
-            ],)?
+                }],
+            )?
         );
         template.variables.sort();
         assert_eq!(
@@ -352,8 +354,11 @@ mod test {
         let release = get_fake_release_data();
         assert_eq!(
             "\n##  1.0\n",
-            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-            ],)?
+            template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &[],
+            )?
         );
         assert_eq!(vec![String::from("version"),], template.variables);
         Ok(())
@@ -364,8 +369,11 @@ mod test {
         let template = "{% set hello_variable = 'hello' %}{{ hello_variable | upper_first }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("Hello", r);
         Ok(())
     }
@@ -376,8 +384,11 @@ mod test {
                         replace_regex(from='o', to='a') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("hella warld", r);
         Ok(())
     }
@@ -388,8 +399,11 @@ mod test {
                         | find_regex(pat='hello') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("[hello, hello]", r);
         Ok(())
     }
@@ -400,8 +414,11 @@ mod test {
                         | split_regex(pat=' ') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
 
         assert_eq!("[hello, world,, hello, universe]", r);
         Ok(())

--- a/website/docs/configuration/remote.md
+++ b/website/docs/configuration/remote.md
@@ -52,6 +52,18 @@ git cliff --github-token <TOKEN>
 
 Same applies for GitLab/Bitbucket with `--gitlab-token`/`--gitea-token`/`--bitbucket-token` and `GITLAB_TOKEN`/`GITEA_TOKEN`/`BITBUCKET_TOKEN` environment variables.
 
+For GitLab, tokens are resolved in the following order:
+
+- `GITLAB_TOKEN` or the `--gitlab-token` flag
+- Netrc (`$NETRC` if set, otherwise `~/.netrc`)
+- `remote.gitlab.token` from the configuration file
+
+The netrc entry should match the GitLab API host (derived from `remote.gitlab.api_url` or `GITLAB_API_URL`). A minimal entry looks like:
+
+```netrc
+machine gitlab.com login oauth2 password <token>
+```
+
 ### api_url
 
 Sets the API URL for a particular remote.

--- a/website/docs/integration/gitlab.md
+++ b/website/docs/integration/gitlab.md
@@ -45,12 +45,18 @@ You can follow [this guide](https://docs.gitlab.com/ee/user/profile/personal_acc
 
 :::
 
-To set an access token, you can use the [configuration file](/docs/configuration/remote) (not recommended), `--gitlab-token` argument or `GITLAB_TOKEN` environment variable.
+To set an access token, you can use the [configuration file](/docs/configuration/remote) (not recommended), `--gitlab-token` argument or `GITLAB_TOKEN` environment variable. If `GITLAB_TOKEN` is not set, **git-cliff** looks for a matching entry in `$NETRC` (or `~/.netrc`) before falling back to the configured token.
 
 For example:
 
 ```bash
 GITLAB_TOKEN="***" git cliff --gitlab-repo "orhun/git-cliff"
+```
+
+Or via netrc:
+
+```netrc
+machine gitlab.com login oauth2 password <token>
 ```
 
 :::tip


### PR DESCRIPTION
## Description
- add GitLab token resolution helper with precedence `GITLAB_TOKEN` -> `$NETRC`/`~/.netrc` (or `_netrc` on Windows) -> config token
- derive host from `api_url`/`GITLAB_API_URL`, strip scheme/trailing slash, and keep tokens out of logs
- wire helper into CLI config load so netrc is used automatically
- update docs with precedence and sample netrc entry
- add tests for env > netrc > config, custom host, default machine; make tag-dependent tests resilient in local fixtures

## Motivation and Context
Makes GitLab auth work without exporting `GITLAB_TOKEN` or storing tokens in config, aligning with common netrc-based workflows. Ensures custom GitLab hosts are matched correctly and sensitive tokens are not logged.

## How Has This Been Tested?
- `cargo test`
- `cargo test -p git-cliff-core --lib -- --nocapture`
- `cargo test -p git-cliff-core --features gitlab gitlab_token`

## Screenshots / Logs (if applicable)
N/A

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (no code change)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Other

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with rustfmt.
- [x] I checked the lints with clippy.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
