### PR TITLE
ci: pass GITHUB_TOKEN to profiler job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,8 @@ jobs:
   profiler:
     name: Run profiler
     runs-on: ubuntu-22.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Description

Pass `GITHUB_TOKEN` to the `Run profiler` CI job.

## Motivation and Context

The profiler job was hitting GitHub API rate limits when running unauthenticated.
Passing `GITHUB_TOKEN` allows the job to use authenticated requests and prevents
rate-limit failures.

## How Has This Been Tested?

- No functional changes outside CI behavior.

## Screenshots / Logs (if applicable)

https://github.com/orhun/git-cliff/actions/runs/21201203311/job/60987114763?pr=1350

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
