### PR TITLE
perf(cli): skip per-commit diff stats when unused

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -560,6 +560,17 @@ impl Config {
             if path.is_file() { Some(path) } else { None }
         })
     }
+
+    /// Returns whether changelog templates reference per-commit statistics.
+    pub fn needs_commit_statistics(&self) -> bool {
+        const VAR: &str = "commit.statistics";
+        self.changelog
+            .header
+            .iter()
+            .chain([&self.changelog.body])
+            .chain(self.changelog.footer.iter())
+            .any(|content| content.contains(VAR))
+    }
 }
 
 impl FromStr for Config {
@@ -642,6 +653,25 @@ mod test {
         assert!(!Remote::new("", "test").is_set());
         assert!(!Remote::new("test", "").is_set());
         assert!(!Remote::new("", "").is_set());
+    }
+
+    #[test]
+    fn needs_commit_statistics() -> Result<()> {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("parent directory not found")
+            .join("config")
+            .join(crate::DEFAULT_CONFIG);
+        let mut config = Config::load(&path)?;
+
+        assert!(!config.needs_commit_statistics());
+
+        config
+            .changelog
+            .body
+            .push_str("\n{{ commit.statistics.files_changed }}");
+        assert!(config.needs_commit_statistics());
+        Ok(())
     }
 
     #[test]

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -350,25 +350,28 @@ fn process_repository<'a>(
     let mut previous_release = Release::default();
     let mut first_processed_tag = None;
     let repository_path = repository.root_path()?.to_string_lossy().into_owned();
+    let collect_commit_statistics = config.needs_commit_statistics();
     for git_commit in commits.iter().rev() {
         let release = releases.last_mut().unwrap();
         let mut commit = Commit::from(git_commit);
-        commit.statistics = match repository.commit_statistics(git_commit) {
-            Ok(statistics) => statistics,
-            Err(err)
-                if matches!(
-                    &err,
-                    Error::GitError(git_err) if git_err.message().contains("object not found")
-                ) =>
-            {
-                tracing::warn!(
-                    "Skipping diff statistics for commit {} because a Git object is missing: {err}",
-                    commit.id,
-                );
-                CommitStatistics::default()
-            }
-            Err(err) => return Err(err),
-        };
+        if collect_commit_statistics {
+            commit.statistics = match repository.commit_statistics(git_commit) {
+                Ok(statistics) => statistics,
+                Err(err)
+                    if matches!(
+                        &err,
+                        Error::GitError(git_err) if git_err.message().contains("object not found")
+                    ) =>
+                {
+                    tracing::warn!(
+                        "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                        commit.id,
+                    );
+                    CommitStatistics::default()
+                }
+                Err(err) => return Err(err),
+            };
+        }
         let commit_id = commit.id.clone();
         release.commits.push(commit);
         release.repository = Some(repository_path.clone());


### PR DESCRIPTION
## Summary

- Root cause of #1519: v2.13.0 (#1487) started computing git diff statistics for every commit unconditionally
- Add `Config::needs_commit_statistics()` to detect `commit.statistics` usage in header/body/footer templates
- Skip expensive `Repository::commit_statistics()` calls when templates do not reference per-commit statistics

Fixes #1519

## Test plan

- [x] `cargo test -p git-cliff-core config::test::needs_commit_statistics`
- [x] Local repro: default config on 500-commit repo stays fast without statistics template
- [x] Templates using `commit.statistics.*` still populate statistics (existing fixture `test-commit-statistics`)