### PR TITLE
feat(args): add the pre-release option

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -314,6 +314,8 @@ pub enum BumpType {
     Minor,
     /// Bump patch version.
     Patch,
+    /// Bump an existing prerelease version.
+    Prerelease,
 }
 
 /// Bump version configuration.
@@ -363,6 +365,11 @@ pub struct Bump {
 
     /// Force to always bump in major, minor or patch.
     pub bump_type: Option<BumpType>,
+
+    /// Specify if the next version should be a prerelease.
+    /// If no value is given, then the version will be finalized by removing the any
+    /// potential prerelease suffix.
+    pub pre_release: Option<String>,
 }
 
 impl Bump {

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use next_version::{NextVersion, VersionUpdater};
-use semver::Version;
+use semver::{Prerelease, Version};
 use serde::{Deserialize, Serialize};
 use serde_json::value::Value;
 
 use crate::commit::{Commit, Range, commits_to_conventional_commits};
 use crate::config::{Bump, BumpType};
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::statistics::Statistics;
 #[cfg(feature = "remote")]
 use crate::{
@@ -146,27 +146,60 @@ impl Release<'_> {
                     next_version = next_version
                         .with_custom_minor_increment_regex(custom_minor_increment_regex)?;
                 }
-                let next_version = if let Some(bump_type) = &config.bump_type {
+                let mut current_version = semver?;
+
+                let should_finalize_prerelease = config.pre_release.is_none() &&
+                    !current_version.pre.is_empty() &&
+                    config.bump_type != Some(BumpType::Prerelease);
+
+                let mut next_version = if should_finalize_prerelease {
+                    current_version.pre = Prerelease::EMPTY;
+                    current_version
+                } else if let Some(bump_type) = &config.bump_type {
                     match bump_type {
-                        BumpType::Major => semver?.increment_major().to_string(),
-                        BumpType::Minor => semver?.increment_minor().to_string(),
-                        BumpType::Patch => semver?.increment_patch().to_string(),
+                        BumpType::Major => current_version.increment_major(),
+                        BumpType::Minor => current_version.increment_minor(),
+                        BumpType::Patch => current_version.increment_patch(),
+                        BumpType::Prerelease => {
+                            if current_version.pre.is_empty() {
+                                return Err(Error::ChangelogError(String::from(
+                                    "Cannot increment prerelease version because the current \
+                                     version is not a prerelease.",
+                                )));
+                            }
+
+                            if config.pre_release.is_some() {
+                                return Err(Error::ChangelogError(String::from(
+                                    "Cannot change pre-release identifier with the prerelease \
+                                     bump type.",
+                                )));
+                            }
+
+                            current_version.increment_prerelease()
+                        }
                     }
                 } else {
-                    next_version
-                        .increment(
-                            &semver?,
-                            self.commits
-                                .iter()
-                                .map(|commit| commit.message.trim_end().to_string())
-                                .collect::<Vec<String>>(),
-                        )
-                        .to_string()
+                    next_version.increment(
+                        &current_version,
+                        self.commits
+                            .iter()
+                            .map(|commit| commit.message.trim_end().to_string())
+                            .collect::<Vec<String>>(),
+                    )
                 };
+
+                if let Some(identifier) = &config.pre_release {
+                    let pre_release = Prerelease::new(&format!("{identifier}.0"))?;
+
+                    if next_version.pre.is_empty() || next_version.pre < pre_release {
+                        next_version.pre = pre_release;
+                    }
+                }
+
                 if let Some(prefix) = prefix {
                     Ok(format!("{prefix}{next_version}"))
                 } else {
-                    Ok(next_version)
+                    Ok(next_version.to_string())
                 }
             }
             None => Ok(config.get_initial_tag()),
@@ -255,19 +288,17 @@ mod test {
                 "fix: aaaaaa",
             ]),
             ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
-            ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
+            ("v1.0.0-alpha.1", "v1.0.0", vec!["fix: minor"]),
+            ("testing/v1.0.0-beta.1", "testing/v1.0.0", vec![
                 "feat: nice",
             ]),
             ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
-            (
-                "rocket/rocket-v4.0.0-rc.1",
-                "rocket/rocket-v4.0.0-rc.2",
-                vec!["chore!: wow"],
-            ),
+            ("rocket/rocket-v4.0.0-rc.1", "rocket/rocket-v4.0.0", vec![
+                "chore!: wow",
+            ]),
             (
                 "aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.419",
-                "aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932-alpha.420",
+                "aaa#/@#$@9384!#%^#@#@!#!239432413-idk-9999.2200.5932",
                 vec!["feat: damn this is working"],
             ),
         ];
