### PR TITLE
fix(changelog): normalize prepend boundary spacing

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -640,8 +640,21 @@ impl<'a> Changelog<'a> {
         if let Some(header) = &self.config.changelog.header {
             changelog = changelog.replacen(header, "", 1);
         }
-        self.generate(out)?;
-        write!(out, "{changelog}")?;
+
+        let mut generated = Vec::new();
+        self.generate(&mut generated)?;
+        let generated = std::str::from_utf8(&generated)?;
+        let changelog = changelog.trim_start_matches(|c| c == '\n' || c == '\r');
+        if changelog.is_empty() {
+            write!(out, "{generated}")?;
+        } else {
+            let generated = generated.trim_end_matches(|c| c == '\n' || c == '\r');
+            if generated.is_empty() {
+                write!(out, "{changelog}")?;
+            } else {
+                write!(out, "{generated}\n\n{changelog}")?;
+            }
+        }
         Ok(())
     }
 
@@ -1350,6 +1363,25 @@ mod test {
             .replace("			", ""),
             str::from_utf8(&out).unwrap_or_default()
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_inserts_blank_line_before_existing_content() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = None;
+        config.changelog.body = String::from("## New Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        let mut out = Vec::new();
+        changelog.prepend(String::from("## Old Release"), &mut out)?;
+
+        let output = str::from_utf8(&out).unwrap_or_default();
+        assert!(output.contains("## New Release\n\n## Old Release"));
+        assert_eq!("## New Release\n\n## Old Release", output);
 
         Ok(())
     }


### PR DESCRIPTION
## Description

Normalize `--prepend` output so the newly generated changelog block and existing changelog content are separated by exactly one blank line.

The change is localized to `Changelog::prepend` and does not alter normal non-prepend changelog generation. A regression test was added for the case where existing changelog content starts immediately with no leading newline.

## Motivation and Context

When `--prepend` writes generated content directly before existing changelog content, the boundary can end up without a blank line, which can violate Markdown linting expectations.

Fixes #1524

## How Has This Been Tested?

- Added regression test:
  - `changelog_prepend_inserts_blank_line_before_existing_content`
- Ran:
  - `git diff --check`

Attempted to run the targeted Cargo test:

```bash
cargo test -p git-cliff-core changelog_prepend_inserts_blank_line_before_existing_content --no-default-features
```

The test could not complete in this environment because the system C compiler/linker is unavailable (`cc` not found). Retrying with Rust’s bundled `rust-lld` also failed because required system libraries such as `libc`, `libm`, and `libpthread` were unavailable.

`cargo fmt --check` reports pre-existing formatting diffs across unrelated files, so I left those untouched to keep this change localized.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`