### PR TITLE
feat: implement commit processing summary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,8 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -16,7 +16,7 @@ default = ["repo"]
 ## Enable parsing commits from a git repository.
 ## You can turn this off if you already have the commits to put in the
 ## changelog and you don't need `git-cliff` to parse them.
-repo = ["dep:git2", "dep:indexmap"]
+repo = ["dep:git2"]
 # Enable integration with remote repositories.
 remote = [
   "dep:reqwest",
@@ -60,7 +60,7 @@ serde_json = "1.0.145"
 bincode = "2.0.1"
 serde_regex = "1.1.0"
 tera = "1.20.1"
-indexmap = { version = "2.12.1", optional = true, features = ["serde"] }
+indexmap = { version = "2.12.1", features = ["serde"] }
 toml = "0.9.8"
 lazy-regex = "3.4.2"
 next_version = "0.2.26"

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -60,7 +60,7 @@ serde_json = "1.0.145"
 bincode = "2.0.1"
 serde_regex = "1.1.0"
 tera = "1.20.1"
-indexmap = { version = "2.12.1", optional = true }
+indexmap = { version = "2.12.1", optional = true, features = ["serde"] }
 toml = "0.9.8"
 lazy-regex = "3.4.2"
 next_version = "0.2.26"

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -16,6 +16,7 @@ use crate::remote::gitea::GiteaClient;
 use crate::remote::github::GitHubClient;
 #[cfg(feature = "gitlab")]
 use crate::remote::gitlab::GitLabClient;
+use crate::summary::Summary;
 use crate::template::Template;
 
 /// Changelog generator.
@@ -90,10 +91,18 @@ impl<'a> Changelog<'a> {
     }
 
     /// Processes a single commit and returns/logs the result.
-    fn process_commit(commit: &Commit<'a>, git_config: &GitConfig) -> Option<Commit<'a>> {
+    fn process_commit(
+        commit: &Commit<'a>,
+        git_config: &GitConfig,
+        summary: &mut Summary,
+    ) -> Option<Commit<'a>> {
         match commit.process(git_config) {
-            Ok(commit) => Some(commit),
+            Ok(commit) => {
+                summary.record_ok();
+                Some(commit)
+            }
             Err(e) => {
+                summary.record_err(&e);
                 let short_id = commit.id.chars().take(7).collect::<String>();
                 let summary = commit.message.lines().next().unwrap_or_default().trim();
                 log::trace!("{short_id} - {e} ({summary})");
@@ -159,31 +168,32 @@ impl<'a> Changelog<'a> {
         Ok(())
     }
 
-    fn process_commit_list(commits: &mut Vec<Commit<'a>>, git_config: &GitConfig) -> Result<()> {
-        *commits = commits
-            .iter()
-            .filter_map(|commit| Self::process_commit(commit, git_config))
-            .flat_map(|commit| {
+    fn process_commit_list(
+        commits: &mut Vec<Commit<'a>>,
+        git_config: &GitConfig,
+        summary: &mut Summary,
+    ) -> Result<()> {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            if let Some(commit) = Self::process_commit(commit, git_config, summary) {
                 if git_config.split_commits {
-                    commit
-                        .message
-                        .lines()
-                        .filter_map(|line| {
-                            let mut c = commit.clone();
-                            c.message = line.to_string();
-                            c.links.clear();
-                            if c.message.is_empty() {
-                                None
-                            } else {
-                                Self::process_commit(&c, git_config)
-                            }
-                        })
-                        .collect()
+                    for line in commit.message.lines() {
+                        let mut c = commit.clone();
+                        c.message = line.to_string();
+                        c.links.clear();
+                        if c.message.is_empty() {
+                            continue;
+                        }
+                        if let Some(c) = Self::process_commit(&c, git_config, summary) {
+                            processed.push(c);
+                        }
+                    }
                 } else {
-                    vec![commit]
+                    processed.push(commit);
                 }
-            })
-            .collect::<Vec<Commit>>();
+            }
+        }
+        *commits = processed;
 
         if git_config.require_conventional {
             Self::check_conventional_commits(commits)?;
@@ -200,12 +210,35 @@ impl<'a> Changelog<'a> {
     /// criteria set by configuration file.
     fn process_commits(&mut self) -> Result<()> {
         log::debug!("Processing the commits");
+
+        let mut summary = Summary::default();
         for release in self.releases.iter_mut() {
-            Self::process_commit_list(&mut release.commits, &self.config.git)?;
+            Self::process_commit_list(&mut release.commits, &self.config.git, &mut summary)?;
             for submodule_commits in release.submodule_commits.values_mut() {
-                Self::process_commit_list(submodule_commits, &self.config.git)?;
+                Self::process_commit_list(submodule_commits, &self.config.git, &mut summary)?;
             }
         }
+
+        log::info!(
+            "Processed {} commit(s) in total (`split_commits` option may cause duplicates)",
+            summary.processed
+        );
+
+        for (&kind, &count) in &summary.by_kind {
+            if count == 0 {
+                continue;
+            }
+            let message = format!(
+                "{count} commit(s) were skipped due to {kind}(s) (run with `--verbose` for \
+                 details)",
+            );
+            if kind.should_warn() {
+                log::warn!("{message}");
+            } else {
+                log::info!("{message}");
+            }
+        }
+
         Ok(())
     }
 

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -228,8 +228,7 @@ impl<'a> Changelog<'a> {
                 continue;
             }
             let message = format!(
-                "{count} commit(s) were skipped due to {kind}(s) (run with `--verbose` for \
-                 details)",
+                "{count} commit(s) were skipped due to {kind}(s) (run with `-vv` for details)",
             );
             if kind.should_warn() {
                 log::warn!("{message}");

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -219,11 +219,10 @@ impl<'a> Changelog<'a> {
             }
         }
 
-        log::info!(
+        log::debug!(
             "Processed {} commit(s) in total (`split_commits` option may cause duplicates)",
             summary.processed
         );
-
         for (&kind, &count) in &summary.by_kind {
             if count == 0 {
                 continue;
@@ -235,7 +234,7 @@ impl<'a> Changelog<'a> {
             if kind.should_warn() {
                 log::warn!("{message}");
             } else {
-                log::info!("{message}");
+                log::debug!("{message}");
             }
         }
 

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -283,7 +283,6 @@ impl Commit<'_> {
         filter: bool,
     ) -> Result<Self> {
         let lookup_context = serde_json::to_value(&self).map_err(|e| {
-            // TODO: This should be updated as a JsonError?
             AppError::FieldError(format!("failed to convert context into value: {e}",))
         })?;
         for parser in parsers {

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -283,6 +283,7 @@ impl Commit<'_> {
         filter: bool,
     ) -> Result<Self> {
         let lookup_context = serde_json::to_value(&self).map_err(|e| {
+            // TODO: This should be updated as a JsonError?
             AppError::FieldError(format!("failed to convert context into value: {e}",))
         })?;
         for parser in parsers {

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -37,6 +37,8 @@ pub mod remote;
 pub mod repo;
 /// Release statistics.
 pub mod statistics;
+/// Changelog commit processing summary.
+pub mod summary;
 /// Git tag.
 pub mod tag;
 /// Template engine.

--- a/git-cliff-core/src/summary.rs
+++ b/git-cliff-core/src/summary.rs
@@ -143,6 +143,45 @@ mod test {
         let err = AppError::GroupError("Skipping commit due to config".into());
         let kind = CommitProcessingErrorKind::from(&err);
         assert_eq!(kind, CommitProcessingErrorKind::Skipped);
+
+        let err = AppError::UnmatchedCommitsError(1);
+        let kind = CommitProcessingErrorKind::from(&err);
+        assert_eq!(kind, CommitProcessingErrorKind::Other);
+    }
+
+    #[test]
+    fn commit_processing_error_kind_from_app_error_owned() {
+        let err = AppError::IoError(StdIoError::other("something went wrong".to_string()));
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Io);
+
+        let err = Commit::parse("")
+            .map_err(AppError::ParseError)
+            .expect_err("expected parse error");
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Parse);
+
+        let err = serde_json::from_str::<serde_json::Value>("{ invalid json }")
+            .map_err(AppError::from)
+            .expect_err("expected JSON parse error");
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Json);
+
+        let err = AppError::FieldError("missing field".into());
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Field);
+
+        let err = AppError::GroupError("no matching group".into());
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Group);
+
+        let err = AppError::GroupError("Skipping commit due to config".into());
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Skipped);
+
+        let err = AppError::UnmatchedCommitsError(1);
+        let kind: CommitProcessingErrorKind = err.into();
+        assert_eq!(kind, CommitProcessingErrorKind::Other);
     }
 
     #[test]

--- a/git-cliff-core/src/summary.rs
+++ b/git-cliff-core/src/summary.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::fmt::Display;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error as AppError;
@@ -88,7 +88,7 @@ pub struct Summary {
     ///
     /// Each entry represents how many commits fell into a particular
     /// [`CommitProcessingErrorKind`] during processing.
-    pub by_kind: HashMap<CommitProcessingErrorKind, usize>,
+    pub by_kind: IndexMap<CommitProcessingErrorKind, usize>,
 }
 
 impl Summary {

--- a/git-cliff-core/src/summary.rs
+++ b/git-cliff-core/src/summary.rs
@@ -1,0 +1,111 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Error as AppError;
+
+/// Represents the category of errors that may occur while processing a commit.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CommitProcessingErrorKind {
+    /// Occurs while spawning or interacting with an OS command via a preprocessor.
+    Io,
+    /// Occurs when parsing a commit message into a conventional commit fails.
+    Parse,
+    /// Occurs when serializing or deserializing data to or from JSON fails.
+    Json,
+    /// Occurs when a referenced commit field is missing or has an unsupported type.
+    Field,
+    /// Occurs when a commit does not match any grouping rule.
+    Group,
+    /// Occurs when a commit is skipped intentionally due to configuration.
+    Skipped,
+    /// Occurs when an error does not fit into any other defined category.
+    Other,
+}
+
+impl From<AppError> for CommitProcessingErrorKind {
+    fn from(err: AppError) -> Self {
+        CommitProcessingErrorKind::from(&err)
+    }
+}
+
+impl From<&AppError> for CommitProcessingErrorKind {
+    fn from(err: &AppError) -> Self {
+        match err {
+            AppError::IoError(_) => CommitProcessingErrorKind::Io,
+            AppError::ParseError(_) => CommitProcessingErrorKind::Parse,
+            AppError::JsonError(_) => CommitProcessingErrorKind::Json,
+            AppError::FieldError(_) => CommitProcessingErrorKind::Field,
+            AppError::GroupError(msg) if msg.contains("Skipping commit") => {
+                CommitProcessingErrorKind::Skipped
+            }
+            AppError::GroupError(_) => CommitProcessingErrorKind::Group,
+            _ => CommitProcessingErrorKind::Other,
+        }
+    }
+}
+
+impl Display for CommitProcessingErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            CommitProcessingErrorKind::Io => "I/O error",
+            CommitProcessingErrorKind::Parse => "parse error",
+            CommitProcessingErrorKind::Json => "JSON error",
+            CommitProcessingErrorKind::Field => "field error",
+            CommitProcessingErrorKind::Group => "grouping error",
+            CommitProcessingErrorKind::Skipped => "intentionally skipped commit",
+            CommitProcessingErrorKind::Other => "other error",
+        };
+        f.write_str(s)
+    }
+}
+
+impl CommitProcessingErrorKind {
+    /// Whether this error kind should be surfaced as a warning summary.
+    pub fn should_warn(self) -> bool {
+        matches!(
+            self,
+            CommitProcessingErrorKind::Io |
+                CommitProcessingErrorKind::Parse |
+                CommitProcessingErrorKind::Json |
+                CommitProcessingErrorKind::Field |
+                CommitProcessingErrorKind::Group |
+                CommitProcessingErrorKind::Other
+        )
+    }
+}
+
+/// Aggregated summary of commit processing results for a changelog.
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Summary {
+    /// The total number of commits that were processed.
+    pub processed: usize,
+    /// The number of commits grouped by processing error kind.
+    ///
+    /// Each entry represents how many commits fell into a particular
+    /// [`CommitProcessingErrorKind`] during processing.
+    pub by_kind: HashMap<CommitProcessingErrorKind, usize>,
+}
+
+impl Summary {
+    /// Records a successfully processed commit.
+    pub fn record_ok(&mut self) {
+        self.processed += 1;
+    }
+
+    /// Records a failed or skipped commit.
+    pub fn record_err(&mut self, err: &AppError) {
+        self.processed += 1;
+        let kind = CommitProcessingErrorKind::from(err);
+        *self.by_kind.entry(kind).or_insert(0) += 1;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO: Implement unit tests.
+}

--- a/git-cliff-core/src/summary.rs
+++ b/git-cliff-core/src/summary.rs
@@ -107,7 +107,7 @@ impl Summary {
 
 #[cfg(test)]
 mod test {
-    use std::io::{Error as StdIoError, ErrorKind as StdIoErrorKind};
+    use std::io::Error as StdIoError;
 
     use git_conventional::Commit;
 
@@ -116,10 +116,7 @@ mod test {
 
     #[test]
     fn commit_processing_error_kind_from_app_error() {
-        let err = AppError::IoError(StdIoError::new(
-            StdIoErrorKind::Other,
-            "something went wrong",
-        ));
+        let err = AppError::IoError(StdIoError::other("something went wrong".to_string()));
         let kind = CommitProcessingErrorKind::from(&err);
         assert_eq!(kind, CommitProcessingErrorKind::Io);
 


### PR DESCRIPTION
## Description

Adds aggregated commit processing summaries, logging errored commits in a concise way.
Errors are categorized by `CommitProcessingErrorKind` (`Io`, `Parse`, `Json`, `Field`, `Group`, `Skipped`, `Other`).
The summary includes total commits processed and counts per error kind, and emits `warning` or `info` messages depending on severity.

Closes #1354 

## Motivation and Context

https://discord.com/channels/1093977388892819553/1093978266135707668/1462836253295771668

## How Has This Been Tested?

- Implemented unit tests.
- Manual testing with sample commits (`git-cliff` repository) to verify correct aggregation and logging output.
- Checked that both skipped commits and errors appear in the summary with the correct log level.

## Screenshots / Logs (if applicable)

<img width="1512" height="239" alt="Screenshot 2026-01-20 at 15 12 05" src="https://github.com/user-attachments/assets/539e32f2-70e8-4dae-9c45-9b242976ea32" />

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
