### PR TITLE
fix(statistics): ignore missing git objects

### DIFF
--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -19,7 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use args::{BumpOption, Opt, Sort, Strip};
 use clap::ValueEnum;
 use git_cliff_core::changelog::Changelog;
-use git_cliff_core::commit::{Commit, Range};
+use git_cliff_core::commit::{Commit, CommitStatistics, Range};
 use git_cliff_core::config::{CommitParser, Config};
 use git_cliff_core::embed::{BuiltinConfig, EmbeddedConfig};
 use git_cliff_core::error::{Error, Result};
@@ -353,7 +353,22 @@ fn process_repository<'a>(
     for git_commit in commits.iter().rev() {
         let release = releases.last_mut().unwrap();
         let mut commit = Commit::from(git_commit);
-        commit.statistics = repository.commit_statistics(git_commit)?;
+        commit.statistics = match repository.commit_statistics(git_commit) {
+            Ok(statistics) => statistics,
+            Err(err)
+                if matches!(
+                    &err,
+                    Error::GitError(git_err) if git_err.message().contains("object not found")
+                ) =>
+            {
+                tracing::warn!(
+                    "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                    commit.id,
+                );
+                CommitStatistics::default()
+            }
+            Err(err) => return Err(err),
+        };
         let commit_id = commit.id.clone();
         release.commits.push(commit);
         release.repository = Some(repository_path.clone());


### PR DESCRIPTION
## Description

We no longer fail when an Git object is failed to be read while processing the statistics.

## Motivation and Context

fixes #1521

## How Has This Been Tested?

Not tested, I hope it works

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
