### PR TITLE
fix: handling of nested annotated tags

### DIFF
--- a/.github/fixtures/test-nested-tags/cliff.toml
+++ b/.github/fixtures/test-nested-tags/cliff.toml
@@ -1,0 +1,26 @@
+[changelog]
+header = ""
+body = """
+{% if version %}\
+{% set clean_version = version | replace(from="v", to="") | replace(from="-stable", to="") %}\
+## [{{ clean_version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message }}
+{%- endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+]
+tag_pattern = "v.*-stable$"

--- a/.github/fixtures/test-nested-tags/cliff.toml
+++ b/.github/fixtures/test-nested-tags/cliff.toml
@@ -2,8 +2,7 @@
 header = ""
 body = """
 {% if version %}\
-{% set clean_version = version | replace(from="v", to="") | replace(from="-stable", to="") %}\
-## [{{ clean_version }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | replace(from="v", to="") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
 ## [unreleased]
 {% endif %}\
@@ -23,4 +22,4 @@ commit_parsers = [
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
 ]
-tag_pattern = "v.*-stable$"
+tag_pattern = "v.*"

--- a/.github/fixtures/test-nested-tags/commit.sh
+++ b/.github/fixtures/test-nested-tags/commit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit --allow-empty -m "feat: initial feature"
+GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit --allow-empty -m "fix: bug fix"
+
+# Create chain of nested tags: v0.1.0-stable -> v0.1.0-rc -> v0.1.0-staging -> commit
+git tag -a v0.1.0-staging -m "staging release"
+git tag -a v0.1.0-rc -m "rc release" "$(git rev-parse v0.1.0-staging)"
+git tag -a v0.1.0-stable -m "stable release" "$(git rev-parse v0.1.0-rc)"

--- a/.github/fixtures/test-nested-tags/commit.sh
+++ b/.github/fixtures/test-nested-tags/commit.sh
@@ -4,7 +4,6 @@ set -e
 GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit --allow-empty -m "feat: initial feature"
 GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit --allow-empty -m "fix: bug fix"
 
-# Create chain of nested tags: v0.1.0-stable -> v0.1.0-rc -> v0.1.0-staging -> commit
-git tag -a v0.1.0-staging -m "staging release"
-git tag -a v0.1.0-rc -m "rc release" "$(git rev-parse v0.1.0-staging)"
-git tag -a v0.1.0-stable -m "stable release" "$(git rev-parse v0.1.0-rc)"
+# Create nested annotated tag: v0.1.0 -> rc-1 (tag object) -> commit
+git tag -a rc-1 -m "release candidate"
+git tag -a v0.1.0 -m "release" "$(git rev-parse rc-1)"

--- a/.github/fixtures/test-nested-tags/expected.md
+++ b/.github/fixtures/test-nested-tags/expected.md
@@ -1,0 +1,10 @@
+
+## [0.1.0] - 2022-04-06
+
+### Bug Fixes
+
+- bug fix
+
+### Features
+
+- initial feature

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -166,6 +166,7 @@ jobs:
           - fixtures-name: test-include-path-env-var-github
             include-path-env: "website/**/* .github/**/*"
           - fixtures-name: test-offline
+          - fixtures-name: test-nested-tags
 
     steps:
       - name: Checkout

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -899,10 +899,7 @@ mod test {
         ];
         assert_eq!(expected_commits, release.commits);
 
-        release
-            .github
-            .contributors
-            .sort_by_key(|a| a.pr_number);
+        release.github.contributors.sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1270,10 +1267,7 @@ mod test {
         ];
         assert_eq!(expected_commits, release.commits);
 
-        release
-            .github
-            .contributors
-            .sort_by_key(|a| a.pr_number);
+        release.github.contributors.sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1615,10 +1609,7 @@ mod test {
         ];
         assert_eq!(expected_commits, release.commits);
 
-        release
-            .gitea
-            .contributors
-            .sort_by_key(|a| a.pr_number);
+        release.gitea.contributors.sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1914,10 +1905,7 @@ mod test {
         ];
         assert_eq!(expected_commits, release.commits);
 
