### PR TITLE
fix(bump): use commit subject for non-conventional bumps

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -81,6 +81,20 @@ crate::update_release_metadata!(bitbucket, update_bitbucket_metadata);
 crate::update_release_metadata!(azure_devops, update_azure_devops_metadata);
 
 impl Release<'_> {
+    fn versioning_message(commit: &Commit<'_>) -> String {
+        if commit.conv.is_some() {
+            commit.message.trim_end().to_string()
+        } else {
+            commit
+                .message
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        }
+    }
+
     /// Calculates the next version based on the commits.
     ///
     /// It uses the default bump version configuration to calculate the next
@@ -158,7 +172,7 @@ impl Release<'_> {
                             &semver?,
                             self.commits
                                 .iter()
-                                .map(|commit| commit.message.trim_end().to_string())
+                                .map(Self::versioning_message)
                                 .collect::<Vec<String>>(),
                         )
                         .to_string()
@@ -243,22 +257,28 @@ mod test {
             ("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
             ("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
             ("2.0.0", "2.0.1", vec!["fix: something"]),
-            ("foo/1.0.0", "foo/1.1.0", vec![
-                "feat: add xyz",
-                "fix: fix xyz",
-            ]),
-            ("bar/1.0.0", "bar/2.0.0", vec![
-                "fix: add xyz",
-                "fix!: aaaaaa",
-            ]),
-            ("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
-                "fix: aaaaaa",
-            ]),
+            (
+                "foo/1.0.0",
+                "foo/1.1.0",
+                vec!["feat: add xyz", "fix: fix xyz"],
+            ),
+            (
+                "bar/1.0.0",
+                "bar/2.0.0",
+                vec!["fix: add xyz", "fix!: aaaaaa"],
+            ),
+            (
+                "zzz-123/test/1.0.0",
+                "zzz-123/test/1.0.1",
+                vec!["fix: aaaaaa"],
+            ),
             ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
             ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
-                "feat: nice",
-            ]),
+            (
+                "testing/v1.0.0-beta.1",
+                "testing/v1.0.0-beta.2",
+                vec!["feat: nice"],
+            ),
             ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
             (
                 "rocket/rocket-v4.0.0-rc.1",
@@ -358,6 +378,34 @@ mod test {
             })?;
             assert_eq!(expected_version, &next_version);
         }
+
+        let release = build_release(
+            "nati-1.0.0",
+            &["breaking: remove v1 endpoints\nThis removes the entire /v1 API surface."],
+        );
+        let next_version = release.calculate_next_version_with_config(&Bump {
+            features_always_bump_minor: Some(true),
+            breaking_always_bump_major: Some(true),
+            initial_tag: None,
+            custom_major_increment_regex: Some(String::from("^breaking")),
+            custom_minor_increment_regex: Some(String::from("^feat")),
+            bump_type: None,
+        })?;
+        assert_eq!("nati-2.0.0", next_version);
+
+        let release = build_release(
+            "nati-1.0.0",
+            &["feat: add v2 endpoint\nThis adds the new /v2 API surface."],
+        );
+        let next_version = release.calculate_next_version_with_config(&Bump {
+            features_always_bump_minor: Some(true),
+            breaking_always_bump_major: Some(true),
+            initial_tag: None,
+            custom_major_increment_regex: Some(String::from("^breaking")),
+            custom_minor_increment_regex: Some(String::from("^feat")),
+            bump_type: None,
+        })?;
+        assert_eq!("nati-1.1.0", next_version);
 
         let empty_release = Release {
             previous: Some(Box::new(Release {


### PR DESCRIPTION
## Description

Fixes version bump detection for multiline custom commits when `conventional_commits = false`.

Previously, git-cliff passed the full non-conventional commit message into version bump detection. When a multiline commit was provided via `--with-commit`, `custom_major_increment_regex` and `custom_minor_increment_regex` could be ignored, causing an incorrect patch bump.

This change makes nonconventional commits use only the subject line (the first line) for bump calculation, while preserving the full message for changelog generation. It also adds regression tests covering multiline major and minor bump cases.

## Motivation and Context

Fixes [#1476](https://github.com/orhun/git-cliff/issues/1476).

This is needed for users who disable conventional commits and rely on custom prefixes like `breaking` or `feat` at the start of free-form commit subjects. With this fix, multiline `--with-commit` input behaves consistently with single-line input for version bumping.

## How Has This Been Tested?

Added regression coverage in `git-cliff-core/src/release.rs` for:
- Multiline non-conventional commits matching `custom_major_increment_regex`
- Multiline non-conventional commits matching `custom_minor_increment_regex`

Commands run:
- `cargo fmt --all`
- `cargo test -p git-cliff-core release::test::bump_version -- --nocapture`

Notes:
- The targeted regression test passed.
- `cargo test -p git-cliff-core` still showed existing unrelated failures in `repo::test::{get_latest_tag, git_tags, resolves_existing_tag_with_name_and_message}` in my local environment.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`
