### PR TITLE
feat(git): add configurable commit processing order

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -657,7 +657,8 @@ mod test {
     use super::*;
     use crate::commit::{Commit, Signature};
     use crate::config::{
-        Bump, ChangelogConfig, CommitParser, LinkParser, Remote, RemoteConfig, TextProcessor,
+        Bump, ChangelogConfig, CommitParser, GitConfig, LinkParser, Remote, RemoteConfig,
+        TextProcessor,
     };
 
     fn get_test_data() -> (Config, Vec<Release<'static>>) {

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::Config;
 use crate::error::Result;
-use crate::process::process_commit_list;
+use crate::process::CommitProcessor;
 use crate::release::{Release, Releases};
 #[cfg(feature = "azure_devops")]
 use crate::remote::azure_devops::AzureDevOpsClient;
@@ -97,9 +97,9 @@ impl<'a> Changelog<'a> {
 
         let mut summary = Summary::default();
         for release in &mut self.releases {
-            process_commit_list(&mut release.commits, &self.config.git, &mut summary)?;
+            CommitProcessor::new(&self.config.git, &mut summary).run(&mut release.commits)?;
             for submodule_commits in release.submodule_commits.values_mut() {
-                process_commit_list(submodule_commits, &self.config.git, &mut summary)?;
+                CommitProcessor::new(&self.config.git, &mut summary).run(submodule_commits)?;
             }
         }
 

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::commit::Commit;
-use crate::config::{Config, GitConfig};
-use crate::error::{Error, Result};
+use crate::config::Config;
+use crate::error::Result;
+use crate::process::process_commit_list;
 use crate::release::{Release, Releases};
 #[cfg(feature = "azure_devops")]
 use crate::remote::azure_devops::AzureDevOpsClient;
@@ -90,122 +90,6 @@ impl<'a> Changelog<'a> {
         Ok(())
     }
 
-    /// Processes a single commit and returns/logs the result.
-    fn process_commit(
-        commit: &Commit<'a>,
-        git_config: &GitConfig,
-        summary: &mut Summary,
-    ) -> Option<Commit<'a>> {
-        match commit.process(git_config) {
-            Ok(commit) => {
-                summary.record_ok();
-                Some(commit)
-            }
-            Err(e) => {
-                summary.record_err(&e);
-                let short_id = commit.id.chars().take(7).collect::<String>();
-                let summary = commit.message.lines().next().unwrap_or_default().trim();
-                log::trace!("{short_id} - {e} ({summary})");
-                None
-            }
-        }
-    }
-
-    /// Checks the commits and returns an error if any unconventional commits
-    /// are found.
-    fn check_conventional_commits(commits: &Vec<Commit<'a>>) -> Result<()> {
-        log::debug!("Verifying that all commits are conventional");
-        let mut unconventional_count = 0;
-        commits.iter().for_each(|commit| {
-            if commit.conv.is_none() {
-                log::error!(
-                    "Commit {id} is not conventional:\n{message}",
-                    id = &commit.id[..7],
-                    message = commit
-                        .message
-                        .lines()
-                        .map(|line| { format!("    | {}", line.trim()) })
-                        .collect::<Vec<String>>()
-                        .join("\n")
-                );
-                unconventional_count += 1;
-            }
-        });
-
-        if unconventional_count > 0 {
-            return Err(Error::UnconventionalCommitsError(unconventional_count));
-        }
-
-        Ok(())
-    }
-
-    /// Checks the commits and returns an error if any commits are not matched
-    /// by any commit parser.
-    fn check_unmatched_commits(commits: &Vec<Commit<'a>>) -> Result<()> {
-        log::debug!("Verifying that no commits are unmatched by commit parsers");
-        let mut unmatched_count = 0;
-        commits.iter().for_each(|commit| {
-            let is_unmatched = commit.group.is_none();
-            if is_unmatched {
-                log::error!(
-                    "Commit {id} was not matched by any commit parser:\n{message}",
-                    id = &commit.id[..7],
-                    message = commit
-                        .message
-                        .lines()
-                        .map(|line| { format!("    | {}", line.trim()) })
-                        .collect::<Vec<String>>()
-                        .join("\n")
-                );
-                unmatched_count += 1;
-            }
-        });
-
-        if unmatched_count > 0 {
-            return Err(Error::UnmatchedCommitsError(unmatched_count));
-        }
-
-        Ok(())
-    }
-
-    fn process_commit_list(
-        commits: &mut Vec<Commit<'a>>,
-        git_config: &GitConfig,
-        summary: &mut Summary,
-    ) -> Result<()> {
-        let mut processed = Vec::new();
-        for commit in commits.iter() {
-            if let Some(commit) = Self::process_commit(commit, git_config, summary) {
-                if git_config.split_commits {
-                    for line in commit.message.lines() {
-                        let mut c = commit.clone();
-                        c.message = line.to_string();
-                        c.links.clear();
-                        if c.message.is_empty() {
-                            continue;
-                        }
-                        if let Some(c) = Self::process_commit(&c, git_config, summary) {
-                            processed.push(c);
-                        }
-                    }
-                } else {
-                    processed.push(commit);
-                }
-            }
-        }
-        *commits = processed;
-
-        if git_config.require_conventional {
-            Self::check_conventional_commits(commits)?;
-        }
-
-        if git_config.fail_on_unmatched_commit {
-            Self::check_unmatched_commits(commits)?;
-        }
-
-        Ok(())
-    }
-
     /// Processes the commits and omits the ones that doesn't match the
     /// criteria set by configuration file.
     fn process_commits(&mut self) -> Result<()> {
@@ -213,9 +97,9 @@ impl<'a> Changelog<'a> {
 
         let mut summary = Summary::default();
         for release in &mut self.releases {
-            Self::process_commit_list(&mut release.commits, &self.config.git, &mut summary)?;
+            process_commit_list(&mut release.commits, &self.config.git, &mut summary)?;
             for submodule_commits in release.submodule_commits.values_mut() {
-                Self::process_commit_list(submodule_commits, &self.config.git, &mut summary)?;
+                process_commit_list(submodule_commits, &self.config.git, &mut summary)?;
             }
         }
 
@@ -819,6 +703,7 @@ mod test {
                 output: None,
             },
             git: GitConfig {
+                processing_order: None,
                 conventional_commits: true,
                 require_conventional: false,
                 filter_unconventional: false,

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -655,7 +655,7 @@ mod test {
     use regex::Regex;
 
     use super::*;
-    use crate::commit::Signature;
+    use crate::commit::{Commit, Signature};
     use crate::config::{
         Bump, ChangelogConfig, CommitParser, LinkParser, Remote, RemoteConfig, TextProcessor,
     };

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -713,7 +713,7 @@ mod test {
         process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].group.as_deref(), Some("fix"));
-        assert_eq!(commits[0].message, "restore build");
+        assert_eq!(commits[0].message, "fix(ci): restore build");
     }
 
     #[test]

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -621,7 +621,7 @@ mod test {
     }
 
     #[test]
-    fn process_commit_list_keeps_legacy_behavior_when_order_is_unset() {
+    fn process_commit_list_keeps_legacy_behavior_when_order_is_unset() -> Result<()> {
         let mut commits = vec![Commit::new(
             String::from("123123"),
             String::from("chore(ci): update runner\nfix(ci): restore build"),
@@ -660,12 +660,14 @@ mod test {
             ..Default::default()
         };
 
-        process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
+        process_commit_list(&mut commits, &cfg, &mut Summary::default())?;
         assert!(commits.is_empty());
+
+        Ok(())
     }
 
     #[test]
-    fn process_commit_list_supports_ordered_split_before_parsing() {
+    fn process_commit_list_supports_ordered_split_before_parsing() -> Result<()> {
         let mut commits = vec![Commit::new(
             String::from("123123"),
             String::from("chore(ci): update runner\nfix(ci): restore build"),
@@ -710,10 +712,12 @@ mod test {
             ..Default::default()
         };
 
-        process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
+        process_commit_list(&mut commits, &cfg, &mut Summary::default())?;
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].group.as_deref(), Some("fix"));
         assert_eq!(commits[0].message, "fix(ci): restore build");
+
+        Ok(())
     }
 
     #[test]

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -522,9 +522,6 @@ pub(crate) fn commits_to_conventional_commits<'de, 'a, D: Deserializer<'de>>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::ProcessingStep;
-    use crate::process::process_commit_list;
-    use crate::summary::Summary;
 
     #[test]
     fn conventional_commit() -> Result<()> {
@@ -618,106 +615,6 @@ mod test {
             let commit = commit.process(&cfg).expect("commit should process");
             assert_eq!(&commit.footers().collect::<Vec<_>>(), footers);
         }
-    }
-
-    #[test]
-    fn process_commit_list_keeps_legacy_behavior_when_order_is_unset() -> Result<()> {
-        let mut commits = vec![Commit::new(
-            String::from("123123"),
-            String::from("chore(ci): update runner\nfix(ci): restore build"),
-        )];
-        let cfg = crate::config::GitConfig {
-            processing_order: None,
-            conventional_commits: true,
-            split_commits: true,
-            filter_commits: true,
-            commit_parsers: vec![
-                CommitParser {
-                    sha: None,
-                    message: Regex::new("^chore").ok(),
-                    body: None,
-                    footer: None,
-                    group: None,
-                    default_scope: None,
-                    scope: None,
-                    skip: Some(true),
-                    field: None,
-                    pattern: None,
-                },
-                CommitParser {
-                    sha: None,
-                    message: Regex::new("^fix").ok(),
-                    body: None,
-                    footer: None,
-                    group: Some(String::from("fix")),
-                    default_scope: None,
-                    scope: None,
-                    skip: None,
-                    field: None,
-                    pattern: None,
-                },
-            ],
-            ..Default::default()
-        };
-
-        process_commit_list(&mut commits, &cfg, &mut Summary::default())?;
-        assert!(commits.is_empty());
-
-        Ok(())
-    }
-
-    #[test]
-    fn process_commit_list_supports_ordered_split_before_parsing() -> Result<()> {
-        let mut commits = vec![Commit::new(
-            String::from("123123"),
-            String::from("chore(ci): update runner\nfix(ci): restore build"),
-        )];
-        let cfg = crate::config::GitConfig {
-            processing_order: Some(vec![
-                ProcessingStep::CommitPreprocessors,
-                ProcessingStep::SplitCommits,
-                ProcessingStep::ConventionalCommits,
-                ProcessingStep::CommitParsers,
-                ProcessingStep::LinkParsers,
-            ]),
-            conventional_commits: true,
-            split_commits: true,
-            filter_commits: true,
-            commit_parsers: vec![
-                CommitParser {
-                    sha: None,
-                    message: Regex::new("^chore").ok(),
-                    body: None,
-                    footer: None,
-                    group: None,
-                    default_scope: None,
-                    scope: None,
-                    skip: Some(true),
-                    field: None,
-                    pattern: None,
-                },
-                CommitParser {
-                    sha: None,
-                    message: Regex::new("^fix").ok(),
-                    body: None,
-                    footer: None,
-                    group: Some(String::from("fix")),
-                    default_scope: None,
-                    scope: None,
-                    skip: None,
-                    field: None,
-                    pattern: None,
-                },
-            ],
-            ..Default::default()
-        };
-
-        process_commit_list(&mut commits, &cfg, &mut Summary::default())?;
-        assert_eq!(commits.len(), 1);
-        assert_eq!(commits[0].group.as_deref(), Some("fix"));
-        assert_eq!(commits[0].message, "fix(ci): restore build");
-
-        Ok(())
     }
 
     #[test]

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -522,6 +522,10 @@ pub(crate) fn commits_to_conventional_commits<'de, 'a, D: Deserializer<'de>>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::config::ProcessingStep;
+    use crate::process::process_commit_list;
+    use crate::summary::Summary;
+
     #[test]
     fn conventional_commit() -> Result<()> {
         let test_cases = vec![
@@ -614,6 +618,102 @@ mod test {
             let commit = commit.process(&cfg).expect("commit should process");
             assert_eq!(&commit.footers().collect::<Vec<_>>(), footers);
         }
+    }
+
+    #[test]
+    fn process_commit_list_keeps_legacy_behavior_when_order_is_unset() {
+        let mut commits = vec![Commit::new(
+            String::from("123123"),
+            String::from("chore(ci): update runner\nfix(ci): restore build"),
+        )];
+        let cfg = crate::config::GitConfig {
+            processing_order: None,
+            conventional_commits: true,
+            split_commits: true,
+            filter_commits: true,
+            commit_parsers: vec![
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^chore").ok(),
+                    body: None,
+                    footer: None,
+                    group: None,
+                    default_scope: None,
+                    scope: None,
+                    skip: Some(true),
+                    field: None,
+                    pattern: None,
+                },
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^fix").ok(),
+                    body: None,
+                    footer: None,
+                    group: Some(String::from("fix")),
+                    default_scope: None,
+                    scope: None,
+                    skip: None,
+                    field: None,
+                    pattern: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
+        assert!(commits.is_empty());
+    }
+
+    #[test]
+    fn process_commit_list_supports_ordered_split_before_parsing() {
+        let mut commits = vec![Commit::new(
+            String::from("123123"),
+            String::from("chore(ci): update runner\nfix(ci): restore build"),
+        )];
+        let cfg = crate::config::GitConfig {
+            processing_order: Some(vec![
+                ProcessingStep::CommitPreprocessors,
+                ProcessingStep::SplitCommits,
+                ProcessingStep::ConventionalCommits,
+                ProcessingStep::CommitParsers,
+                ProcessingStep::LinkParsers,
+            ]),
+            conventional_commits: true,
+            split_commits: true,
+            filter_commits: true,
+            commit_parsers: vec![
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^chore").ok(),
+                    body: None,
+                    footer: None,
+                    group: None,
+                    default_scope: None,
+                    scope: None,
+                    skip: Some(true),
+                    field: None,
+                    pattern: None,
+                },
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^fix").ok(),
+                    body: None,
+                    footer: None,
+                    group: Some(String::from("fix")),
+                    default_scope: None,
+                    scope: None,
+                    skip: None,
+                    field: None,
+                    pattern: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        process_commit_list(&mut commits, &cfg, &mut Summary::default()).unwrap();
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].group.as_deref(), Some("fix"));
+        assert_eq!(commits[0].message, "restore build");
     }
 
     #[test]

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -85,6 +85,11 @@ pub struct ChangelogConfig {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct GitConfig {
+    /// Optional processing order for commit transformation steps.
+    ///
+    /// If unset, the legacy processing behavior is preserved for backwards
+    /// compatibility.
+    pub processing_order: Option<Vec<ProcessingStep>>,
     /// Parse commits according to the conventional commits specification.
     pub conventional_commits: bool,
     /// Require all commits to be conventional.
@@ -142,6 +147,25 @@ pub struct GitConfig {
     /// Exclude unrelated commits with changes at the specified paths.
     #[serde(with = "serde_pattern", default)]
     pub exclude_paths: Vec<Pattern>,
+}
+
+/// Processing steps for commits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessingStep {
+    /// An array of regex based parsers to modify commit messages prior to
+    /// further processing.
+    CommitPreprocessors,
+    /// Split commits on newlines, treating each line as an individual commit.
+    SplitCommits,
+    /// Parse commits according to the conventional commits specification.
+    ConventionalCommits,
+    /// An array of regex based parsers for extracting data from the commit
+    /// message.
+    CommitParsers,
+    /// An array of regex based parsers to extract links from the commit
+    /// message and add them to the commit's context.
+    LinkParsers,
 }
 
 /// Serialize and deserialize implementation for [`glob::Pattern`].

--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -26,6 +26,8 @@ pub mod contributor;
 pub mod embed;
 /// Error handling.
 pub mod error;
+/// Commit processing pipeline.
+pub mod process;
 /// Common release type.
 pub mod release;
 /// Remote handler.

--- a/git-cliff-core/src/process.rs
+++ b/git-cliff-core/src/process.rs
@@ -1,0 +1,267 @@
+use crate::commit::Commit;
+use crate::config::{GitConfig, ProcessingStep};
+use crate::error::{Error as AppError, Result};
+use crate::summary::Summary;
+
+/// Processes commits using either legacy behavior or a configured processing order.
+pub fn process_commit_list<'a>(
+    commits: &mut Vec<Commit<'a>>,
+    git_config: &GitConfig,
+    summary: &mut Summary,
+) -> Result<()> {
+    CommitProcessor::new(git_config, summary).run(commits)
+}
+
+/// Stateful commit-processing pipeline.
+pub struct CommitProcessor<'cfg, 'sum> {
+    config: &'cfg GitConfig,
+    summary: &'sum mut Summary,
+}
+
+impl<'cfg, 'sum> CommitProcessor<'cfg, 'sum> {
+    /// Creates a processor bound to config and summary output.
+    #[must_use]
+    pub fn new(config: &'cfg GitConfig, summary: &'sum mut Summary) -> Self {
+        Self { config, summary }
+    }
+
+    /// Runs commit processing and final validation checks.
+    pub fn run<'a>(&mut self, commits: &mut Vec<Commit<'a>>) -> Result<()> {
+        if let Some(order) = &self.config.processing_order {
+            self.run_with_order(commits, order);
+        } else {
+            self.run_legacy(commits);
+        }
+
+        if self.config.require_conventional {
+            self.check_conventional_commits(commits)?;
+        }
+        if self.config.fail_on_unmatched_commit {
+            self.check_unmatched_commits(commits)?;
+        }
+
+        Ok(())
+    }
+
+    /// Applies commit processing steps in the configured linear order.
+    fn run_with_order<'a>(&mut self, commits: &mut Vec<Commit<'a>>, order: &[ProcessingStep]) {
+        for step in order {
+            match step {
+                ProcessingStep::CommitPreprocessors => self.apply_commit_preprocessors(commits),
+                ProcessingStep::SplitCommits => self.apply_split_commits(commits),
+                ProcessingStep::ConventionalCommits => self.apply_conventional_commits(commits),
+                ProcessingStep::CommitParsers => self.apply_commit_parsers(commits),
+                ProcessingStep::LinkParsers => self.apply_link_parsers(commits),
+            }
+        }
+    }
+
+    /// Preserves the historical non-linear processing flow for compatibility.
+    fn run_legacy<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            if let Some(commit) = self.process_single_commit(commit) {
+                if self.config.split_commits {
+                    for line in commit.message.lines() {
+                        let mut split_commit = commit.clone();
+                        split_commit.message = line.to_string();
+                        split_commit.links.clear();
+                        if split_commit.message.is_empty() {
+                            continue;
+                        }
+                        if let Some(split_commit) = self.process_single_commit(&split_commit) {
+                            processed.push(split_commit);
+                        }
+                    }
+                } else {
+                    processed.push(commit);
+                }
+            }
+        }
+        *commits = processed;
+    }
+
+    /// Applies commit preprocessors to all commits.
+    fn apply_commit_preprocessors<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            match commit.clone().preprocess(&self.config.commit_preprocessors) {
+                Ok(commit) => {
+                    self.summary.record_ok();
+                    processed.push(commit);
+                }
+                Err(error) => {
+                    self.summary.record_err(&error);
+                    self.on_processing_error(commit, &error);
+                }
+            }
+        }
+        *commits = processed;
+    }
+
+    /// Splits commit messages by line when `split_commits` is enabled.
+    fn apply_split_commits<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        if !self.config.split_commits {
+            return;
+        }
+        let mut split_commits = Vec::new();
+        for commit in commits.iter() {
+            for line in commit.message.lines() {
+                if line.is_empty() {
+                    continue;
+                }
+                let mut split_commit = commit.clone();
+                split_commit.message = line.to_string();
+                split_commit.links.clear();
+                split_commits.push(split_commit);
+            }
+        }
+        *commits = split_commits;
+    }
+
+    /// Parses commits as conventional according to current config rules.
+    fn apply_conventional_commits<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            if !self.config.conventional_commits {
+                self.summary.record_ok();
+                processed.push(commit.clone());
+                continue;
+            }
+
+            if !self.config.require_conventional &&
+                self.config.filter_unconventional &&
+                !self.config.split_commits
+            {
+                match commit.clone().into_conventional() {
+                    Ok(commit) => {
+                        self.summary.record_ok();
+                        processed.push(commit);
+                    }
+                    Err(error) => {
+                        self.summary.record_err(&error);
+                        self.on_processing_error(commit, &error);
+                    }
+                }
+            } else {
+                match commit.clone().into_conventional() {
+                    Ok(commit) => {
+                        self.summary.record_ok();
+                        processed.push(commit);
+                    }
+                    Err(_) => {
+                        self.summary.record_ok();
+                        processed.push(commit.clone());
+                    }
+                }
+            }
+        }
+        *commits = processed;
+    }
+
+    /// Applies commit parsers for grouping/filtering.
+    fn apply_commit_parsers<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            match commit.clone().parse(
+                &self.config.commit_parsers,
+                self.config.protect_breaking_commits,
+                self.config.filter_commits,
+            ) {
+                Ok(commit) => {
+                    self.summary.record_ok();
+                    processed.push(commit);
+                }
+                Err(error) => {
+                    self.summary.record_err(&error);
+                    self.on_processing_error(commit, &error);
+                }
+            }
+        }
+        *commits = processed;
+    }
+
+    /// Applies link parsers without filtering commits.
+    fn apply_link_parsers<'a>(&mut self, commits: &mut Vec<Commit<'a>>) {
+        let mut processed = Vec::new();
+        for commit in commits.iter() {
+            processed.push(commit.clone().parse_links(&self.config.link_parsers));
+        }
+        *commits = processed;
+    }
+
+    /// Processes one commit with the legacy single-pass pipeline.
+    fn process_single_commit<'a>(&mut self, commit: &Commit<'a>) -> Option<Commit<'a>> {
+        match commit.process(self.config) {
+            Ok(commit) => {
+                self.summary.record_ok();
+                Some(commit)
+            }
+            Err(error) => {
+                self.summary.record_err(&error);
+                self.on_processing_error(commit, &error);
+                None
+            }
+        }
+    }
+
+    /// Validates that all processed commits are conventional.
+    fn check_conventional_commits(&self, commits: &[Commit<'_>]) -> Result<()> {
+        log::debug!("Verifying that all commits are conventional");
+        let mut unconventional_count = 0;
+        commits.iter().for_each(|commit| {
+            if commit.conv.is_none() {
+                log::error!(
+                    "Commit {id} is not conventional:\n{message}",
+                    id = &commit.id[..7],
+                    message = commit
+                        .message
+                        .lines()
+                        .map(|line| { format!("    | {}", line.trim()) })
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                );
+                unconventional_count += 1;
+            }
+        });
+
+        if unconventional_count > 0 {
+            return Err(AppError::UnconventionalCommitsError(unconventional_count));
+        }
+        Ok(())
+    }
+
+    /// Validates that all processed commits matched at least one parser.
+    fn check_unmatched_commits(&self, commits: &[Commit<'_>]) -> Result<()> {
+        log::debug!("Verifying that no commits are unmatched by commit parsers");
+        let mut unmatched_count = 0;
+        commits.iter().for_each(|commit| {
+            let is_unmatched = commit.group.is_none();
+            if is_unmatched {
+                log::error!(
+                    "Commit {id} was not matched by any commit parser:\n{message}",
+                    id = &commit.id[..7],
+                    message = commit
+                        .message
+                        .lines()
+                        .map(|line| { format!("    | {}", line.trim()) })
+                        .collect::<Vec<String>>()
+                        .join("\n")
+                );
+                unmatched_count += 1;
+            }
+        });
+
+        if unmatched_count > 0 {
+            return Err(AppError::UnmatchedCommitsError(unmatched_count));
+        }
+        Ok(())
+    }
+
+    /// Emits a trace log entry for a commit-processing failure.
+    fn on_processing_error(&self, commit: &Commit<'_>, error: &AppError) {
+        let short_id = commit.id.chars().take(7).collect::<String>();
+        let summary = commit.message.lines().next().unwrap_or_default().trim();
+        log::trace!("{short_id} - {error} ({summary})");
+    }
+}

--- a/git-cliff-core/src/process.rs
+++ b/git-cliff-core/src/process.rs
@@ -3,15 +3,6 @@ use crate::config::{GitConfig, ProcessingStep};
 use crate::error::{Error as AppError, Result};
 use crate::summary::Summary;
 
-/// Processes commits using either legacy behavior or a configured processing order.
-pub fn process_commit_list<'a>(
-    commits: &mut Vec<Commit<'a>>,
-    git_config: &GitConfig,
-    summary: &mut Summary,
-) -> Result<()> {
-    CommitProcessor::new(git_config, summary).run(commits)
-}
-
 /// Stateful commit-processing pipeline.
 pub struct CommitProcessor<'cfg, 'sum> {
     config: &'cfg GitConfig,
@@ -263,5 +254,113 @@ impl<'cfg, 'sum> CommitProcessor<'cfg, 'sum> {
         let short_id = commit.id.chars().take(7).collect::<String>();
         let summary = commit.message.lines().next().unwrap_or_default().trim();
         log::trace!("{short_id} - {error} ({summary})");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use regex::Regex;
+
+    use super::*;
+    use crate::config::{CommitParser, ProcessingStep};
+
+    #[test]
+    fn list_keeps_legacy_behavior_when_order_is_unset() -> Result<()> {
+        let mut commits = vec![Commit::new(
+            String::from("123123"),
+            String::from("chore(ci): update runner\nfix(ci): restore build"),
+        )];
+        let cfg = crate::config::GitConfig {
+            processing_order: None,
+            conventional_commits: true,
+            split_commits: true,
+            filter_commits: true,
+            commit_parsers: vec![
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^chore").ok(),
+                    body: None,
+                    footer: None,
+                    group: None,
+                    default_scope: None,
+                    scope: None,
+                    skip: Some(true),
+                    field: None,
+                    pattern: None,
+                },
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^fix").ok(),
+                    body: None,
+                    footer: None,
+                    group: Some(String::from("fix")),
+                    default_scope: None,
+                    scope: None,
+                    skip: None,
+                    field: None,
+                    pattern: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        CommitProcessor::new(&cfg, &mut Summary::default()).run(&mut commits)?;
+        assert!(commits.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn list_supports_ordered_split_before_parsing() -> Result<()> {
+        let mut commits = vec![Commit::new(
+            String::from("123123"),
+            String::from("chore(ci): update runner\nfix(ci): restore build"),
+        )];
+        let cfg = crate::config::GitConfig {
+            processing_order: Some(vec![
+                ProcessingStep::CommitPreprocessors,
+                ProcessingStep::SplitCommits,
+                ProcessingStep::ConventionalCommits,
+                ProcessingStep::CommitParsers,
+                ProcessingStep::LinkParsers,
+            ]),
+            conventional_commits: true,
+            split_commits: true,
+            filter_commits: true,
+            commit_parsers: vec![
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^chore").ok(),
+                    body: None,
+                    footer: None,
+                    group: None,
+                    default_scope: None,
+                    scope: None,
+                    skip: Some(true),
+                    field: None,
+                    pattern: None,
+                },
+                CommitParser {
+                    sha: None,
+                    message: Regex::new("^fix").ok(),
+                    body: None,
+                    footer: None,
+                    group: Some(String::from("fix")),
+                    default_scope: None,
+                    scope: None,
+                    skip: None,
+                    field: None,
+                    pattern: None,
+                },
+            ],
+            ..Default::default()
+        };
+
+        CommitProcessor::new(&cfg, &mut Summary::default()).run(&mut commits)?;
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].group.as_deref(), Some("fix"));
+        assert_eq!(commits[0].message, "fix(ci): restore build");
+
+        Ok(())
     }
 }

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -39,6 +39,7 @@ fn generate_changelog() -> Result<()> {
         output: None,
     };
     let git_config = GitConfig {
+        processing_order: None,
         conventional_commits: true,
         require_conventional: false,
         filter_unconventional: true,

--- a/git-cliff/src/logger.rs
+++ b/git-cliff/src/logger.rs
@@ -1,11 +1,12 @@
 use std::io::Write;
-use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{env, fmt};
 
 use env_logger::Builder;
 use env_logger::fmt::{Color, Style, StyledValue};
 use git_cliff_core::error::{Error, Result};
+#[cfg(feature = "remote")]
+use std::sync::LazyLock;
 #[cfg(feature = "remote")]
 use indicatif::{ProgressBar, ProgressStyle};
 use log::Level;

--- a/git-cliff/src/logger.rs
+++ b/git-cliff/src/logger.rs
@@ -1,12 +1,12 @@
 use std::io::Write;
+#[cfg(feature = "remote")]
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{env, fmt};
 
 use env_logger::Builder;
 use env_logger::fmt::{Color, Style, StyledValue};
 use git_cliff_core::error::{Error, Result};
-#[cfg(feature = "remote")]
-use std::sync::LazyLock;
 #[cfg(feature = "remote")]
 use indicatif::{ProgressBar, ProgressStyle};
 use log::Level;

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -137,17 +137,16 @@ If this field is omitted, **git-cliff** uses the legacy processing flow for back
 
 Supported step names:
 
-- `commit_preprocessors`
-- `split_commits`
-- `conventional_commits`
-- `commit_parsers`
-- `link_parsers`
+- [`commit_preprocessors`](#commit_preprocessors)
+- [`split_commits`](#split_commits)
+- [`conventional_commits`](#conventional_commits)
+- [`commit_parsers`](#commit_parsers)
+- [`link_parsers`](#link_parsers)
 
 The default processing order is:
 
 ```toml
 [git]
-split_commits = true
 processing_order = [
     "commit_preprocessors",
     "split_commits",
@@ -159,7 +158,7 @@ processing_order = [
 
 :::info
 
-This is useful when you want e.g. `split_commits` to happen before parser-based filtering, so each split line is parsed independently.
+This is useful when you want e.g. [`split_commits`](#split_commits) to happen before parser-based filtering, so each split line is parsed independently.
 
 :::
 

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -31,6 +31,13 @@ link_parsers = [
     { pattern = "#(\\d+)", href = "https://github.com/orhun/git-cliff/issues/$1"},
     { pattern = "RFC(\\d+)", text = "ietf-rfc$1", href = "https://datatracker.ietf.org/doc/html/rfc$1"},
 ]
+processing_order = [
+    "commit_preprocessors",
+    "split_commits",
+    "conventional_commits",
+    "commit_parsers",
+    "link_parsers",
+]
 limit_commits = 42
 recurse_submodules = false
 include_paths = ["src/", "doc/**/*.md"]
@@ -121,6 +128,40 @@ With the configuration above, lines are parsed as conventional commits and uncon
 
 If `filter_unconventional = false`, every line will be processed as an unconventional commit, resulting in each line of
 a commit being treated as a changelog entry.
+
+### processing_order
+
+Defines a custom commit processing pipeline.
+
+If this field is omitted, **git-cliff** uses the legacy processing flow for backwards compatibility.
+
+Supported step names:
+
+- `commit_preprocessors`
+- `split_commits`
+- `conventional_commits`
+- `commit_parsers`
+- `link_parsers`
+
+The default processing order is:
+
+```toml
+[git]
+split_commits = true
+processing_order = [
+    "commit_preprocessors",
+    "split_commits",
+    "conventional_commits",
+    "commit_parsers",
+    "link_parsers",
+]
+```
+
+:::info
+
+This is useful when you want e.g. `split_commits` to happen before parser-based filtering, so each split line is parsed independently.
+
+:::
 
 ### commit_preprocessors
 


### PR DESCRIPTION
## Description

This change adds a configurable `processing_order` option for custom changelog generation pipelines:

```toml
[git]
processing_order = [
  "commit_preprocessors",
  "split_commits",
  "conventional_commits",
  "commit_parsers",
  "link_parsers",
]
```

## Motivation and Context

Useful for cases where users want to apply custom commit preprocessors before splitting commits,
or when they want to run link parsers before commit parsers.

This change provides more flexibility in how the changelog generation pipeline is structured.

Continuation of #1201
fixes #1201

## How Has This Been Tested?

not tested
inshallah the CI will pass

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
