### PR TITLE
fix(core): keep remote template vars when integrations disabled

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -55,12 +55,20 @@ impl<'a> Changelog<'a> {
         Ok(Self {
             releases,
             header_template: match &config.changelog.header {
-                Some(header) => Some(Template::new("header", header.clone(), trim)?),
+                Some(header) => {
+                    let template = Template::new("header", header.clone(), trim)?;
+                    warn_disabled_remote_template_variables(&template);
+                    Some(template)
+                }
                 None => None,
             },
             body_template: get_body_template(&config, trim)?,
             footer_template: match &config.changelog.footer {
-                Some(footer) => Some(Template::new("footer", footer.clone(), trim)?),
+                Some(footer) => {
+                    let template = Template::new("footer", footer.clone(), trim)?;
+                    warn_disabled_remote_template_variables(&template);
+                    Some(template)
+                }
                 None => None,
             },
             config,
@@ -660,6 +668,7 @@ impl<'a> Changelog<'a> {
 
 fn get_body_template(config: &Config, trim: bool) -> Result<Template> {
     let template = Template::new("body", config.changelog.body.clone(), trim)?;
+    warn_disabled_remote_template_variables(&template);
     let deprecated_vars = [
         "commit.github",
         "commit.gitea",
@@ -674,6 +683,44 @@ fn get_body_template(config: &Config, trim: bool) -> Result<Template> {
         );
     }
     Ok(template)
+}
+
+fn warn_disabled_remote_template_variables(template: &Template) {
+    #[cfg(not(feature = "github"))]
+    if template.contains_variable(&["github"]) {
+        tracing::warn!(
+            "Template uses GitHub-related variables but the GitHub feature is not enabled. \
+             Remote metadata will be empty."
+        );
+    }
+    #[cfg(not(feature = "gitlab"))]
+    if template.contains_variable(&["gitlab"]) {
+        tracing::warn!(
+            "Template uses GitLab-related variables but the GitLab feature is not enabled. \
+             Remote metadata will be empty."
+        );
+    }
+    #[cfg(not(feature = "gitea"))]
+    if template.contains_variable(&["gitea"]) {
+        tracing::warn!(
+            "Template uses Gitea-related variables but the Gitea feature is not enabled. \
+             Remote metadata will be empty."
+        );
+    }
+    #[cfg(not(feature = "bitbucket"))]
+    if template.contains_variable(&["bitbucket"]) {
+        tracing::warn!(
+            "Template uses Bitbucket-related variables but the Bitbucket feature is not enabled. \
+             Remote metadata will be empty."
+        );
+    }
+    #[cfg(not(feature = "azure_devops"))]
+    if template.contains_variable(&["azure_devops"]) {
+        tracing::warn!(
+            "Template uses Azure DevOps-related variables but the Azure DevOps feature is not \
+             enabled. Remote metadata will be empty."
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1109,26 +1156,7 @@ mod test {
             ])]),
             statistics: None,
             bump_type: None,
-            #[cfg(feature = "github")]
-            github: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitlab")]
-            gitlab: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitea")]
-            gitea: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "bitbucket")]
-            bitbucket: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "azure_devops")]
-            azure_devops: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
+            ..Default::default()
         };
         let releases = vec![
             test_release.clone(),
@@ -1231,26 +1259,7 @@ mod test {
                 ]),
                 statistics: None,
                 bump_type: None,
-                #[cfg(feature = "github")]
-                github: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "gitlab")]
-                gitlab: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "gitea")]
-                gitea: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "bitbucket")]
-                bitbucket: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "azure_devops")]
-                azure_devops: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
+                ..Default::default()
             },
         ];
         (config, releases)

--- a/git-cliff-core/src/contributor.rs
+++ b/git-cliff-core/src/contributor.rs
@@ -17,6 +17,13 @@ pub struct RemoteContributor {
     pub is_first_time: bool,
 }
 
+/// Metadata of a remote release.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
+pub struct RemoteReleaseMetadata {
+    /// Contributors.
+    pub contributors: Vec<RemoteContributor>,
+}
+
 impl Hash for RemoteContributor {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.username.hash(state);

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -7,12 +7,13 @@ use serde_json::value::Value;
 
 use crate::commit::{Commit, Range, commits_to_conventional_commits};
 use crate::config::{Bump, BumpType};
+use crate::contributor::RemoteReleaseMetadata;
 use crate::error::Result;
 use crate::statistics::Statistics;
 #[cfg(feature = "remote")]
 use crate::{
     contributor::RemoteContributor,
-    remote::{RemoteCommit, RemotePullRequest, RemoteReleaseMetadata},
+    remote::{RemoteCommit, RemotePullRequest},
 };
 
 /// Representation of a release.
@@ -51,19 +52,14 @@ pub struct Release<'a> {
     #[serde(rename = "bump_type")]
     pub bump_type: Option<BumpType>,
     /// Contributors.
-    #[cfg(feature = "github")]
     pub github: RemoteReleaseMetadata,
     /// Contributors.
-    #[cfg(feature = "gitlab")]
     pub gitlab: RemoteReleaseMetadata,
     /// Contributors.
-    #[cfg(feature = "gitea")]
     pub gitea: RemoteReleaseMetadata,
     /// Contributors.
-    #[cfg(feature = "bitbucket")]
     pub bitbucket: RemoteReleaseMetadata,
     /// Contributors.
-    #[cfg(feature = "azure_devops")]
     #[serde(rename = "azure_devops")]
     pub azure_devops: RemoteReleaseMetadata,
 }
