### PR TITLE
fix(cd): publish musl wheels to PyPI by matching matrix.build.NAME

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -271,7 +271,7 @@ jobs:
           args: --release --sdist --out wheels
           sccache: "true"
       - name: Build Python wheels (musl)
-        if: matrix.build.PYPI_PUBLISH == true && endsWith(matrix.build.OS, 'musl')
+        if: matrix.build.PYPI_PUBLISH == true && endsWith(matrix.build.NAME, 'musl')
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           working-directory: pypi


### PR DESCRIPTION
## Description

The `Build Python wheels (musl)` step in `.github/workflows/cd.yml` gates on `endsWith(matrix.build.OS, 'musl')`, but every musl matrix entry has `OS: ubuntu-22.04`, so the condition never matches and no `musllinux_1_2`-tagged wheels are produced. The musl identifier lives in `matrix.build.NAME` (e.g. `linux-x64-musl`, `linux-x86-musl`, `linux-arm64-musl`), which is what the `Install dependencies` step at line 139 already keys on:

```yaml
if [[ "${{ matrix.build.NAME }}" = *"-musl" ]]; then
```

This change makes the wheels step use the same predicate.

## Motivation and Context

Closes #1267. Reporter pinpointed the wrong field; @orhun confirmed the fix on the issue ("I think we meant to use the `NAME` there instead of `OS`").

After this change, the `(musl)` step fires for the three matrix entries that should produce musllinux wheels:

| NAME              | TARGET                       | PYPI_PUBLISH |
| ----------------- | ---------------------------- | ------------ |
| linux-x64-musl    | x86_64-unknown-linux-musl    | true         |
| linux-x86-musl    | i686-unknown-linux-musl      | true         |
| linux-arm64-musl  | aarch64-unknown-linux-musl   | true         |

## How Has This Been Tested?

Workflow change only, so I parsed the matrix locally and verified that with the corrected predicate the `(musl)` step fires for exactly the three entries above, and not for the glibc/macOS/Windows ones. The actual wheel builds will be verified end-to-end on the next release that runs `cd.yml`.

One observation worth flagging: the `Build Python wheels (linux)` step at line 254 is gated on `startsWith(matrix.build.NAME, 'linux')`, which already fires for the musl entries too. With this fix the `(musl)` step also runs for those entries, so maturin runs twice for each musl target (once with `manylinux: auto` then once with `manylinux: musllinux_1_2`). The second run overwrites with the explicit musllinux_1_2 tag, so the published wheel is correct, but the first run is wasted CPU. If you'd prefer to skip it, the cleanest follow-up is `&& !endsWith(matrix.build.NAME, '-musl')` on the `(linux)` step's `if`. Happy to fold that into this PR or send it as a follow-up, whichever you prefer.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.