### PR TITLE
ci(lychee): fix root-relative link resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Check the links
+      - name: Check website links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          args: -v --config lychee.toml *.md website/docs/* website/blog/*
+          args: >
+            -v
+            --config lychee.toml
+            --root-dir website
+            website/docs/* website/blog/*
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check root markdown links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >
+            -v
+            --config lychee.toml
+            *.md
           fail: true
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description

This PR fixes link check failures in CI caused by root-relative links inside the website documentation.

The lychee configuration has been updated to:

- Run link checks separately for `website/**/*` and repository-level `*.md`
- Provide `--root-dir` website for website docs

Closes #1422 

## Motivation and Context

Previously, the lychee step failed with errors like:

https://github.com/orhun/git-cliff/actions/runs/22559287619/job/65342428917

This happened because the documentation uses Docusaurus-style root relative links, but `lychee` was running without a defined root directory.

## How Has This Been Tested?

N/A

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
