### PR TITLE
fix(template): add trim_prefix filter for version tags

### DIFF
--- a/.github/fixtures/new-fixture-template/cliff.toml
+++ b/.github/fixtures/new-fixture-template/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-always-render-unreleased/cliff.toml
+++ b/.github/fixtures/test-always-render-unreleased/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-always-render/cliff.toml
+++ b/.github/fixtures/test-always-render/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-initial-tag-cli-arg/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag-cli-arg/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-initial-tag-default/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag-default/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-initial-tag/cliff.toml
+++ b/.github/fixtures/test-bump-initial-tag/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-unreleased-with-tag-message-arg/cliff.toml
+++ b/.github/fixtures/test-bump-unreleased-with-tag-message-arg/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
     {% if message %}
         {{ message }}
     {% endif %}\

--- a/.github/fixtures/test-bump-version-custom-minor/cliff.toml
+++ b/.github/fixtures/test-bump-version-custom-minor/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-version-keep-zerover/cliff.toml
+++ b/.github/fixtures/test-bump-version-keep-zerover/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-version-major/cliff.toml
+++ b/.github/fixtures/test-bump-version-major/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-version-minor/cliff.toml
+++ b/.github/fixtures/test-bump-version-minor/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-version-patch/cliff.toml
+++ b/.github/fixtures/test-bump-version-patch/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bump-version/cliff.toml
+++ b/.github/fixtures/test-bump-version/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bumped-version-no-increment/cliff.toml
+++ b/.github/fixtures/test-bumped-version-no-increment/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-bumped-version/cliff.toml
+++ b/.github/fixtures/test-bumped-version/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-cli-arg-ignore-tags/cliff.toml
+++ b/.github/fixtures/test-cli-arg-ignore-tags/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-cli-arg-skip-tags/cliff.toml
+++ b/.github/fixtures/test-cli-arg-skip-tags/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-commit-footers/cliff.toml
+++ b/.github/fixtures/test-commit-footers/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-commit-preprocessors/cliff.toml
+++ b/.github/fixtures/test-commit-preprocessors/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-commit-range-with-given-range/cliff.toml
+++ b/.github/fixtures/test-commit-range-with-given-range/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}

--- a/.github/fixtures/test-commit-range-with-sort-commits/cliff.toml
+++ b/.github/fixtures/test-commit-range-with-sort-commits/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}

--- a/.github/fixtures/test-commit-range/cliff.toml
+++ b/.github/fixtures/test-commit-range/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}

--- a/.github/fixtures/test-commit-statistics/cliff.toml
+++ b/.github/fixtures/test-commit-statistics/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-configure-from-cargo-toml/Cargo.toml
+++ b/.github/fixtures/test-configure-from-cargo-toml/Cargo.toml
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-custom-scope/cliff.toml
+++ b/.github/fixtures/test-custom-scope/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-date-order/cliff.toml
+++ b/.github/fixtures/test-date-order/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-fail-on-unmatched-commit/cliff.toml
+++ b/.github/fixtures/test-fail-on-unmatched-commit/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-footer-filter/cliff.toml
+++ b/.github/fixtures/test-footer-filter/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-footer-template/cliff.toml
+++ b/.github/fixtures/test-footer-template/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-from-context/cliff.toml
+++ b/.github/fixtures/test-from-context/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}{% if extra.note %} - {{ extra.note }}{% endif %}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}{% if extra.note %} - {{ extra.note }}{% endif %}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-header-template/cliff.toml
+++ b/.github/fixtures/test-header-template/cliff.toml
@@ -16,7 +16,7 @@ header = """
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}]
+    ## [{{ version | trim_prefix(pat="v") }}]
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-ignore-tags/cliff.toml
+++ b/.github/fixtures/test-ignore-tags/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-include-path-config/cliff.toml
+++ b/.github/fixtures/test-include-path-config/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-include-path-env-var-github/cliff.toml
+++ b/.github/fixtures/test-include-path-env-var-github/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-include-path-env-var/cliff.toml
+++ b/.github/fixtures/test-include-path-env-var/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-include-path-repeated-flag/cliff.toml
+++ b/.github/fixtures/test-include-path-repeated-flag/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-include-path-space-separated/cliff.toml
+++ b/.github/fixtures/test-include-path-space-separated/cliff.toml
@@ -1,7 +1,7 @@
 [changelog]
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-invert-ignore-tags/cliff.toml
+++ b/.github/fixtures/test-invert-ignore-tags/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-keep-a-changelog-links-current-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-current-arg/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-latest-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-latest-arg/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-no-tags/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-no-tags/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-one-tag-bump-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-one-tag-bump-arg/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-one-tag/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-one-tag/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-tag-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-tag-arg/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links-unreleased-arg/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links-unreleased-arg/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-keep-a-changelog-links/cliff.toml
+++ b/.github/fixtures/test-keep-a-changelog-links/cliff.toml
@@ -17,9 +17,9 @@ body = """
 {% if version %}\
     {% if previous %}\
       {% if previous.version %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% else %}\
