### PR TITLE
feat(config): search .cliff.toml as alternative config file name

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
-use crate::{DEFAULT_CONFIG, command, error};
+use crate::{CONFIG_CANDIDATES, command, error};
 
 /// Default initial tag.
 const DEFAULT_INITIAL_TAG: &str = "0.1.0";
@@ -497,24 +497,32 @@ impl Config {
         // cannot panic - see https://github.com/lunacookies/etcetera/issues/42
         let strategy = choose_base_strategy()
             .expect("cannot determine current OS's default strategy (layout)");
-        for supported_path in [
-            strategy.config_dir().join("git-cliff").join(DEFAULT_CONFIG),
-            // paths for backwards compatibility
-            #[cfg(target_os = "macos")]
-            strategy
-                .home_dir()
-                .to_path_buf()
-                .join("Library/Application Support/git-cliff")
-                .join(DEFAULT_CONFIG),
-        ]
-        .iter()
-        {
-            if supported_path.exists() {
+        let config_dir = strategy.config_dir();
+
+        let mut candidates: Vec<PathBuf> = CONFIG_CANDIDATES
+            .iter()
+            .map(|name| config_dir.join("git-cliff").join(name))
+            .collect();
+
+        // legacy macOS paths for backwards compatibility
+        #[cfg(target_os = "macos")]
+        for name in CONFIG_CANDIDATES {
+            candidates.push(
+                strategy
+                    .home_dir()
+                    .to_path_buf()
+                    .join("Library/Application Support/git-cliff")
+                    .join(name),
+            );
+        }
+
+        for path in &candidates {
+            if path.exists() {
                 #[allow(clippy::unnecessary_debug_formatting)]
                 {
-                    log::debug!("Using configuration file from: {supported_path:?}");
+                    log::debug!("Using configuration file from: {path:?}");
                 }
-                return Some(supported_path.clone());
+                return Some(path.clone());
             }
         }
         None
@@ -600,5 +608,12 @@ mod test {
         assert!(!Remote::new("", "test").is_set());
         assert!(!Remote::new("test", "").is_set());
         assert!(!Remote::new("", "").is_set());
+    }
+
+    #[test]
+    fn config_candidates_order() {
+        // cliff.toml must remain the primary (index 0) so existing setups are unaffected
+        assert_eq!(crate::CONFIG_CANDIDATES[0], crate::DEFAULT_CONFIG);
+        assert!(crate::CONFIG_CANDIDATES.contains(&".cliff.toml"));
     }
 }

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -46,6 +46,11 @@ pub mod template;
 
 /// Default configuration file.
 pub const DEFAULT_CONFIG: &str = "cliff.toml";
+/// Alternative configuration file names searched in order when the default is not found.
+///
+/// This allows users to use a dot-prefixed file (`.cliff.toml`) to keep the
+/// project root tidy, following a convention used by many other tools.
+pub const CONFIG_CANDIDATES: &[&str] = &[DEFAULT_CONFIG, ".cliff.toml"];
 /// Default output file.
 pub const DEFAULT_OUTPUT: &str = "CHANGELOG.md";
 /// Default ignore file.

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -25,7 +25,7 @@ use git_cliff_core::embed::{BuiltinConfig, EmbeddedConfig};
 use git_cliff_core::error::{Error, Result};
 use git_cliff_core::release::Release;
 use git_cliff_core::repo::{Repository, SubmoduleRange};
-use git_cliff_core::{DEFAULT_CONFIG, IGNORE_FILE};
+use git_cliff_core::{CONFIG_CANDIDATES, DEFAULT_CONFIG, IGNORE_FILE};
 use glob::Pattern;
 
 /// Checks for a new version on crates.io
@@ -570,8 +570,10 @@ pub fn run_with_changelog_modifier<'a>(
     } else if let Some(contents) = Config::read_from_manifest()? {
         contents.parse()?
     } else if let Some(discovered_path) = env::current_dir()?.ancestors().find_map(|dir| {
-        let path = dir.join(DEFAULT_CONFIG);
-        if path.is_file() { Some(path) } else { None }
+        CONFIG_CANDIDATES
+            .iter()
+            .map(|name| dir.join(name))
+            .find(|p| p.is_file())
     }) {
         log::info!(
             "Using configuration from parent directory: {}",


### PR DESCRIPTION
Closes #1446

## What this does

When git-cliff searches for a config file it now checks both `cliff.toml` and `.cliff.toml`, in that order. Users who keep their configs under dot-prefixed names (a pattern common with `.eslintrc`, `.rustfmt.toml`, `.prettierrc`, etc.) can do the same for git-cliff without any extra flags.

## How it works

A new `CONFIG_CANDIDATES` constant in `git-cliff-core` lists the names to try:

```rust
pub const CONFIG_CANDIDATES: &[&str] = &[DEFAULT_CONFIG, ".cliff.toml"];
```

All three lookup sites use this slice:

- **`Config::retrieve_config_path`** — user-level config directory (and legacy macOS paths)
- **parent-directory walk** in `run_with_changelog_modifier` — the ancestor search that finds a `cliff.toml` in a parent directory

`cliff.toml` is still index 0, so it always wins over `.cliff.toml` when both exist. `DEFAULT_CONFIG` and the `--config` default are unchanged, so existing setups are completely unaffected.

## Testing

Added a unit test to `config::test` that asserts `cliff.toml` is first in `CONFIG_CANDIDATES` and that `.cliff.toml` is present.