### PR TITLE
fix: `cacache` build without async runtime by enabling `tokio-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cacache"
-version = "13.0.0"
+version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61ff12b19d89c752c213316b87fdb4a587f073d219b893cc56974b8c9f39bf7"
+checksum = "5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b"
 dependencies = [
  "digest",
  "either",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -78,7 +78,9 @@ async-stream = { version = "0.3.6", optional = true }
 url.workspace = true
 dyn-clone = "1.0.17"
 urlencoding = "2.1.3"
-cacache = { version = "=13.0.0", features = ["mmap"], default-features = false }
+# `tokio-runtime` is already enabled transitively by the CLI. This just avoids runtime-less build failures.
+# See: https://github.com/zkat/cacache-rs/issues/92
+cacache = { version = "13.1.0", features = ["mmap", "tokio-runtime"], default-features = false }
 time = "0.3.44"
 chrono = { version = "0.4.41", features = ["serde"] }
 


### PR DESCRIPTION
## Description

Enable the `tokio-runtime` feature for the `cacache` dependency in `git-cliff-core`.

## Motivation and Context

In the workspace root, `cacache` is already resolved with an async runtime enabled due to transitive dependencies from the CLI:

```sh
$ cargo tree -f "{p} {f}" | grep cacache
├── cacache v13.1.0 futures,libc,memmap2,mmap,tokio,tokio-runtime,tokio-stream
├── http-cache-reqwest v0.15.0 default,manager-cacache
│   ├── http-cache v0.20.0 bincode,cacache,cacache-tokio,manager-cacache
│   │   ├── cacache v13.1.0 futures,libc,memmap2,mmap,tokio,tokio-runtime,tokio-stream (*)
```

However, when building `git-cliff-core` in isolation, `cacache` is currently resolved without any async runtime enabled:

```sh
$ cargo tree -f "{p} {f}" | grep cacache
├── cacache v13.0.0 libc,memmap2,mmap
```

As a result, cargo build succeeds at the workspace level, but `cargo msrv -p git-cliff-core check` fails due to missing runtime-dependent types in `cacache`.

### Additional context

- https://github.com/orhun/git-cliff/pull/1328
- https://github.com/zkat/cacache-rs/issues/92

## How Has This Been Tested?

- `cargo build` for `git-cliff-core`
- `cargo build` for the workspace
- `cargo msrv` to verify the configuration builds correctly under MSRV constraints

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
