### PR TITLE
test(fixture): add test fixture for skipped contributors

### DIFF
--- a/.github/fixtures/test-github-integration-skipped-contributors/cliff.toml
+++ b/.github/fixtures/test-github-integration-skipped-contributors/cliff.toml
@@ -1,0 +1,53 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+# GitHub integration for fetching commit metadata.
+[remote.github]
+owner = "orhun"
+repo = "git-cliff-readme-example"
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+## What's Changed
+
+{%- if version %} in {{ version }}{%- endif -%}
+{% for commit in commits %}
+  * {{ commit.message | split(pat="\n") | first | trim }}\
+    {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif -%}
+    {% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{%- endif %}
+{%- endfor -%}
+
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+  {% raw %}\n{% endraw -%}
+  ### New Contributors
+{%- endif %}\
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  * @{{ contributor.username }} made their first contribution
+    {%- if contributor.pr_number %} in \
+      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
+    {%- endif %}
+{%- endfor -%}
+
+{% if version %}
+    {% if previous.version %}
+      **Full Changelog**: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{ previous.version }}...{{ version }}
+    {% endif %}
+{% else -%}
+  {% raw %}\n{% endraw %}
+{% endif %}
+"""
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+  # Remove issue numbers.
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "" },
+]
+commit_parsers = [
+  { message = ".*", skip = true },
+]

--- a/.github/fixtures/test-github-integration-skipped-contributors/commit.sh
+++ b/.github/fixtures/test-github-integration-skipped-contributors/commit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+git remote add origin https://github.com/orhun/git-cliff-readme-example
+git pull origin master
+git fetch --tags

--- a/.github/fixtures/test-github-integration-skipped-contributors/expected.md
+++ b/.github/fixtures/test-github-integration-skipped-contributors/expected.md
@@ -1,0 +1,5 @@
+## What's Changed in v1.0.0
+
+### New Contributors
+* @orhun made their first contribution
+

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -20,6 +20,7 @@ jobs:
           - fixtures-name: test-github-integration
           - fixtures-name: test-github-integration-custom-range
             command: v1.0.0..v1.0.1
+          - fixtures-name: test-github-integration-skipped-contributors
           - fixtures-name: test-gitlab-integration
           - fixtures-name: test-gitlab-integration-custom-range
             command: 9f66ac0f76..89de5e8e50


### PR DESCRIPTION
## Description

Adds a test fixture for GitHub integration but all commits skipped, just to see if the contributors are going to be skipped as well.

## Motivation and Context

related to #1351

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