@@ -309,6 +340,7 @@ mod test {
                 custom_major_increment_regex: None,
                 custom_minor_increment_regex: None,
                 bump_type: None,
+                pre_release: None,
             })?;
             assert_eq!(expected_version, &next_version);
         }
@@ -332,6 +364,7 @@ mod test {
                 custom_major_increment_regex: None,
                 custom_minor_increment_regex: None,
                 bump_type: None,
+                pre_release: None,
             })?;
             assert_eq!(expected_version, &next_version);
         }
@@ -344,6 +377,7 @@ mod test {
                 ("0.1.0", "0.1.1", vec!["fix: fix xyz"]),
                 ("0.1.0", "0.1.1", vec!["feat: add xyz", "fix: fix xyz"]),
                 ("0.1.0", "1.0.0", vec!["feat!: add xyz", "feat: zzz"]),
+                ("1.2.0-rc.3", "1.2.0", vec!["fix: fix xyz"]),
             ]
             .iter(),
         ) {
@@ -355,6 +389,7 @@ mod test {
                 custom_major_increment_regex: None,
                 custom_minor_increment_regex: None,
                 bump_type: None,
+                pre_release: None,
             })?;
             assert_eq!(expected_version, &next_version);
         }
@@ -379,9 +414,216 @@ mod test {
                     custom_major_increment_regex: None,
                     custom_minor_increment_regex: None,
                     bump_type: None,
+                    pre_release: None
                 })?
             );
         }
