### PR TITLE
fix(args): handle --workdir include paths relative to repo root

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -289,6 +289,22 @@ fn process_repository<'a>(
     let cwd = env::current_dir()?;
     let mut include_path = config.git.include_paths.clone();
     if let Ok(root) = repository.root_path() {
+        if include_path.is_empty() {
+            if let Some(workdir) = args.workdir.as_ref() {
+                let resolved_workdir = fs::canonicalize(workdir).unwrap_or_else(|_| workdir.clone());
+                if resolved_workdir.starts_with(&root) && resolved_workdir != root {
+                    let path = resolved_workdir.join("**").join("*");
+                    if let Ok(stripped) = path.strip_prefix(&root) {
+                        log::info!(
+                            "Including changes from the workdir: {}",
+                            resolved_workdir.display()
+                        );
+                        include_path = vec![Pattern::new(stripped.to_string_lossy().as_ref())?];
+                    }
+                }
+            }
+        }
+
         if cwd.starts_with(&root) &&
             cwd != root &&
             args.repository.as_ref().is_none_or(Vec::is_empty) &&
@@ -534,11 +550,6 @@ pub fn run_with_changelog_modifier<'a>(
         if let Some(changelog) = args.prepend {
             args.prepend = Some(workdir.join(changelog));
         }
-        // pushing an empty component force-adds a trailing path separator
-        // which is needed for correct glob expansion
-        args.include_path = Some(vec![Pattern::new(
-            workdir.join("").to_string_lossy().as_ref(),
-        )?]);
     }
 
     // Set path for the configuration file.

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -291,7 +291,8 @@ fn process_repository<'a>(
     if let Ok(root) = repository.root_path() {
         if include_path.is_empty() {
             if let Some(workdir) = args.workdir.as_ref() {
-                let resolved_workdir = fs::canonicalize(workdir).unwrap_or_else(|_| workdir.clone());
+                let resolved_workdir =
+                    fs::canonicalize(workdir).unwrap_or_else(|_| workdir.clone());
                 if resolved_workdir.starts_with(&root) && resolved_workdir != root {
                     let path = resolved_workdir.join("**").join("*");
                     if let Ok(stripped) = path.strip_prefix(&root) {


### PR DESCRIPTION
## Description

Fixes `--workdir` path handling so repository-root workdirs no longer force an include filter that drops commits.

## Motivation and Context

Fixes #1369.

Previously, `--workdir` always injected an include glob from the raw workdir path. When workdir pointed to the repository root (or a parent directory in combinations like `--repository ... --workdir ./`), the generated include pattern did not match commit file paths, producing an empty changelog.

This change:
- Stops injecting `args.include_path` early from `--workdir`.
- Resolves `--workdir` against the discovered repo root later (in `process_repository`).
- Only applies a derived include pattern when workdir is inside the repo **and not equal to** repo root.

That preserves subdirectory scoping while avoiding false-empty output for root workdirs.

## How Has This Been Tested?

Local Rust toolchain is unavailable in this environment (`cargo` not installed), so I could not run `cargo test` / `clippy` here.

Validation performed:
- Reproduced and inspected the failing argument/path flow in `run_with_changelog_modifier` + `process_repository`.
- Verified the updated logic path-by-path against the issue repro scenarios:
  - `git-cliff --workdir .` from repo root: no include filter forced.
  - `git-cliff --workdir <repo-dir>` from parent: no include filter forced.
  - `git-cliff --repository <repo-dir> --workdir ./` from parent: no include filter forced.
  - `git-cliff --workdir <subdir>`: include filtering still applied for subdirectory scope.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`