-          ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+          ## [{{ version | trim_prefix(pat="v") }}](https://github.com/dummy/dummy/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
       {% endif %}\
     {% endif %}\
 {% else %}\

--- a/.github/fixtures/test-latest-with-one-tag/cliff.toml
+++ b/.github/fixtures/test-latest-with-one-tag/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-limit-commits/cliff.toml
+++ b/.github/fixtures/test-limit-commits/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-monorepo-include-path/cliff.toml
+++ b/.github/fixtures/test-monorepo-include-path/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-no-exec/cliff.toml
+++ b/.github/fixtures/test-no-exec/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-override-scope/cliff.toml
+++ b/.github/fixtures/test-override-scope/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/.github/fixtures/test-regex-json-array/cliff.toml
+++ b/.github/fixtures/test-regex-json-array/cliff.toml
@@ -10,7 +10,7 @@ repo = "git-cliff-readme-example-one-pr-one-commit"
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-regex-replace-parser/cliff.toml
+++ b/.github/fixtures/test-regex-replace-parser/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-release-statistics/cliff.toml
+++ b/.github/fixtures/test-release-statistics/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-require-conventional-skipped/cliff.toml
+++ b/.github/fixtures/test-require-conventional-skipped/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-skip-breaking-changes/cliff.toml
+++ b/.github/fixtures/test-skip-breaking-changes/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-skip-commits/cliff.toml
+++ b/.github/fixtures/test-skip-commits/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-skip-tags/cliff.toml
+++ b/.github/fixtures/test-skip-tags/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-split-commits/cliff.toml
+++ b/.github/fixtures/test-split-commits/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-submodules-include-path-config/cliff.toml
+++ b/.github/fixtures/test-submodules-include-path-config/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-submodules-include-path/cliff.toml
+++ b/.github/fixtures/test-submodules-include-path/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-submodules-range/cliff.toml
+++ b/.github/fixtures/test-submodules-range/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-submodules/cliff.toml
+++ b/.github/fixtures/test-submodules/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-tag-message/cliff.toml
+++ b/.github/fixtures/test-tag-message/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
     {% if message %}
         {{ message }}
     {% endif %}\

--- a/.github/fixtures/test-topo-order-arg/cliff.toml
+++ b/.github/fixtures/test-topo-order-arg/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-topo-order/cliff.toml
+++ b/.github/fixtures/test-topo-order/cliff.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-unchanged-tag-date/cliff.toml
+++ b/.github/fixtures/test-unchanged-tag-date/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/.github/fixtures/test-workdir-include-path/cliff.toml
+++ b/.github/fixtures/test-workdir-include-path/cliff.toml
@@ -3,7 +3,7 @@
 # https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -27,10 +27,10 @@ body = """
 
 {% if version %}\
     {% if previous.version %}\
