### PR TITLE
fix(core): split commits before applying commit parsers

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -1530,6 +1530,8 @@ chore(deps): fix broken deps
 			#### other
 			- support unconventional commits
 			- this commit is preprocessed
+			- use footer
+			- footer text
 			- make awesome stuff look better
 
 			#### ui
@@ -1537,9 +1539,9 @@ chore(deps): fix broken deps
 
 			### Commit Statistics
 
-			- 18 commit(s) contributed to the release.
-			- 12 day(s) passed between the first and last commit.
-			- 17 commit(s) parsed as conventional.
+			- 20 commit(s) contributed to the release.
+			- 13 day(s) passed between the first and last commit.
+			- 19 commit(s) parsed as conventional.
 			- 1 linked issue(s) detected in commits.
 			  - [#3](https://github.com/3) (referenced 1 time(s))
 			-- total releases: 2 --

--- a/git-cliff-core/src/process.rs
+++ b/git-cliff-core/src/process.rs
@@ -3,6 +3,14 @@ use crate::config::{GitConfig, ProcessingStep};
 use crate::error::{Error as AppError, Result};
 use crate::summary::Summary;
 
+const DEFAULT_PROCESSING_ORDER: [ProcessingStep; 5] = [
+    ProcessingStep::CommitPreprocessors,
+    ProcessingStep::SplitCommits,
+    ProcessingStep::ConventionalCommits,
+    ProcessingStep::CommitParsers,
+    ProcessingStep::LinkParsers,
+];
+
 /// Stateful commit-processing pipeline.
 pub struct CommitProcessor<'cfg, 'sum> {
     config: &'cfg GitConfig,
@@ -20,6 +28,10 @@ impl<'cfg, 'sum> CommitProcessor<'cfg, 'sum> {
     pub fn run<'a>(&mut self, commits: &mut Vec<Commit<'a>>) -> Result<()> {
         if let Some(order) = &self.config.processing_order {
             self.run_with_order(commits, order);
+        } else if self.config.split_commits {
+            // Split lines before applying commit parsers so patterns like `^fix:`
+            // match individual lines instead of the full multiline message.
+            self.run_with_order(commits, &DEFAULT_PROCESSING_ORDER);
         } else {
             self.run_legacy(commits);
         }
@@ -265,7 +277,7 @@ mod test {
     use crate::config::{CommitParser, ProcessingStep};
 
     #[test]
-    fn list_keeps_legacy_behavior_when_order_is_unset() -> Result<()> {
+    fn split_commits_applies_parsers_per_line_when_order_is_unset() -> Result<()> {
         let mut commits = vec![Commit::new(
             String::from("123123"),
             String::from("chore(ci): update runner\nfix(ci): restore build"),
@@ -305,7 +317,44 @@ mod test {
         };
 
         CommitProcessor::new(&cfg, &mut Summary::default()).run(&mut commits)?;
-        assert!(commits.is_empty());
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].group.as_deref(), Some("fix"));
+        assert_eq!(commits[0].message, "fix(ci): restore build");
+
+        Ok(())
+    }
+
+    #[test]
+    fn split_commits_supports_line_start_commit_parser() -> Result<()> {
+        let mut commits = vec![Commit::new(
+            String::from("123123"),
+            String::from("Unconventional commit\n\nfix: first line of the commit body"),
+        )];
+        let cfg = crate::config::GitConfig {
+            processing_order: None,
+            conventional_commits: false,
+            filter_unconventional: false,
+            split_commits: true,
+            filter_commits: true,
+            commit_parsers: vec![CommitParser {
+                sha: None,
+                message: Regex::new("^fix:").ok(),
+                body: None,
+                footer: None,
+                group: Some(String::from("Fixed")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            }],
+            ..Default::default()
+        };
+
+        CommitProcessor::new(&cfg, &mut Summary::default()).run(&mut commits)?;
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].message, "fix: first line of the commit body");
+        assert_eq!(commits[0].group.as_deref(), Some("Fixed"));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes #1093.

When `split_commits` is enabled without an explicit `processing_order`, commit parsers were applied to the full multiline message before lines were split. Patterns anchored to the start of a line (e.g. `^fix:`) therefore failed on body lines.

This change routes `split_commits` through the ordered processing pipeline by default, splitting lines before commit parsers run.

## Test plan

- [x] Added regression test for `^fix:` matching split unconventional commit lines
- [x] Updated split-commits changelog fixture expectations
- [x] `cargo test -p git-cliff-core process::`
- [x] `cargo test -p git-cliff-core changelog_generator_split_commits`