### PR TITLE
refactor(deps): replace dirs_next with etcetera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "expect-test"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,8 +1012,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "dirs",
  "env_logger",
+ "etcetera 0.11.0",
  "git-cliff-core",
  "glob",
  "indicatif",
@@ -1030,9 +1040,9 @@ dependencies = [
  "cacache",
  "chrono",
  "config",
- "dirs",
  "document-features",
  "dyn-clone",
+ "etcetera 0.11.0",
  "expect-test",
  "futures",
  "git-conventional",
@@ -3322,7 +3332,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b27dcf766dc6ad64c2085201626e1a7955dc1983532bfc8406d552903ace2a"
 dependencies = [
- "etcetera",
+ "etcetera 0.10.0",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ regex = "1.11.1"
 glob = "0.3.2"
 log = "0.4.21"
 secrecy = { version = "0.8.0", features = ["serde"] }
-dirs = "6.0.0"
+etcetera = "0.11.0"
 url = "2.5.3"
 reqwest = { version = "0.12.28", default-features = false, features = [
   "blocking",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/orhun/git-cliff"
 repository = "https://github.com/orhun/git-cliff"
 keywords = ["changelog", "generator", "conventional", "commit"]
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.87.0"
 
 [features]
 default = ["repo"]
@@ -52,7 +52,7 @@ glob.workspace = true
 regex.workspace = true
 log.workspace = true
 secrecy.workspace = true
-dirs.workspace = true
+etcetera.workspace = true
 thiserror = "2.0.17"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 use std::{fmt, fs};
 
+use etcetera::{BaseStrategy, choose_base_strategy};
 use glob::Pattern;
 use regex::{Regex, RegexBuilder};
 use secrecy::SecretString;
@@ -488,34 +489,25 @@ impl Config {
             .try_deserialize()?)
     }
 
-    /// Find a special config path on macOS.
-    ///
-    /// The `dirs` crate ignores the `XDG_CONFIG_HOME` env var on macOS and only considers
-    /// `Library/Application Support` as the config dir, which is primarily used by GUI apps.
-    ///
-    /// This function determines the config path and honors the `XDG_CONFIG_HOME` env var.
-    /// If it is not set, it will fall back to `~/.config`
-    #[cfg(target_os = "macos")]
-    pub fn retrieve_xdg_config_on_macos() -> PathBuf {
-        let config_dir = std::env::var("XDG_CONFIG_HOME").map_or_else(
-            |_| dirs::home_dir().unwrap_or_default().join(".config"),
-            PathBuf::from,
-        );
-        config_dir.join("git-cliff")
-    }
-
     /// Find the path of the config file.
     ///
     /// If the config file is not found in its standard locations, [`None`] is returned.
     #[must_use]
     pub fn retrieve_config_path() -> Option<PathBuf> {
+        // cannot panic - see https://github.com/lunacookies/etcetera/issues/42
+        let strategy = choose_base_strategy()
+            .expect("cannot determine current OS's default strategy (layout)");
         for supported_path in [
+            strategy.config_dir().join("git-cliff").join(DEFAULT_CONFIG),
+            // paths for backwards compatibility
             #[cfg(target_os = "macos")]
-            Some(Config::retrieve_xdg_config_on_macos().join(DEFAULT_CONFIG)),
-            dirs::config_dir().map(|dir| dir.join("git-cliff").join(DEFAULT_CONFIG)),
+            strategy
+                .home_dir()
+                .to_path_buf()
+                .join("Library/Application Support/git-cliff")
+                .join(DEFAULT_CONFIG),
         ]
         .iter()
-        .filter_map(|v| v.as_ref())
         {
             if supported_path.exists() {
                 #[allow(clippy::unnecessary_debug_formatting)]

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -23,6 +23,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use dyn_clone::DynClone;
+use etcetera::{BaseStrategy, choose_base_strategy};
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -99,6 +100,8 @@ impl Remote {
         if !self.is_set() {
             return Err(Error::RemoteNotSetError);
         }
+        let strategy = choose_base_strategy()
+            .expect("cannot determine current OS's default strategy (layout)");
         let mut headers = HeaderMap::new();
         headers.insert(
             reqwest::header::ACCEPT,
@@ -126,13 +129,7 @@ impl Remote {
             .with(Cache(HttpCache {
                 mode: CacheMode::Default,
                 manager: CACacheManager {
-                    path: dirs::cache_dir()
-                        .ok_or_else(|| {
-                            Error::DirsError(String::from(
-                                "failed to find the user's cache directory",
-                            ))
-                        })?
-                        .join(env!("CARGO_PKG_NAME")),
+                    path: strategy.cache_dir().join(env!("CARGO_PKG_NAME")),
                 },
                 options: HttpCacheOptions::default(),
             }))

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -100,6 +100,7 @@ impl Remote {
         if !self.is_set() {
             return Err(Error::RemoteNotSetError);
         }
+        // cannot panic - see https://github.com/lunacookies/etcetera/issues/42
         let strategy = choose_base_strategy()
             .expect("cannot determine current OS's default strategy (layout)");
         let mut headers = HeaderMap::new();

--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["changelog", "generator", "conventional", "commit"]
 categories = ["command-line-utilities"]
 default-run = "git-cliff"
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.87.0"
 
 [[bin]]
 name = "git-cliff-completions"
@@ -49,7 +49,7 @@ glob.workspace = true
 regex.workspace = true
 log.workspace = true
 secrecy.workspace = true
-dirs.workspace = true
+etcetera.workspace = true
 clap = { version = "4.5.53", features = ["derive", "env", "wrap_help", "cargo"] }
 clap_complete = "4.5.61"
 clap_mangen = "0.2.31"

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn path_tilde_expansion() {
-        let home_dir = dirs::home_dir().expect("cannot retrieve home directory");
+        let home_dir = std::env::home_dir().expect("cannot retrieve home directory");
         let dir = Opt::parse_dir("~/").expect("cannot expand tilde");
         assert_eq!(home_dir, dir);
     }


### PR DESCRIPTION
## Description

This changed replaces the crate `dirs` with `etcetera`. The dirs crate unfortunately still returns the `~/Library/...` directories and does not follow the XDG standard on macOS (which is also a Unix system at its core).
The directories in `~/Library/...` are supposed to be used by macOS GUI applications and not terminal apps.

However, the change still maintains backwards compat in case a config file is stored in `~/Library/Application Support/git-cliff`.

## Motivation and Context

see #1475

## How Has This Been Tested?

- cargo test
- manual testing

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