-        ## [{{ version | trim_start_matches(pat="v") }}]\
+        ## [{{ version | trim_prefix(pat="v") }}]\
           ({{ self::remote_url() }}/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
     {% else %}\
-        ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+        ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
     {% endif %}\
 {% else %}\
     ## [unreleased]

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -7,7 +7,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/examples/azure-devops-keepachangelog.toml
+++ b/examples/azure-devops-keepachangelog.toml
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version -%}
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
     ## [Unreleased]
 {% endif -%}
@@ -40,7 +40,7 @@ footer = """
 {% for release in releases -%}
     {% if release.version -%}
         {% if release.previous.version -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: \
+            [{{ release.version | trim_prefix(pat="v") }}]: \
                 https://dev.azure.com/{{ remote.azure_devops.owner }}\
                     /_git/{{ remote.azure_devops.repo }}/branchCompare?baseVersion=GT{{ release.previous.version }}&targetVersion=GT{{ release.version }}
         {% endif -%}

--- a/examples/cocogitto.toml
+++ b/examples/cocogitto.toml
@@ -14,9 +14,9 @@ body = """
 ---
 {% if version %}\
     {% if previous.version %}\
-        ## [{{ version | trim_start_matches(pat="v") }}]($REPO/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+        ## [{{ version | trim_prefix(pat="v") }}]($REPO/compare/{{ previous.version }}..{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
     {% else %}\
-        ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+        ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
     {% endif %}\
 {% else %}\
     ## [unreleased]

