### PR TITLE
feat(context): add per-commit statistics

### DIFF
--- a/.github/fixtures/test-commit-statistics/cliff.toml
+++ b/.github/fixtures/test-commit-statistics/cliff.toml
@@ -1,0 +1,20 @@
+[changelog]
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }} ({{ commit.statistics.files_changed }} files, +{{ commit.statistics.additions }}/-{{ commit.statistics.deletions }})\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[git]
+commit_parsers = [
+    { message = "^feat", group = "Features", default_scope = "app" },
+    { message = "^fix", group = "Bug Fixes", scope = "cli" },
+]

--- a/.github/fixtures/test-commit-statistics/commit.sh
+++ b/.github/fixtures/test-commit-statistics/commit.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+cat <<'EOF' > notes.txt
+base
+EOF
+GIT_COMMITTER_DATE="2022-04-06 01:25:08" git add notes.txt
+GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit -m "Initial commit"
+git tag v0.1.0
+
+cat <<'EOF' > notes.txt
+base
+alpha
+beta
+EOF
+GIT_COMMITTER_DATE="2022-04-06 01:25:09" git add notes.txt
+GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit -m "feat: expand notes"
+
+cat <<'EOF' > notes.txt
+base
+beta
+gamma
+EOF
+cat <<'EOF' > summary.txt
+todo
+done
+EOF
+GIT_COMMITTER_DATE="2022-04-06 01:25:10" git add notes.txt summary.txt
+GIT_COMMITTER_DATE="2022-04-06 01:25:10" git commit -m "fix: refresh notes"

--- a/.github/fixtures/test-commit-statistics/expected.md
+++ b/.github/fixtures/test-commit-statistics/expected.md
@@ -1,0 +1,12 @@
+## [unreleased]
+
+### Bug Fixes
+
+- Refresh notes (2 files, +3/-1)
+
+### Features
+
+- Expand notes (1 files, +2/-0)
+
+## [0.1.0] - 2022-04-06
+

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -133,6 +133,7 @@ jobs:
             command: --config-url "https://github.com/orhun/git-cliff/blob/main/.github/fixtures/new-fixture-template/cliff.toml?raw=true"
           - fixtures-name: test-topo-order-commits
           - fixtures-name: test-commit-range
+          - fixtures-name: test-commit-statistics
           - fixtures-name: test-commit-range-with-sort-commits
           - fixtures-name: test-commit-range-with-given-range
             command: a140cef^..a9d4050 --ignore-tags "."

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -78,6 +78,17 @@ impl<'a> From<CommitSignature<'a>> for Signature {
     }
 }
 
+/// Statistics about the changes in a single commit.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct CommitStatistics {
+    /// Total number of files changed in the commit.
+    pub files_changed: usize,
+    /// Total number of inserted lines in the commit.
+    pub additions: usize,
+    /// Total number of deleted lines in the commit.
+    pub deletions: usize,
+}
+
 /// Commit range (from..to)
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Range {
@@ -124,6 +135,9 @@ pub struct Commit<'a> {
     pub committer: Signature,
     /// Whether if the commit has two or more parents.
     pub merge_commit: bool,
+    /// Per-commit diff statistics exposed to the template context.
+    #[serde(default)]
+    pub statistics: CommitStatistics,
     /// Arbitrary data to be used with the `--from-context` CLI option.
     pub extra: Option<Value>,
     /// Remote metadata of the commit.
@@ -448,7 +462,7 @@ impl Serialize for Commit<'_> {
             }
         }
 
-        let mut commit = serializer.serialize_struct("Commit", 20)?;
+        let mut commit = serializer.serialize_struct("Commit", 21)?;
         commit.serialize_field("id", &self.id)?;
         if let Some(conv) = &self.conv {
             commit.serialize_field("message", conv.description())?;
@@ -482,6 +496,7 @@ impl Serialize for Commit<'_> {
         commit.serialize_field("committer", &self.committer)?;
         commit.serialize_field("conventional", &self.conv.is_some())?;
         commit.serialize_field("merge_commit", &self.merge_commit)?;
+        commit.serialize_field("statistics", &self.statistics)?;
         commit.serialize_field("extra", &self.extra)?;
         #[cfg(feature = "github")]
         commit.serialize_field("github", &self.github)?;

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -12,6 +12,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use url::Url;
 
+use crate::commit::CommitStatistics;
 use crate::config::Remote;
 use crate::error::{Error, Result};
 use crate::tag::Tag;
@@ -207,6 +208,30 @@ impl Repository {
             });
         }
         Ok(commits)
