### PR TITLE
fix(cli): add --with-commit messages to tagged release

### DIFF
--- a/.github/fixtures/test-with-commit-tag-arg/cliff.toml
+++ b/.github/fixtures/test-with-commit-tag-arg/cliff.toml
@@ -1,0 +1,25 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[git]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^chore\\(release\\)", group = "Miscellaneous Tasks" },
+]

--- a/.github/fixtures/test-with-commit-tag-arg/commit.sh
+++ b/.github/fixtures/test-with-commit-tag-arg/commit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+GIT_COMMITTER_DATE="2021-01-23 01:23:45" git commit --allow-empty -m "feat: add feature 1"
+git tag v0.1.0
+
+GIT_COMMITTER_DATE="2021-01-24 01:23:46" git commit --allow-empty -m "feat: add feature 2"
+git tag v0.2.0
+
+GIT_COMMITTER_DATE="2021-01-25 01:23:47" git commit --allow-empty -m "fix: fix feature 1"

--- a/.github/fixtures/test-with-commit-tag-arg/expected.md
+++ b/.github/fixtures/test-with-commit-tag-arg/expected.md
@@ -1,0 +1,22 @@
+## [0.3.0] - <<DATE>>
+
+### Bug Fixes
+
+- Fix feature 1
+
+### Miscellaneous Tasks
+
+- Release v0.3.0
+
+## [0.2.0] - 2021-01-24
+
+### Features
+
+- Add feature 2
+
+## [0.1.0] - 2021-01-23
+
+### Features
+
+- Add feature 1
+

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -82,6 +82,8 @@ jobs:
           - fixtures-name: test-keep-a-changelog-links-one-tag
           - fixtures-name: test-keep-a-changelog-links-tag-arg
             command: --tag v0.3.0
+          - fixtures-name: test-with-commit-tag-arg
+            command: --tag v0.3.0 --with-commit "chore(release): Release v0.3.0"
           - fixtures-name: test-keep-a-changelog-links-unreleased-arg
             command: --unreleased
           - fixtures-name: test-keep-a-changelog-links-unreleased-arg

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -412,13 +412,27 @@ fn process_repository<'a>(
         }
     }
 
-    // Add custom commit messages to the latest release.
+    // Add custom commit messages to the target release.
     if let Some(custom_commits) = &args.with_commit {
-        releases
-            .last_mut()
-            .unwrap()
-            .commits
-            .extend(custom_commits.iter().cloned().map(Commit::from));
+        let custom_commits = custom_commits
+            .iter()
+            .cloned()
+            .map(Commit::from)
+            .collect::<Vec<_>>();
+        if let Some(tag) = args.tag.as_deref() {
+            if let Some(release) = releases
+                .iter_mut()
+                .find(|release| release.version.as_deref() == Some(tag))
+            {
+                release.commits.extend(custom_commits);
+            } else {
+                tracing::warn!(
+                    "Custom commit messages were not added because no release matched tag '{tag}'"
+                );
+            }
+        } else if let Some(release) = releases.last_mut() {
+            release.commits.extend(custom_commits);
+        }
     }
 
     // Set the previous release if the first release does not have one set.


### PR DESCRIPTION
## Summary

- When `--tag` is used with `--with-commit`, add custom commit messages to the release matching that tag instead of the unreleased section
- Preserve existing behavior for `--with-commit` without `--tag` (still targets the unreleased release used by `--bump`)
- Add fixture test `test-with-commit-tag-arg`

Fixes #1426

## Test plan

- [x] Local repro: `--tag v1.1.0 --with-commit "chore(release): ..."` places message under tagged release
- [x] `--bump minor --with-commit ...` behavior unchanged
- [x] `--with-commit` without `--tag` still adds to unreleased section