### PR TITLE
fix(website): Link to correct release notes

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
         ],
       },
       announcementBar: {
-        content: `⛰️ <b><a target="_blank" href="https://git-cliff.org/blog/2.12.0">git-cliff v2.13.0</a> is now out!</b> 🥳️`,
+        content: `⛰️ <b><a target="_blank" href="https://git-cliff.org/blog/2.13.0">git-cliff v2.13.0</a> is now out!</b> 🥳️`,
         backgroundColor: "#243840",
         textColor: "#ffffff",
         isCloseable: true,


### PR DESCRIPTION


## Description

The banner pointed to the 2.12.0 release notes. I changed the URL to go to the new release notes.

## Motivation and Context
Wrong release note linked

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
