### PR TITLE
fix(config): respect the changelog.output configuration

### DIFF
--- a/git-cliff/src/main.rs
+++ b/git-cliff/src/main.rs
@@ -49,8 +49,12 @@ fn main() -> Result<()> {
     // Generate a changelog.
     let changelog = git_cliff::run(args.clone())?;
 
-    // Get output file.
-    let out: Box<dyn io::Write> = if let Some(path) = &args.output {
+    // Get output destination.
+    let output = args
+        .output
+        .clone()
+        .or(changelog.config.changelog.output.clone());
+    let out: Box<dyn io::Write> = if let Some(path) = &output {
         if path == Path::new("-") {
             Box::new(io::stdout())
         } else {


### PR DESCRIPTION
## Description

This fixes a regression from 2.11.0

## Motivation and Context

fixes #1317

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply.   -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️  -->