-        release
-            .bitbucket
-            .contributors
-            .sort_by_key(|a| a.pr_number);
+        release.bitbucket.contributors.sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -902,7 +902,7 @@ mod test {
         release
             .github
             .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+            .sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1273,7 +1273,7 @@ mod test {
         release
             .github
             .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+            .sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1618,7 +1618,7 @@ mod test {
         release
             .gitea
             .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+            .sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -1917,7 +1917,7 @@ mod test {
         release
             .bitbucket
             .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+            .sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
@@ -2231,7 +2231,7 @@ mod test {
         release
             .azure_devops
             .contributors
-            .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
+            .sort_by_key(|a| a.pr_number);
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -560,7 +560,7 @@ impl Repository {
             }
         }
         if !topo_order {
-            tags.sort_by(|a, b| a.0.time().seconds().cmp(&b.0.time().seconds()));
+            tags.sort_by_key(|a| a.0.time().seconds());
         }
         Ok(tags
             .into_iter()

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -541,10 +541,11 @@ impl Repository {
                     message: None,
                 }));
             } else if let Some(tag) = obj.as_tag() {
-                if let Some(commit) = tag
-                    .target()
+                // Use peel to resolve nested tags to the final commit
+                if let Some(commit) = obj
+                    .peel(git2::ObjectType::Commit)
                     .ok()
-                    .and_then(|target| target.into_commit().ok())
+                    .and_then(|o| o.into_commit().ok())
                 {
                     if use_branch_tags && !self.should_include_tag(&head_commit, &commit)? {
                         continue;
@@ -806,6 +807,58 @@ mod test {
             "v0.1.0"
         );
         assert!(!tags.contains_key("4ddef08debfff48117586296e49d5caa0800d1b5"));
+        Ok(())
+    }
+
+    #[test]
+    fn git_nested_tags() -> Result<()> {
+        let (repo, temp_dir) = create_temp_repo();
+        let path = temp_dir.path();
+
+        Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(path)
+            .output()?;
+
+        let commit = str::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .current_dir(path)
+                .output()?
+                .stdout
+                .as_ref(),
+        )?
+        .trim()
+        .to_string();
+
+        Command::new("git")
+            .args(["tag", "-a", "v1.0.0-staging", "-m", "s"])
+            .current_dir(path)
+            .output()?;
+        let tag = str::from_utf8(
+            Command::new("git")
+                .args(["rev-parse", "v1.0.0-staging"])
+                .current_dir(path)
+                .output()?
+                .stdout
+                .as_ref(),
+        )?
+        .trim()
+        .to_string();
+
+        // nested tag: v1.0.0-stable -> v1.0.0-staging -> commit
+        Command::new("git")
+            .args(["tag", "-a", "v1.0.0-stable", "-m", "s", &tag])
+            .current_dir(path)
+            .output()?;
+
+        let tags = repo.tags(&Some(Regex::new("v1.0.0-stable")?), false, false)?;
+        assert_eq!(
+            tags.get(&commit)
+                .expect("nested tag should resolve to commit")
+                .name,
+            "v1.0.0-stable"
+        );
         Ok(())
     }
 

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -816,7 +816,7 @@ mod test {
         let path = temp_dir.path();
 
         Command::new("git")
-            .args(["commit", "--allow-empty", "-m", "init"])
+            .args(["commit", "--allow-empty", "--no-gpg-sign", "-m", "init"])
             .current_dir(path)
             .output()?;
 

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -815,46 +815,22 @@ mod test {
         let (repo, temp_dir) = create_temp_repo();
         let path = temp_dir.path();
 
-        Command::new("git")
-            .args(["commit", "--allow-empty", "--no-gpg-sign", "-m", "init"])
-            .current_dir(path)
-            .output()?;
-
-        let commit = str::from_utf8(
-            Command::new("git")
-                .args(["rev-parse", "HEAD"])
-                .current_dir(path)
-                .output()?
-                .stdout
-                .as_ref(),
-        )?
-        .trim()
-        .to_string();
+        let commit = create_commit_with_files(&repo, vec![("initial.txt", "initial content")]);
 
         Command::new("git")
             .args(["tag", "-a", "v1.0.0-staging", "-m", "s"])
             .current_dir(path)
             .output()?;
-        let tag = str::from_utf8(
-            Command::new("git")
-                .args(["rev-parse", "v1.0.0-staging"])
-                .current_dir(path)
-                .output()?
-                .stdout
-                .as_ref(),
-        )?
-        .trim()
-        .to_string();
 
         // nested tag: v1.0.0-stable -> v1.0.0-staging -> commit
         Command::new("git")
-            .args(["tag", "-a", "v1.0.0-stable", "-m", "s", &tag])
+            .args(["tag", "-a", "v1.0.0-stable", "-m", "s", "v1.0.0-staging"])
             .current_dir(path)
             .output()?;
 
         let tags = repo.tags(&Some(Regex::new("v1.0.0-stable")?), false, false)?;
         assert_eq!(
-            tags.get(&commit)
+            tags.get(&commit.id().to_string())
                 .expect("nested tag should resolve to commit")
                 .name,
             "v1.0.0-stable"


### PR DESCRIPTION
Fix handling of nested annotated tags (tags pointing to other tags instead of commits directly).

## Description 
 
When an annotated tag points to another annotated tag (instead of directly to a commit), git-cliff silently skips it. This PR fixes the issue by using `obj.peel(ObjectType::Commit)` to follow the entire chain of tag objects until reaching the final commit. 

## Motivation and Context

In some workflows, tags are "promoted" by creating new tags pointing to existing ones. For example: 

v1.0.0-stable -> v1.0.0-rc (tag) -> v1.0.0-staging (tag) -> commit

The current code uses `tag.target().into_commit()` which only resolves one level of indirection. When the target is another tag object (not a commit), `into_commit()` fails and the tag is silently skipped from the changelog.

## How Has This Been Tested?

Added `git_nested_tags` test that:       
  1. Creates a temp repository with an empty commit
  2. Creates an annotated tag `v1.0.0-staging` pointing to the commit                                                                                                                                      
  3. Creates a nested annotated tag `v1.0.0-stable` pointing to `v1.0.0-staging`                                                                                                                           
  4. Verifies that `v1.0.0-stable` correctly resolves to the original commit                                                                                                                               
                                                                                                                                                                                                           
The test fails without the fix and passes with it.

## Screenshots / Logs (if applicable)                                                                                                                                                                    

Before fix - nested tag is missing:                                                                                                                                                                      
  ```bash                                                                                                                                                                                                  
  $ git tag -a v1.0.0-staging -m "staging"                                                                                                                                                                 
  $ git tag -a v1.0.0-stable -m "stable" $(git rev-parse v1.0.0-staging)                                                                                                                                   
  $ git cliff --tag-pattern ".*-stable$"                                                                                                                                                                   
  # v1.0.0-stable is missing from output
  ```                                                                                                                                                                   

After fix - nested tag is included correctly. 

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply.   -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️  -->
