### PR TITLE
fix: revert log level

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -96,14 +96,7 @@ impl<'a> Changelog<'a> {
             Err(e) => {
                 let short_id = commit.id.chars().take(7).collect::<String>();
                 let summary = commit.message.lines().next().unwrap_or_default().trim();
-                match &e {
-                    Error::ParseError(_) | Error::FieldError(_) => {
-                        log::warn!("{short_id} - {e} ({summary})");
-                    }
-                    _ => {
-                        log::trace!("{short_id} - {e} ({summary})");
-                    }
-                }
+                log::trace!("{short_id} - {e} ({summary})");
                 None
             }
         }


### PR DESCRIPTION
## Description

Closes #1352 

## Motivation and Context

https://discord.com/channels/1093977388892819553/1093977389672956026/1460916457062793448

## How Has This Been Tested?

- Run `cargo test`
- Run locally and check if the log level is reverted

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️  -->