@@ -277,26 +273,7 @@ mod test {
                 submodule_commits: HashMap::new(),
                 statistics: None,
                 bump_type: None,
-                #[cfg(feature = "github")]
-                github: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "gitlab")]
-                gitlab: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "gitea")]
-                gitea: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "bitbucket")]
-                bitbucket: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
-                #[cfg(feature = "azure_devops")]
-                azure_devops: crate::remote::RemoteReleaseMetadata {
-                    contributors: vec![],
-                },
+                ..Default::default()
             }
         }
 

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -38,6 +38,8 @@ use crate::config::Remote;
 use crate::contributor::RemoteContributor;
 use crate::error::{Error, Result};
 
+pub use crate::contributor::RemoteReleaseMetadata;
+
 /// User agent for interacting with the GitHub API.
 ///
 /// This is needed since GitHub API does not accept empty user agent.
@@ -86,13 +88,6 @@ dyn_clone::clone_trait_object!(RemotePullRequest);
 
 /// Result of a remote metadata.
 pub type RemoteMetadata = (Vec<Box<dyn RemoteCommit>>, Vec<Box<dyn RemotePullRequest>>);
-
-/// Metadata of a remote release.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
-pub struct RemoteReleaseMetadata {
-    /// Contributors.
-    pub contributors: Vec<RemoteContributor>,
-}
 
 impl Remote {
     /// Creates a HTTP client for the remote.

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -279,26 +279,7 @@ mod test {
             submodule_commits: HashMap::new(),
             statistics: None,
             bump_type: None,
-            #[cfg(feature = "github")]
-            github: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitlab")]
-            gitlab: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitea")]
-            gitea: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "bitbucket")]
-            bitbucket: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "azure_devops")]
-            azure_devops: crate::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
+            ..Default::default()
         }
     }
 
@@ -354,6 +335,18 @@ mod test {
             ],)?
         );
         assert_eq!(vec![String::from("version"),], template.variables);
+        Ok(())
+    }
+
+    #[test]
+    fn render_template_with_disabled_github_feature() -> Result<()> {
+        let template = "{{ github.contributors | length }}";
+        let template = Template::new("test", template.to_string(), false)?;
+        let release = get_fake_release_data();
+        assert_eq!(
+            "0",
+            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[])?,
+        );
         Ok(())
     }
 

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -229,26 +229,7 @@ fn generate_changelog() -> Result<()> {
             submodule_commits: HashMap::new(),
             statistics: None,
             bump_type: None,
-            #[cfg(feature = "github")]
-            github: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitlab")]
-            gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitea")]
-            gitea: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "bitbucket")]
-            bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "azure_devops")]
-            azure_devops: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
+            ..Default::default()
         },
         Release {
             version: Some(String::from("v1.0.0")),
@@ -263,26 +244,7 @@ fn generate_changelog() -> Result<()> {
             submodule_commits: HashMap::new(),
             statistics: None,
             bump_type: None,
-            #[cfg(feature = "github")]
-            github: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitlab")]
-            gitlab: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "gitea")]
-            gitea: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "bitbucket")]
-            bitbucket: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
-            #[cfg(feature = "azure_devops")]
-            azure_devops: git_cliff_core::remote::RemoteReleaseMetadata {
-                contributors: vec![],
-            },
+            ..Default::default()
         },
     ];
 


### PR DESCRIPTION
## Summary

Fixes #659 by ensuring templates that reference remote variables (e.g. `github.contributors`) no longer fail when the corresponding integration feature is disabled.

- Move `RemoteReleaseMetadata` to always-available `contributor` module
- Always include empty remote metadata fields on `Release`
- Warn when a template uses remote variables without the matching feature enabled

## Problem

Running with `--no-default-features` and a GitHub-style template previously failed with:

```
Variable `github.contributors` not found in context while rendering 'template'
```

## Solution

Remote metadata fields are always present (default empty), and `warn_disabled_remote_template_variables` emits a helpful warning when templates reference disabled integrations.

## Test plan

- [x] `cargo test -p git-cliff-core --no-default-features`
- [x] Added `render_template_with_disabled_github_feature` unit test