--- a/examples/detailed.toml
+++ b/examples/detailed.toml
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/examples/github-keepachangelog.toml
+++ b/examples/github-keepachangelog.toml
@@ -19,7 +19,7 @@ body = """
 {%- endmacro -%}
 
 {% if version -%}
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
     ## [Unreleased]
 {% endif -%}
@@ -59,7 +59,7 @@ footer = """
 {% for release in releases -%}
     {% if release.version -%}
         {% if release.previous.version -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: \
+            [{{ release.version | trim_prefix(pat="v") }}]: \
                 {{ self::remote_url() }}/compare/{{ release.previous.version }}...{{ release.version }}
         {% endif -%}
     {% else -%}

--- a/examples/github.toml
+++ b/examples/github.toml
@@ -12,7 +12,7 @@
 body = """
 ## What's Changed
 
-{%- if version %} in {{ version | trim_start_matches(pat="v") }}{%- endif -%}
+{%- if version %} in {{ version | trim_prefix(pat="v") }}{%- endif -%}
 {% for commit in commits %}
   {% if commit.remote.pr_title -%}
     {%- set commit_message = commit.remote.pr_title -%}

--- a/examples/keepachangelog.toml
+++ b/examples/keepachangelog.toml
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version -%}
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_prefix(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else -%}
     ## [Unreleased]
 {% endif -%}
@@ -32,11 +32,11 @@ footer = """
 {% for release in releases -%}
     {% if release.version -%}
         {% if release.previous.version -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: \
+            [{{ release.version | trim_prefix(pat="v") }}]: \
                 https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
                     /compare/{{ release.previous.version }}..{{ release.version }}
         {% else -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: \
+            [{{ release.version | trim_prefix(pat="v") }}]: \
                 https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
                     /tree/{{ release.version }}
         {% endif -%}

--- a/examples/minimal.toml
+++ b/examples/minimal.toml
@@ -6,7 +6,7 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}\
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}\
 {% else %}\
     ## Unreleased\
 {% endif %}\

--- a/examples/scoped.toml
+++ b/examples/scoped.toml
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/examples/scopesorted.toml
+++ b/examples/scopesorted.toml
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/examples/statistics.toml
+++ b/examples/statistics.toml
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/examples/unconventional.toml
+++ b/examples/unconventional.toml
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.\n
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## Unreleased
 {% endif %}\

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -178,8 +178,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref()) ==
-                    Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref())
+                    == Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -210,10 +210,12 @@ impl<'a> Changelog<'a> {
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
         crate::set_progress_message!("Fetching GitHub metadata for the changelog");
-        if self.config.remote.github.is_custom ||
-            self.body_template
-                .contains_variable(github::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.github.is_custom
+            || self
+                .body_template
+                .contains_variable(github::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -255,10 +257,12 @@ impl<'a> Changelog<'a> {
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
         crate::set_progress_message!("Fetching GitLab metadata for the changelog");
-        if self.config.remote.gitlab.is_custom ||
-            self.body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitlab.is_custom
+            || self
+                .body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -312,10 +316,12 @@ impl<'a> Changelog<'a> {
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
         crate::set_progress_message!("Fetching Gitea metadata for the changelog");
-        if self.config.remote.gitea.is_custom ||
-            self.body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitea.is_custom
+            || self
+                .body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -360,10 +366,12 @@ impl<'a> Changelog<'a> {
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
         crate::set_progress_message!("Fetching Bitbucket metadata for the changelog");
-        if self.config.remote.bitbucket.is_custom ||
-            self.body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.bitbucket.is_custom
+            || self
+                .body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -406,10 +414,12 @@ impl<'a> Changelog<'a> {
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::azure_devops;
         crate::set_progress_message!("Fetching Azure DevOps metadata for the changelog");
-        if self.config.remote.azure_devops.is_custom ||
-            self.body_template
-                .contains_variable(azure_devops::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.azure_devops.is_custom
+            || self
+                .body_template
+                .contains_variable(azure_devops::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(azure_devops::TEMPLATE_VARIABLES))
         {
@@ -1089,24 +1099,29 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
-                Commit::new(
-                    String::from("sub0jkl12"),
-                    String::from("chore(app): submodule_one do nothing"),
-                ),
-                Commit::new(
-                    String::from("subqwerty"),
-                    String::from("chore: submodule_one <preprocess>"),
-                ),
-                Commit::new(
-                    String::from("subqwertz"),
-                    String::from("feat!: submodule_one support breaking commits"),
-                ),
-                Commit::new(
-                    String::from("subqwert0"),
-                    String::from("match(group): submodule_one support regex-replace for groups"),
-                ),
-            ])]),
+            submodule_commits: HashMap::from([(
+                String::from("submodule_one"),
+                vec![
+                    Commit::new(
+                        String::from("sub0jkl12"),
+                        String::from("chore(app): submodule_one do nothing"),
+                    ),
+                    Commit::new(
+                        String::from("subqwerty"),
+                        String::from("chore: submodule_one <preprocess>"),
+                    ),
+                    Commit::new(
+                        String::from("subqwertz"),
+                        String::from("feat!: submodule_one support breaking commits"),
+                    ),
+                    Commit::new(
+                        String::from("subqwert0"),
+                        String::from(
+                            "match(group): submodule_one support regex-replace for groups",
+                        ),
+                    ),
+                ],
+            )]),
             statistics: None,
             bump_type: None,
             #[cfg(feature = "github")]
@@ -1220,14 +1235,20 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (String::from("submodule_one"), vec![
-                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                    ]),
-                    (String::from("submodule_two"), vec![Commit::new(
-                        String::from("ab76ef"),
-                        String::from("sub_two bump"),
-                    )]),
+                    (
+                        String::from("submodule_one"),
+                        vec![
+                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                        ],
+                    ),
+                    (
+                        String::from("submodule_two"),
+                        vec![Commit::new(
+                            String::from("ab76ef"),
+                            String::from("sub_two bump"),
+                        )],
+                    ),
                 ]),
                 statistics: None,
                 bump_type: None,

--- a/git-cliff-core/src/command.rs
+++ b/git-cliff-core/src/command.rs
@@ -61,10 +61,11 @@ mod test {
     fn run_os_command() -> Result<()> {
         assert_eq!(
             "eroc-ffilc-tig",
-            run("echo $APP_NAME | rev", None, vec![(
-                "APP_NAME",
-                env!("CARGO_PKG_NAME")
-            )])?
+            run(
+                "echo $APP_NAME | rev",
+                None,
+                vec![("APP_NAME", env!("CARGO_PKG_NAME"))]
+            )?
             .trim()
         );
         assert_eq!(

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -302,8 +302,8 @@ impl Commit<'_> {
     /// and the commit is breaking, or the parser's `skip` field is None or
     /// `false`. Returns `true` otherwise.
     fn skip_commit(&self, parser: &CommitParser, protect_breaking: bool) -> bool {
-        parser.skip.unwrap_or(false) &&
-            !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
+        parser.skip.unwrap_or(false)
+            && !(self.conv.as_ref().is_some_and(ConventionalCommit::breaking) && protect_breaking)
     }
 
     /// Parses the commit using [`CommitParser`]s.

--- a/git-cliff-core/src/process.rs
+++ b/git-cliff-core/src/process.rs
@@ -120,9 +120,9 @@ impl<'cfg, 'sum> CommitProcessor<'cfg, 'sum> {
                 continue;
             }
 
-            if !self.config.require_conventional &&
-                self.config.filter_unconventional &&
-                !self.config.split_commits
+            if !self.config.require_conventional
+                && self.config.filter_unconventional
+                && !self.config.split_commits
             {
                 match commit.clone().into_conventional() {
                     Ok(commit) => {

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -306,22 +306,28 @@ mod test {
             ("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
             ("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
             ("2.0.0", "2.0.1", vec!["fix: something"]),
-            ("foo/1.0.0", "foo/1.1.0", vec![
-                "feat: add xyz",
-                "fix: fix xyz",
-            ]),
-            ("bar/1.0.0", "bar/2.0.0", vec![
-                "fix: add xyz",
-                "fix!: aaaaaa",
-            ]),
-            ("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
-                "fix: aaaaaa",
-            ]),
+            (
+                "foo/1.0.0",
+                "foo/1.1.0",
+                vec!["feat: add xyz", "fix: fix xyz"],
+            ),
+            (
+                "bar/1.0.0",
+                "bar/2.0.0",
+                vec!["fix: add xyz", "fix!: aaaaaa"],
+            ),
+            (
+                "zzz-123/test/1.0.0",
+                "zzz-123/test/1.0.1",
+                vec!["fix: aaaaaa"],
+            ),
             ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
             ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
-                "feat: nice",
-            ]),
+            (
+                "testing/v1.0.0-beta.1",
+                "testing/v1.0.0-beta.2",
+                vec!["feat: nice"],
+            ),
             ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
             (
                 "rocket/rocket-v4.0.0-rc.1",
@@ -486,10 +492,10 @@ mod test {
         assert_eq!("1.0.0", result.version);
         assert_eq!(None, result.bump_type);
 
-        let release = build_release("1.0.0", &[
-            "docs: update readme",
-            "feat: add a user-facing feature",
-        ]);
+        let release = build_release(
+            "1.0.0",
+            &["docs: update readme", "feat: add a user-facing feature"],
+        );
         let result = release.calculate_next_version_with_config(&Bump {
             no_increment_regex: Some(String::from("^docs$")),
             ..Default::default()

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -208,8 +208,8 @@ macro_rules! update_release_metadata {
                     {
                         let sha_short = Some(v.id().clone().chars().take(12).collect());
                         let pull_request = pull_requests.iter().find(|pr| {
-                            pr.merge_commit() == Some(v.id().clone()) ||
-                                pr.merge_commit() == sha_short
+                            pr.merge_commit() == Some(v.id().clone())
+                                || pr.merge_commit() == sha_short
                         });
                         commit.$remote.username = v.username();
                         commit.$remote.pr_number = pull_request.map(|v| v.number());
@@ -249,9 +249,9 @@ macro_rules! update_release_metadata {
                                 // If the current release is unreleased or we cannot
                                 // resolve the release commit timestamp, skip filtering
                                 // to avoid false positives.
-                                self.timestamp.is_none() ||
-                                    release_commit_timestamp.is_none() ||
-                                    commit.timestamp() < release_commit_timestamp
+                                self.timestamp.is_none()
+                                    || release_commit_timestamp.is_none()
+                                    || commit.timestamp() < release_commit_timestamp
                             })
                             .map(|v| v.username())
                             .any(|login| login == v.username);

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -325,8 +325,8 @@ impl Repository {
                 changed_files.iter().any(|path| {
                     include_pattern
                         .iter()
-                        .any(|pattern| pattern.matches_path(path)) &&
-                        !exclude_pattern
+                        .any(|pattern| pattern.matches_path(path))
+                        && !exclude_pattern
                             .iter()
                             .any(|pattern| pattern.matches_path(path))
                 })
@@ -508,8 +508,8 @@ impl Repository {
     fn should_include_tag(&self, head_commit: &Commit, tag_commit: &Commit) -> Result<bool> {
         Ok(self
             .inner
-            .graph_descendant_of(head_commit.id(), tag_commit.id())? ||
-            head_commit.id() == tag_commit.id())
+            .graph_descendant_of(head_commit.id(), tag_commit.id())?
+            || head_commit.id() == tag_commit.id())
     }
 
     /// Parses and returns a commit-tag map.
@@ -536,10 +536,13 @@ impl Repository {
                     continue;
                 }
 
-                tags.push((commit, Tag {
-                    name,
-                    message: None,
-                }));
+                tags.push((
+                    commit,
+                    Tag {
+                        name,
+                        message: None,
+                    },
+                ));
             } else if let Some(tag) = obj.as_tag() {
                 if let Some(commit) = tag
                     .target()
@@ -549,12 +552,15 @@ impl Repository {
                     if use_branch_tags && !self.should_include_tag(&head_commit, &commit)? {
                         continue;
                     }
-                    tags.push((commit, Tag {
-                        name: tag.name().map(String::from).unwrap_or(name),
-                        message: tag
-                            .message()
-                            .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
-                    }));
+                    tags.push((
+                        commit,
+                        Tag {
+                            name: tag.name().map(String::from).unwrap_or(name),
+                            message: tag
+                                .message()
+                                .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
+                        },
+                    ));
                 }
             }
         }
@@ -1077,10 +1083,13 @@ mod test {
             Repository::normalize_pattern(Pattern::new(input).expect("valid pattern"))
         };
 
-        let first_commit = create_commit_with_files(&repo, vec![
-            ("initial.txt", "initial content"),
-            ("dir/initial.txt", "initial content"),
-        ]);
+        let first_commit = create_commit_with_files(
+            &repo,
+            vec![
+                ("initial.txt", "initial content"),
+                ("dir/initial.txt", "initial content"),
+            ],
+        );
 
         {
             let retain = repo.should_retain_commit(
@@ -1091,12 +1100,15 @@ mod test {
             assert!(retain, "include: dir/");
         }
 
-        let commit = create_commit_with_files(&repo, vec![
-            ("file1.txt", "content1"),
-            ("file2.txt", "content2"),
-            ("dir/file3.txt", "content3"),
-            ("dir/subdir/file4.txt", "content4"),
-        ]);
+        let commit = create_commit_with_files(
+            &repo,
+            vec![
+                ("file1.txt", "content1"),
+                ("file2.txt", "content2"),
+                ("dir/file3.txt", "content3"),
+                ("dir/subdir/file4.txt", "content4"),
+            ],
+        );
 
         {
             let retain = repo.should_retain_commit(&commit, None, None);

--- a/git-cliff-core/src/summary.rs
+++ b/git-cliff-core/src/summary.rs
@@ -69,12 +69,12 @@ impl CommitProcessingErrorKind {
     pub fn should_warn(self) -> bool {
         matches!(
             self,
-            CommitProcessingErrorKind::Io |
-                CommitProcessingErrorKind::Parse |
-                CommitProcessingErrorKind::Json |
-                CommitProcessingErrorKind::Field |
-                CommitProcessingErrorKind::Group |
-                CommitProcessingErrorKind::Other
+            CommitProcessingErrorKind::Io
+                | CommitProcessingErrorKind::Parse
+                | CommitProcessingErrorKind::Json
+                | CommitProcessingErrorKind::Field
+                | CommitProcessingErrorKind::Group
+                | CommitProcessingErrorKind::Other
         )
     }
 }

--- a/git-cliff-core/src/template.rs
+++ b/git-cliff-core/src/template.rs
@@ -40,6 +40,7 @@ impl Template {
         }
 
         tera.register_filter("upper_first", Self::upper_first_filter);
+        tera.register_filter("trim_prefix", Self::trim_prefix);
         tera.register_filter("split_regex", Self::split_regex);
         tera.register_filter("replace_regex", Self::replace_regex);
         tera.register_filter("find_regex", Self::find_regex);
@@ -49,6 +50,34 @@ impl Template {
             variables: Self::get_template_variables(name, &tera)?,
             tera,
         })
+    }
+
+    /// Strips a prefix from a string when it is followed by a version number.
+    ///
+    /// For example, `v1.2.3` becomes `1.2.3`, while `version/1.2.3` stays unchanged.
+    fn trim_prefix(value: &Value, args: &HashMap<String, Value>) -> TeraResult<Value> {
+        let s = tera::try_get_value!("trim_prefix", "value", String, value);
+        let pat = match args.get("pat") {
+            Some(val) => tera::try_get_value!("trim_prefix", "pat", String, val),
+            None => {
+                return Err(tera::Error::msg(
+                    "Filter `trim_prefix` expected an arg called `pat`",
+                ));
+            }
+        };
+
+        if s.starts_with(&pat) {
+            let remainder = &s[pat.len()..];
+            if remainder
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_digit())
+            {
+                return Ok(tera::to_value(remainder)?);
+            }
+        }
+
+        Ok(tera::to_value(&s)?)
     }
 
     /// Filter for making the first character of a string uppercase.
@@ -315,13 +344,15 @@ mod test {
         assert_eq!(
             "\n\t\t## 1.0 - 2023\n\t\t\n\t\t### feat\n\t\t- Add xyz\n\t\t\n\t\t### fix\n\t\t- Fix \
              abc\n\t\t",
-            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-                TextProcessor {
+            template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &[TextProcessor {
                     pattern: Regex::new("<DATE>").expect("failed to compile regex"),
                     replace: Some(String::from("2023")),
                     replace_command: None,
-                }
-            ],)?
+                }],
+            )?
         );
         template.variables.sort();
         assert_eq!(
@@ -350,8 +381,11 @@ mod test {
         let release = get_fake_release_data();
         assert_eq!(
             "\n##  1.0\n",
-            template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-            ],)?
+            template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &[],
+            )?
         );
         assert_eq!(vec![String::from("version"),], template.variables);
         Ok(())
@@ -362,8 +396,11 @@ mod test {
         let template = "{% set hello_variable = 'hello' %}{{ hello_variable | upper_first }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("Hello", r);
         Ok(())
     }
@@ -374,8 +411,11 @@ mod test {
                         replace_regex(from='o', to='a') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("hella warld", r);
         Ok(())
     }
@@ -386,8 +426,11 @@ mod test {
                         | find_regex(pat='hello') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
         assert_eq!("[hello, hello]", r);
         Ok(())
     }
@@ -398,10 +441,37 @@ mod test {
                         | split_regex(pat=' ') }}";
         let release = get_fake_release_data();
         let template = Template::new("test", template.to_string(), true)?;
-        let r = template.render(&release, Option::<HashMap<&str, String>>::None.as_ref(), &[
-        ])?;
+        let r = template.render(
+            &release,
+            Option::<HashMap<&str, String>>::None.as_ref(),
+            &[],
+        )?;
 
         assert_eq!("[hello, world,, hello, universe]", r);
+        Ok(())
+    }
+
+    #[test]
+    fn test_trim_prefix_filter() -> Result<()> {
+        let cases = [
+            ("v1.2.3", "1.2.3"),
+            ("version/1.0.16", "version/1.0.16"),
+            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.1"),
+            ("1.2.3", "1.2.3"),
+        ];
+
+        for (input, expected) in cases {
+            let template = format!("{{{{ '{input}' | trim_prefix(pat='v') }}}}");
+            let release = get_fake_release_data();
+            let template = Template::new("test", template, true)?;
+            let rendered = template.render(
+                &release,
+                Option::<HashMap<&str, String>>::None.as_ref(),
+                &[],
+            )?;
+            assert_eq!(expected, rendered, "input: {input}");
+        }
+
         Ok(())
     }
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -291,11 +291,11 @@ fn process_repository<'a>(
     let cwd = env::current_dir()?;
     let mut include_path = config.git.include_paths.clone();
     if let Ok(root) = repository.root_path() {
-        if cwd.starts_with(&root) &&
-            cwd != root &&
-            args.repository.as_ref().is_none_or(Vec::is_empty) &&
-            args.workdir.is_none() &&
-            include_path.is_empty()
+        if cwd.starts_with(&root)
+            && cwd != root
+            && args.repository.as_ref().is_none_or(Vec::is_empty)
+            && args.workdir.is_none()
+            && include_path.is_empty()
         {
             let path = cwd.join("**").join("*");
             if let Ok(stripped) = path.strip_prefix(root) {
@@ -790,11 +790,14 @@ pub fn run_with_changelog_modifier<'a>(
                 skip_list.extend(skip_commit.clone());
             }
             for sha1 in skip_list {
-                config.git.commit_parsers.insert(0, CommitParser {
-                    sha: Some(sha1.clone()),
-                    skip: Some(true),
-                    ..Default::default()
-                });
+                config.git.commit_parsers.insert(
+                    0,
+                    CommitParser {
+                        sha: Some(sha1.clone()),
+                        skip: Some(true),
+                        ..Default::default()
+                    },
+                );
             }
 
             // The commit range, used for determining the remote commits to include

--- a/website/blog/git-cliff-2.0.0.md
+++ b/website/blog/git-cliff-2.0.0.md
@@ -132,7 +132,7 @@ footer = """
 {% for release in releases -%}
     {% if release.version -%}
         {% if release.previous.version -%}
-            [{{ release.version | trim_start_matches(pat="v") }}]: \
+            [{{ release.version | trim_prefix(pat="v") }}]: \
                 https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
                     /compare/{{ release.previous.version }}..{{ release.version }}
         {% endif -%}

--- a/website/blog/git-cliff-2.10.0.md
+++ b/website/blog/git-cliff-2.10.0.md
@@ -141,7 +141,7 @@ This behavior has been reverted in this release and the default values for `[cha
 [changelog]
 body = """
 {% if version %}\
-    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}\
+    ## {{ version | trim_prefix(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}\
 {% else %}\
     ## Unreleased\
 {% endif %}\

--- a/website/docs/templating/syntax.md
+++ b/website/docs/templating/syntax.md
@@ -27,6 +27,13 @@ See the [Tera Documentation](https://keats.github.io/tera/docs/#templates) for m
     {{ "hello" | upper_first }} →  Hello
   ```
 
+- `trim_prefix`: Strips a prefix from a string when it is followed by a version number.
+
+  ```jinja
+  {{ "v1.2.3" | trim_prefix(pat="v") }} →  1.2.3
+  {{ "version/1.2.3" | trim_prefix(pat="v") }} →  version/1.2.3
+  ```
+
 - `find_regex`: Finds all occurrences of a regex pattern in a string.
 
   ```jinja


### PR DESCRIPTION
## Summary

- Adds a semver-aware `trim_prefix` Tera filter that strips a prefix only when it is immediately followed by a digit (e.g. `v1.2.3` → `1.2.3`)
- Leaves tags like `version/1.0.16` unchanged, fixing the bug where `trim_start_matches(pat="v")` produced `ersion/1.0.16`
- Updates default configs, examples, CI fixtures, and docs to use `trim_prefix(pat="v")` instead of `trim_start_matches(pat="v")`

Fixes #1291

## Test plan

- [x] `cargo test -p git-cliff-core template::test::test_trim_prefix_filter`
- [x] `cargo test -p git-cliff-core template::test`
- [ ] CI integration tests (fixtures updated to use new filter)