### PR TITLE
fix(args): split path filter env vars

### DIFF
--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -119,7 +119,8 @@ pub struct Opt {
 		long,
 		env = "GIT_CLIFF_INCLUDE_PATH",
 		value_name = "PATTERN",
-		num_args(1..)
+		num_args(1..),
+		value_delimiter = ' '
 	)]
     pub include_path: Option<Vec<Pattern>>,
     /// Sets the path to exclude related commits.
@@ -127,7 +128,8 @@ pub struct Opt {
 		long,
 		env = "GIT_CLIFF_EXCLUDE_PATH",
 		value_name = "PATTERN",
-		num_args(1..)
+		num_args(1..),
+		value_delimiter = ' '
 	)]
     pub exclude_path: Option<Vec<Pattern>>,
     /// Sets the regex for matching git tags.
@@ -476,11 +478,44 @@ impl Opt {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsStr;
+    use std::ffi::{OsStr, OsString};
+    use std::sync::{Mutex, OnceLock};
 
     use clap::CommandFactory;
 
     use super::*;
+
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original_value: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original_value = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self {
+                key,
+                original_value,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(value) = &self.original_value {
+                    std::env::set_var(self.key, value);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     #[test]
     fn verify_cli() {
@@ -560,5 +595,29 @@ mod tests {
             bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("major"))?
         );
         Ok(())
+    }
+
+    #[test]
+    fn path_filter_env_vars_support_multiple_values() {
+        let _guard = ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("failed to lock env mutex");
+        let _include_path = EnvVarGuard::set("GIT_CLIFF_INCLUDE_PATH", "website/**/* .github/**/*");
+        let _exclude_path = EnvVarGuard::set("GIT_CLIFF_EXCLUDE_PATH", "target/**/* dist/**/*");
+
+        let opt = Opt::parse_from(["git-cliff"]);
+        let include_path = opt
+            .include_path
+            .expect("include path should be parsed from env");
+        let patterns = include_path.iter().map(Pattern::as_str).collect::<Vec<_>>();
+
+        assert_eq!(vec!["website/**/*", ".github/**/*"], patterns);
+        let exclude_path = opt
+            .exclude_path
+            .expect("exclude path should be parsed from env");
+        let patterns = exclude_path.iter().map(Pattern::as_str).collect::<Vec<_>>();
+
+        assert_eq!(vec!["target/**/*", "dist/**/*"], patterns);
     }
 }


### PR DESCRIPTION
## Description

Add a path filter env value delimiter so space-separated values from `GIT_CLIFF_INCLUDE_PATH` are parsed into multiple patterns instead of a single string. For consistency, apply the same behavior to `GIT_CLIFF_EXCLUDE_PATH` and add a regression test that covers both env vars.

## Motivation and Context

Fixes #1447.

Without an explicit delimiter, multi-value path filters passed through env vars are treated as one value, which breaks the documented/expected path filtering workflow.

## How Has This Been Tested?

- Added a unit test for multi-value `GIT_CLIFF_INCLUDE_PATH` and `GIT_CLIFF_EXCLUDE_PATH`
- `cargo test`
- `cargo clippy --tests --verbose -- -D warnings`
- `cargo +nightly fmt --all -- --check`

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
