### PR TITLE
feat(git): skip commits from .git-blame-ignore-revs

### DIFF
--- a/git-cliff-core/src/lib.rs
+++ b/git-cliff-core/src/lib.rs
@@ -60,6 +60,31 @@ pub const CONFIG_FILES: &[&str] = &["cliff.toml", ".cliff.toml", ".config/cliff.
 pub const DEFAULT_OUTPUT: &str = "CHANGELOG.md";
 /// Default ignore file.
 pub const IGNORE_FILE: &str = ".cliffignore";
+/// File containing commit hashes to ignore in git blame.
+pub const BLAME_IGNORE_REV_FILE: &str = ".git-blame-ignore-revs";
+
+/// Parses a newline-separated list of commit hashes, ignoring comments and blank lines.
+pub fn parse_hash_list(contents: &str) -> Vec<String> {
+    contents
+        .lines()
+        .filter(|line| !(line.starts_with('#') || line.trim().is_empty()))
+        .map(|line| String::from(line.trim()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_hash_list_ignores_comments_and_blank_lines() {
+        let contents = "# ignore formatting commits\n\nabc123\n  def456  \n# trailing\n";
+        assert_eq!(
+            vec![String::from("abc123"), String::from("def456")],
+            parse_hash_list(contents)
+        );
+    }
+}
 
 /// Sets a human-readable message on the current progress bar span.
 /// This macro only has effect if the `tracing-indicatif` feature is enabled.

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -17,6 +17,9 @@ use crate::config::Remote;
 use crate::error::{Error, Result};
 use crate::tag::Tag;
 
+/// Name of the file listing commits ignored by git blame.
+const BLAME_IGNORE_REV_FILE: &str = ".git-blame-ignore-revs";
+
 /// Regex for replacing the signature part of a tag message.
 static TAG_SIGNATURE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -186,6 +189,7 @@ impl Repository {
             .filter_map(StdResult::ok)
             .filter_map(|id| self.inner.find_commit(id).ok())
             .collect();
+        commits.retain(|commit| !self.only_modifies_blame_ignore_file(commit));
         if include_path.is_some() || exclude_path.is_some() {
             let include_patterns = include_path.map(|patterns| {
                 patterns
@@ -305,6 +309,15 @@ impl Repository {
             }
             None => star_added,
         }
+    }
+
+    /// Returns whether a commit only modifies `.git-blame-ignore-revs`.
+    fn only_modifies_blame_ignore_file(&self, commit: &Commit) -> bool {
+        let changed_files = self.commit_changed_files(commit);
+        !changed_files.is_empty()
+            && changed_files
+                .iter()
+                .all(|path| path.as_os_str() == BLAME_IGNORE_REV_FILE)
     }
 
     /// Calculates whether the commit should be retained or not.
@@ -1168,5 +1181,25 @@ mod test {
             );
             assert!(!retain, "exclude: **/*.txt");
         }
+    }
+
+    #[test]
+    fn only_modifies_blame_ignore_file() {
+        let (repo, _temp_dir) = create_temp_repo();
+        let _initial = create_commit_with_files(&repo, vec![("README.md", "hello")]);
+        let blame_only = create_commit_with_files(
+            &repo,
+            vec![(".git-blame-ignore-revs", "abc123\n")],
+        );
+        let mixed = create_commit_with_files(
+            &repo,
+            vec![
+                (".git-blame-ignore-revs", "abc123\ndef456\n"),
+                ("README.md", "updated"),
+            ],
+        );
+
+        assert!(repo.only_modifies_blame_ignore_file(&blame_only));
+        assert!(!repo.only_modifies_blame_ignore_file(&mixed));
     }
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -25,7 +25,7 @@ use git_cliff_core::embed::{BuiltinConfig, EmbeddedConfig};
 use git_cliff_core::error::{Error, Result};
 use git_cliff_core::release::Release;
 use git_cliff_core::repo::{Repository, SubmoduleRange};
-use git_cliff_core::{DEFAULT_CONFIG, IGNORE_FILE};
+use git_cliff_core::{DEFAULT_CONFIG, BLAME_IGNORE_REV_FILE, IGNORE_FILE, parse_hash_list};
 use glob::Pattern;
 
 /// Checks for a new version on crates.io
@@ -779,12 +779,12 @@ pub fn run_with_changelog_modifier<'a>(
             let ignore_file = repository.root_path()?.join(IGNORE_FILE);
             if ignore_file.exists() {
                 let contents = fs::read_to_string(ignore_file)?;
-                let commits = contents
-                    .lines()
-                    .filter(|v| !(v.starts_with('#') || v.trim().is_empty()))
-                    .map(|v| String::from(v.trim()))
-                    .collect::<Vec<String>>();
-                skip_list.extend(commits);
+                skip_list.extend(parse_hash_list(&contents));
+            }
+            let blame_ignore_file = repository.root_path()?.join(BLAME_IGNORE_REV_FILE);
+            if blame_ignore_file.exists() {
+                let contents = fs::read_to_string(blame_ignore_file)?;
+                skip_list.extend(parse_hash_list(&contents));
             }
             if let Some(ref skip_commit) = args.skip_commit {
                 skip_list.extend(skip_commit.clone());

--- a/website/docs/usage/skipping-commits.md
+++ b/website/docs/usage/skipping-commits.md
@@ -20,3 +20,12 @@ For example:
 4f88dda8c746173ea59f920b7579b7f6c74bd6c8
 10c3194381f2cc4f93eb97404369568882ed8677
 ```
+
+## Git blame ignore revisions
+
+If your repository contains a [`.git-blame-ignore-revs`](https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt) file at its root, git-cliff automatically:
+
+- skips the commit hashes listed in that file
+- skips commits that only modify `.git-blame-ignore-revs`
+
+Comments and blank lines in the file are ignored, similar to `.cliffignore`.


### PR DESCRIPTION
## Summary

Implements the sane defaults agreed in #1084:

- Skip commit hashes listed in `.git-blame-ignore-revs` at the repository root
- Skip commits that only modify `.git-blame-ignore-revs`
- Reuse shared `parse_hash_list()` for comment/blank-line handling (also used by `.cliffignore` parsing)

Fixes #1084

## Test plan

- [x] `cargo test -p git-cliff-core parse_hash_list`
- [x] `cargo test -p git-cliff-core only_modifies_blame_ignore_file`
- [x] `cargo test -p git-cliff --lib`