### PR TITLE
fix(docs): use updated usage of `doc_auto_cfg` and fix internal link

### DIFF
--- a/git-cliff-core/src/error.rs
+++ b/git-cliff-core/src/error.rs
@@ -113,7 +113,7 @@ pub enum Error {
     #[error("Requiring all commits be conventional but found {0} unconventional commits.")]
     UnconventionalCommitsError(i32),
     /// Error raised when commits are not matched by any commit parser and the
-    /// [`GitConfig::fail_on_unmatched_commit`] option is enabled.
+    /// [`crate::config::GitConfig::fail_on_unmatched_commit`] option is enabled.
     #[error("Found {0} unmatched commit(s)")]
     UnmatchedCommitsError(i32),
 }

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Features
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, clippy::unwrap_used)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/orhun/git-cliff/main/website/static/img/git-cliff.png",


### PR DESCRIPTION
## Description

The docs are failing for `git-cliff-core`.

https://docs.rs/crate/git-cliff-core/latest

This PR addresses that.

I also noticed there was a broken internal link, which I resoled by using the fully qualified path.

## Motivation and Context

https://github.com/rust-lang/rfcs/pull/3631 has been merged, which removes `#![cfg_attr(docsrs, feature(doc_auto_cfg))]`.

## How Has This Been Tested?

According to https://docs.rs/about/builds, docs.rs uses `nightly-2026-02-13` to build docs.

I ran 

```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly-2026-02-13 doc --all-features --no-deps
```

and no warnings or errors showed, so it seems to work?

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply.   -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] ~I have updated the documentation accordingly (if applicable).~
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [ ] ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️  -->