+    }
+
+    /// Returns diff statistics for a single commit.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the commit tree, parent tree, diff, or diff
+    /// statistics cannot be read.
+    pub fn commit_statistics(&self, commit: &Commit<'_>) -> Result<CommitStatistics> {
+        let current_tree = commit.tree()?;
+        let previous_tree = commit
+            .parent(0)
+            .ok()
+            .map(|parent| parent.tree())
+            .transpose()?;
+        let diff =
+            self.inner
+                .diff_tree_to_tree(previous_tree.as_ref(), Some(&current_tree), None)?;
+        let stats = diff.stats()?;
+        Ok(CommitStatistics {
+            files_changed: stats.files_changed(),
+            additions: stats.insertions(),
+            deletions: stats.deletions(),
+        })
     }
 
     /// Returns submodule repositories for a given commit range.

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -350,7 +350,8 @@ fn process_repository<'a>(
     let repository_path = repository.root_path()?.to_string_lossy().into_owned();
     for git_commit in commits.iter().rev() {
         let release = releases.last_mut().unwrap();
-        let commit = Commit::from(git_commit);
+        let mut commit = Commit::from(git_commit);
+        commit.statistics = repository.commit_statistics(git_commit)?;
         let commit_id = commit.id.clone();
         release.commits.push(commit);
         release.repository = Some(repository_path.clone());

--- a/website/docs/templating/context.md
+++ b/website/docs/templating/context.md
@@ -58,6 +58,11 @@ following context is generated to use for templating:
         "email": "user.email@example.com",
         "timestamp": 1660330071
       },
+      "statistics": {
+        "files_changed": 1,
+        "additions": 1,
+        "deletions": 0
+      },
       "raw_message": "<type>[scope]: <description>\n[body]\n[footer(s)]"
     }
   ],
@@ -179,6 +184,11 @@ If [`conventional_commits`](/docs/configuration/git#conventional_commits) is set
         "email": "user.email@example.com",
         "timestamp": 1660330071
       },
+      "statistics": {
+        "files_changed": 1,
+        "additions": 1,
+        "deletions": 0
+      },
       "raw_message": "(full commit message including description, footers, etc.)"
     }
   ],
@@ -213,6 +223,23 @@ If [`conventional_commits`](/docs/configuration/git#conventional_commits) is set
 See the [GitHub integration](/docs/integration/github) for the additional values you can use in the template.
 
 :::
+
+## Commit statistics
+
+Each commit contains a `statistics` object with diff metrics for that commit.
+The following fields are available:
+
+- `files_changed`: Total number of files changed in the commit.
+- `additions`: Total number of inserted lines in the commit.
+- `deletions`: Total number of deleted lines in the commit.
+
+You can use these fields in your templates like so:
+
+```jinja2
+{% for commit in commits %}
+- {{ commit.message }} ({{ commit.statistics.files_changed }} files, +{{ commit.statistics.additions }}, -{{ commit.statistics.deletions }})
+{% endfor %}
+```
 
 ## Release statistics
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adds per-commit diff statistics to the changelog template context.

Each commit now exposes:

- `commit.statistics.files_changed`
- `commit.statistics.additions`
- `commit.statistics.deletions`

The statistics are computed from the local git repository using the diff between the first parent tree and the current commit tree. For root commits, the diff is calculated from an empty tree to the commit tree.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #1288

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual verification was done with `target/debug/git-cliff` in a newly created local git repository containing two commits:

- root commit: 2 files changed, 2 additions, 0 deletions
- second commit: 3 files changed, 2 additions, 1 deletion

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
