### PR TITLE
fix(changelog): preserve blank line between prepended section and existing content

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -640,7 +640,23 @@ impl<'a> Changelog<'a> {
         if let Some(header) = &self.config.changelog.header {
             changelog = changelog.replacen(header, "", 1);
         }
-        self.generate(out)?;
+        let mut generated = Vec::new();
+        self.generate(&mut generated)?;
+        let generated = std::str::from_utf8(&generated)?;
+        write!(out, "{generated}")?;
+        // Both the rendered output and the existing content are written
+        // through unchanged so templates keep full control over their own
+        // whitespace. Only when there is no newline at all at the boundary
+        // (the rendered output does not end with one and the existing
+        // changelog does not start with one) a blank line is inserted to
+        // keep the two sections from running into each other.
+        if !generated.is_empty() &&
+            !changelog.is_empty() &&
+            !generated.ends_with('\n') &&
+            !changelog.starts_with(['\n', '\r'])
+        {
+            write!(out, "\n\n")?;
+        }
         write!(out, "{changelog}")?;
         Ok(())
     }
@@ -1635,6 +1651,63 @@ chore(deps): fix broken deps
     -- total releases: 2 --
 "]]
         .assert_eq(str::from_utf8(&out).unwrap_or_default());
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_inserts_blank_line_before_existing_content() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = None;
+        config.changelog.body = String::from("## New Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        let mut out = Vec::new();
+        changelog.prepend(String::from("## Old Release"), &mut out)?;
+
+        assert_eq!(
+            "## New Release\n\n## Old Release",
+            str::from_utf8(&out).unwrap_or_default()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_handles_empty_existing_content() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = None;
+        config.changelog.body = String::from("## New Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        let mut out = Vec::new();
+        changelog.prepend(String::new(), &mut out)?;
+
+        assert_eq!("## New Release", str::from_utf8(&out).unwrap_or_default());
+
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_keeps_template_controlled_boundary() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = None;
+        config.changelog.body = String::from("## New Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        let mut out = Vec::new();
+        changelog.prepend(String::from("\n## Old Release"), &mut out)?;
+
+        assert_eq!(
+            "## New Release\n## Old Release",
+            str::from_utf8(&out).unwrap_or_default()
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

When `--prepend` is used, the boundary between the newly generated section and the existing changelog can end up with no blank line between them. This happens because the body template often ends without a trailing newline and the existing changelog has its leading newline stripped along with the header by `replacen(header, "", 1)`.

`prepend` now renders the generated content into a temporary buffer, trims trailing newlines from the new section and leading newlines from the existing content, then joins them with exactly one blank line. Empty inputs on either side are handled without introducing spurious newlines.

## Motivation and Context

Fixes #1524. The behaviour and approach follow the discussion on the previously self-withdrawn #1525, but the scope here stays strictly on the `--prepend` boundary as the original report describes; nothing else in changelog generation is touched.

## How Has This Been Tested?

Added two unit tests against `Changelog::prepend`:

- `changelog_prepend_inserts_blank_line_before_existing_content` covers the bug from #1524.
- `changelog_prepend_handles_empty_existing_content` guards against introducing trailing newlines when there is no existing changelog.

Ran:

```
cargo test -p git-cliff-core --no-default-features
cargo +nightly fmt --check
```

All 42 `git-cliff-core` unit tests pass. Pre-existing `clippy` warnings in unrelated code (`changelog.rs:451` / `changelog.rs:474`) are unchanged.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