+
+        for (version, expected_version, commits) in [
+            ("0.0.1", "0.0.2-alpha.0", vec!["fix: fix xyz"]),
+            ("0.0.1", "0.1.0-alpha.0", vec![
+                "feat: add xyz",
+                "fix: fix xyz",
+            ]),
+            ("0.0.1", "0.1.0-alpha.0", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+            ("0.1.0", "0.1.1-alpha.0", vec!["fix: fix xyz"]),
+            ("0.1.0", "0.2.0-alpha.0", vec![
+                "feat: add xyz",
+                "fix: fix xyz",
+            ]),
+            ("0.1.0", "0.2.0-alpha.0", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+            ("0.1.0-alpha.0", "0.1.0-alpha.1", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+            ("0.1.0-beta.0", "0.1.0-beta.1", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: Some("alpha".to_string()),
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version, commits) in [
+            ("0.1.0-alpha.0", "0.1.0-rc.0", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+            ("0.1.0-beta.2", "0.1.0-rc.0", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: Some("rc".to_string()),
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version, commits) in [
+            ("0.1.0-alpha.0", "0.1.0", vec![
+                "feat!: add xyz",
+                "feat: zzz",
+            ]),
+            ("0.1.0-beta.2", "0.1.0", vec!["feat!: add xyz", "feat: zzz"]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version, commits) in [
+            ("1.2.0-beta.2", "1.2.0-beta.3", vec!["feat: zzz"]),
+            ("1.2.0-alpha.2", "1.2.0-beta.0", vec!["feat: zzz"]),
+            ("v1.2.0", "v1.3.0-beta.0", vec!["feat: zzz"]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: Some("beta".to_string()),
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version, commits) in [
+            ("0.3.0-beta.2", "1.0.0-alpha.0", vec!["feat: zzz"]),
+            ("0.3.0-rc.2", "1.0.0-alpha.0", vec!["feat!: zzz"]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: Some(BumpType::Major),
+                pre_release: Some("alpha".to_string()),
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version) in [
+            ("1.2.0-beta.2", "1.2.0-beta.3"),
+            ("1.2.0-beta.1.2", "1.2.0-beta.1.3"),
+            ("1.2.0-beta", "1.2.0-beta.1"),
+        ] {
+            let release = build_release(version, &["feat: zzz"]);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: Some(BumpType::Prerelease),
+                pre_release: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        {
+            let release = build_release("1.2.0", &["feat: zzz"]);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: Some(BumpType::Prerelease),
+                pre_release: None,
+            });
+            // Since the current version is not a prerelease, it cannot be incremented as a
+            // prerelease
+            assert!(next_version.is_err());
+        }
+
+        {
+            let release = build_release("1.2.0-alpha.0", &["feat: zzz"]);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: Some(BumpType::Prerelease),
+                pre_release: Some("beta".to_string()),
+            });
+            // Changing into a different pre-release identifier is not allowed with the prerelease
+            // bump type
+            assert!(next_version.is_err());
+        }
+
+        for (version, expected_version, commits) in [
+            ("1.2.0-beta.2+build.45", "1.2.0+build.45", vec!["feat: zzz"]),
+            ("1.2.0-beta.1.2", "1.2.0", vec!["feat: zzz"]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: None,
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
+        for (version, expected_version, commits) in [
+            ("1.2.0-beta.2+build.45", "1.2.0-beta.3+build.45", vec![
+                "feat: zzz",
+            ]),
+            ("1.2.0-beta.1.2", "1.2.0-beta.1.3", vec!["feat: zzz"]),
+        ] {
+            let release = build_release(version, &commits);
+            let next_version = release.calculate_next_version_with_config(&Bump {
+                features_always_bump_minor: Some(true),
+                breaking_always_bump_major: Some(false),
+                initial_tag: None,
+                custom_major_increment_regex: None,
+                custom_minor_increment_regex: None,
+                bump_type: None,
+                pre_release: Some("beta".to_string()),
+            })?;
+            assert_eq!(expected_version, &next_version);
+        }
+
         Ok(())
     }
 

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -198,6 +198,19 @@ pub struct Opt {
         allow_hyphen_values = true
     )]
     pub tag: Option<String>,
+    /// Initializes the prerelease suffix for a base version bump.
+    #[arg(
+        long = "prerelease",
+        value_name = "IDENTIFIER",
+        requires = "bump",
+        conflicts_with = "release"
+    )]
+    pub prerelease: Option<String>,
+
+    /// Finalizes the current prerelease version by removing its suffix.
+    #[arg(long, help_heading = Some("FLAGS"), conflicts_with = "prerelease")]
+    pub release: bool,
+
     /// Bumps the version for unreleased changes. Optionally with specified
     /// version.
     #[arg(
@@ -450,6 +463,7 @@ impl TypedValueParser for BumpOptionParser {
             "major" => Ok(BumpOption::Specific(BumpType::Major)),
             "minor" => Ok(BumpOption::Specific(BumpType::Minor)),
             "patch" => Ok(BumpOption::Specific(BumpType::Patch)),
+            "prerelease" => Ok(BumpOption::Specific(BumpType::Prerelease)),
             _ => {
                 let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
                 if let Some(arg) = arg {
@@ -579,6 +593,10 @@ mod tests {
         assert_eq!(
             BumpOption::Specific(BumpType::Major),
             bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("major"))?
+        );
+        assert_eq!(
+            BumpOption::Specific(BumpType::Prerelease),
+            bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("prerelease"))?
         );
         Ok(())
     }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -20,7 +20,7 @@ use args::{BumpOption, Opt, Sort, Strip};
 use clap::ValueEnum;
 use git_cliff_core::changelog::Changelog;
 use git_cliff_core::commit::{Commit, Range};
-use git_cliff_core::config::{CommitParser, Config};
+use git_cliff_core::config::{BumpType, CommitParser, Config};
 use git_cliff_core::embed::{BuiltinConfig, EmbeddedConfig};
 use git_cliff_core::error::{Error, Result};
 use git_cliff_core::release::Release;
@@ -196,41 +196,8 @@ fn process_repository<'a>(
         args.topo_order,
         args.use_branch_tags,
     )?;
-    let skip_regex = config.git.skip_tags.as_ref();
-    let ignore_regex = config.git.ignore_tags.as_ref();
-    let count_tags = config.git.count_tags.as_ref();
+
     let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
-    tags.retain(|_, tag| {
-        let name = &tag.name;
-
-        // Keep skip tags to drop commits in the later stage.
-        let skip = skip_regex.is_some_and(|r| r.is_match(name));
-        if skip {
-            return true;
-        }
-
-        let count = count_tags.is_none_or(|r| {
-            let count_tag = r.is_match(name);
-            if count_tag {
-                log::debug!("Counting release: {name}");
-            }
-            count_tag
-        });
-
-        let ignore = ignore_regex.is_some_and(|r| {
-            if r.as_str().trim().is_empty() {
-                return false;
-            }
-
-            let ignore_tag = r.is_match(name);
-            if ignore_tag {
-                log::debug!("Ignoring release: {name}");
-            }
-            ignore_tag
-        });
-
-        count && !ignore
-    });
 
     if !config.remote.is_any_set() {
         match repository.upstream_remote() {
@@ -726,7 +693,19 @@ pub fn run_with_changelog_modifier<'a>(
 
     // Process commits and releases for the changelog.
     if let Some(BumpOption::Specific(bump_type)) = args.bump {
+        if bump_type == BumpType::Prerelease && args.release {
+            return Err(Error::ArgumentError(String::from(
+                "The '--bump prerelease' and '--release' options cannot be used together",
+            )));
+        }
+
         config.bump.bump_type = Some(bump_type);
+    }
+
+    if let Some(prerelease) = &args.prerelease {
+        config.bump.pre_release = Some(prerelease.clone());
+    } else if args.release {
+        config.bump.pre_release = None;
     }
 
     // Generate changelog from context.
@@ -808,7 +787,7 @@ pub fn write_changelog<W: io::Write>(
         .output
         .clone()
         .or(changelog.config.changelog.output.clone());
-    if args.bump.is_some() || args.bumped_version {
+    if args.bump.is_some() || args.bumped_version || args.release {
         let next_version = if let Some(next_version) = changelog.bump_version()? {
             next_version
         } else if let Some(last_version) =
@@ -837,6 +816,7 @@ pub fn write_changelog<W: io::Write>(
             return Ok(());
         }
     }
+    changelog.filter_releases();
     if args.context {
         changelog.write_context(&mut out)?;
         return Ok(());

--- a/website/docs/configuration/bump.md
+++ b/website/docs/configuration/bump.md
@@ -84,7 +84,7 @@ git-cliff --bumped-version
 
 ### bump_type
 
-When set, it forces to always bump in major, minor or patch.
+When set, it forces to always bump in major, minor, patch, or prerelease.
 
 e.g.
 
@@ -92,3 +92,6 @@ e.g.
 [bump]
 bump_type = "minor"
 ```
+
+When `bump_type = "prerelease"`, the current prerelease suffix is incremented.
+This errors if the previous version is not already a prerelease.

--- a/website/docs/usage/args.md
+++ b/website/docs/usage/args.md
@@ -46,6 +46,8 @@ git-cliff [FLAGS] [OPTIONS] [--] [RANGE]
 -p, --prepend <PATH>               Prepends entries to the given changelog file [env: GIT_CLIFF_PREPEND=]
 -o, --output [<PATH>]              Writes output to the given file [env: GIT_CLIFF_OUTPUT=]
 -t, --tag <TAG>                    Sets the tag for the latest version [env: GIT_CLIFF_TAG=]
+    --prerelease <IDENTIFIER>      Assigns the prerelease identifier for a version bump
+    --release                      Finalizes the current prerelease version by removing its suffix
 -b, --body <TEMPLATE>              Sets the template for the changelog body [env: GIT_CLIFF_TEMPLATE=]
     --from-context <PATH>          Generates changelog from a JSON context [env: GIT_CLIFF_CONTEXT=]
 -s, --strip <PART>                 Strips the given parts from the changelog [possible values: header, footer, all]

--- a/website/docs/usage/bump-version.md
+++ b/website/docs/usage/bump-version.md
@@ -54,6 +54,39 @@ Optionally, you can specify a bump type in `--bump`:
 git cliff --bump [major|minor|patch]
 ```
 
+## Prerelease versions
+
+You can initialize a prerelease for a base version bump:
+
+```bash
+git cliff --bump --prerelease beta
+```
+
+This produces a version such as `1.3.0-beta.0`.
+
+To increment an existing prerelease suffix without changing the base version:
+
+```bash
+git cliff --bump prerelease
+```
+
+Examples:
+
+- `1.2.0-beta.0` -> `1.2.0-beta.1`
+- `1.2.0-beta` -> `1.2.0-beta.1`
+- `1.2.0-beta.2` -> `1.2.0-beta.3`
+
+To finalize a prerelease as a stable release:
+
+```bash
+git cliff --release
+```
+
+Examples:
+
+- `1.2.0-beta.2` -> `1.2.0`
+- `1.2.0-rc.1+build.45` -> `1.2.0+build.45`
+
 ## Zero-based versioning scheme
 
 When working with a zero-based versioning scheme (i.e., `0.x.y` or `0.0.x`),


### PR DESCRIPTION
Add the possibility of  specifying pre-releases via the cli arguments. Now it is possible to specify in the cli `--pre-release [type]` and the bump version will be a prerelease

## Description

Many projects have the need of creating pre-releases for testing with users, before the final release. This PR implements and extra cli argument that the user can specify the type of the pre-release and then changelogs for pre-releases will be generated.

It makes sure that the calculation of the pre-release is correct. So if there already an `rc` version and the user specifies via the cli `--pre-release alpha`, then the calculcation will be correct and it will increment the rc version

There was a [similar issue in the past](https://github.com/orhun/git-cliff/issues/692), but it was never planned. So if it is not of interests feel free just to close the PR.

To make it work with `ingore_tags`  I had to refactor a bit the `process_releases` function. Now it happens in 2 steps, so the calculation of the next version happens first, and then we filter out the releases that we do not want.

## Motivation and Context

Give the possibility of specifying pre-releases, so that projects can create changelogs for these releases

## How Has This Been Tested?

I included a couple of new UTs and tested it manually by invonking the git-cliff cli. For example:

```
cargo run -- --bumped-version --pre-release rc
v2.12.0-rc.0
```

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I have not yet gone through all the points ( and I have not yet update the docs, because I wanted first to get some feedback :) )

- [X] My code follows the code style of this project.
- [X] I have updated the documentation accordingly.
- [X] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [X] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Thank you for contributing to git-cliff! ⛰️  -->
