### PR TITLE
Fix: avoid random testimonial during hydration

### DIFF
--- a/website/src/components/Testimonials/index.tsx
+++ b/website/src/components/Testimonials/index.tsx
@@ -57,7 +57,11 @@ const getRandomTestimonial = () => {
 };
 
 export default function Testimonials(): JSX.Element {
-  const review = getRandomTestimonial();
+  const [review, setReview] = React.useState(testimonials[0]);
+
+  React.useEffect(() => {
+    setReview(getRandomTestimonial());
+  }, []);
 
   return (
     <div className={styles.testimonialsList}>


### PR DESCRIPTION
## Problem

Issue #1385 reproduces on the homepage after building and serving the website. `Testimonials` can render one testimonial in the static HTML and a different one during hydration, which triggers a React hydration mismatch warning.

## Cause

`Testimonials` calls `Math.random()` during render. SSG and the first client render therefore choose independently, so the server markup and hydrated client tree can diverge.

## Fix

The component now renders a deterministic testimonial for the server render and initial client render. After mount, a `useEffect` selects a random testimonial on the client, preserving the randomized behavior without mismatching hydration.

## Testing

`./node_modules/.bin/tsc`
`./node_modules/.bin/docusaurus build`
`cargo test`
`cargo clippy --tests --verbose -- -D warnings`
Headless Chrome against the built site showed no hydration-related console warnings after the change.

Closes #1385
