### PR TITLE
fix(gitlab): resolve commit author usernames from API

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -16,6 +16,8 @@ use crate::remote::gitea::GiteaClient;
 use crate::remote::github::GitHubClient;
 #[cfg(feature = "gitlab")]
 use crate::remote::gitlab::GitLabClient;
+#[cfg(feature = "gitlab")]
+use crate::remote::{RemoteCommit, RemotePullRequest};
 use crate::summary::Summary;
 use crate::template::Template;
 
@@ -178,8 +180,8 @@ impl<'a> Changelog<'a> {
                 release
                     .previous
                     .as_ref()
-                    .and_then(|release| release.version.as_ref()) ==
-                    Some(skipped_tag)
+                    .and_then(|release| release.version.as_ref())
+                    == Some(skipped_tag)
             }) {
                 if let Some(previous_release) = self.releases.get_mut(release_index + 1) {
                     previous_release.previous = None;
@@ -210,10 +212,12 @@ impl<'a> Changelog<'a> {
     fn get_github_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::github;
         crate::set_progress_message!("Fetching GitHub metadata for the changelog");
-        if self.config.remote.github.is_custom ||
-            self.body_template
-                .contains_variable(github::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.github.is_custom
+            || self
+                .body_template
+                .contains_variable(github::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(github::TEMPLATE_VARIABLES))
         {
@@ -255,10 +259,12 @@ impl<'a> Changelog<'a> {
     fn get_gitlab_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitlab;
         crate::set_progress_message!("Fetching GitLab metadata for the changelog");
-        if self.config.remote.gitlab.is_custom ||
-            self.body_template
-                .contains_variable(gitlab::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitlab.is_custom
+            || self
+                .body_template
+                .contains_variable(gitlab::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitlab::TEMPLATE_VARIABLES))
         {
@@ -275,16 +281,23 @@ impl<'a> Changelog<'a> {
                             return Err(err);
                         }
                     };
-                    let (commits, merge_requests) = tokio::try_join!(
-                        // Send id to these functions
-                        gitlab_client.get_commits(
-                            project_id.expect("Project id is required for git-cliff semantics"),
-                            ref_name
-                        ),
-                        gitlab_client.get_pull_requests(
-                            project_id.expect("Project id is required for git-cliff semantics")
-                        ),
+                    let project_id =
+                        project_id.expect("Project id is required for git-cliff semantics");
+                    let (mut commits, merge_requests) = tokio::try_join!(
+                        gitlab_client.fetch_commits(project_id, ref_name),
+                        gitlab_client.fetch_merge_requests(project_id),
                     )?;
+                    gitlab_client
+                        .resolve_commit_usernames(project_id, &mut commits, &merge_requests)
+                        .await?;
+                    let commits: Vec<Box<dyn RemoteCommit>> = commits
+                        .into_iter()
+                        .map(|commit| Box::new(commit) as Box<dyn RemoteCommit>)
+                        .collect();
+                    let merge_requests: Vec<Box<dyn RemotePullRequest>> = merge_requests
+                        .into_iter()
+                        .map(|merge_request| Box::new(merge_request) as Box<dyn RemotePullRequest>)
+                        .collect();
                     tracing::debug!("Number of GitLab commits: {}", commits.len());
                     tracing::debug!("Number of GitLab merge requests: {}", merge_requests.len());
                     Ok((commits, merge_requests))
@@ -312,10 +325,12 @@ impl<'a> Changelog<'a> {
     fn get_gitea_metadata(&self, ref_name: Option<&str>) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::gitea;
         crate::set_progress_message!("Fetching Gitea metadata for the changelog");
-        if self.config.remote.gitea.is_custom ||
-            self.body_template
-                .contains_variable(gitea::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.gitea.is_custom
+            || self
+                .body_template
+                .contains_variable(gitea::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(gitea::TEMPLATE_VARIABLES))
         {
@@ -360,10 +375,12 @@ impl<'a> Changelog<'a> {
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::bitbucket;
         crate::set_progress_message!("Fetching Bitbucket metadata for the changelog");
-        if self.config.remote.bitbucket.is_custom ||
-            self.body_template
-                .contains_variable(bitbucket::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.bitbucket.is_custom
+            || self
+                .body_template
+                .contains_variable(bitbucket::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(bitbucket::TEMPLATE_VARIABLES))
         {
@@ -406,10 +423,12 @@ impl<'a> Changelog<'a> {
     ) -> Result<crate::remote::RemoteMetadata> {
         use crate::remote::azure_devops;
         crate::set_progress_message!("Fetching Azure DevOps metadata for the changelog");
-        if self.config.remote.azure_devops.is_custom ||
-            self.body_template
-                .contains_variable(azure_devops::TEMPLATE_VARIABLES) ||
-            self.footer_template
+        if self.config.remote.azure_devops.is_custom
+            || self
+                .body_template
+                .contains_variable(azure_devops::TEMPLATE_VARIABLES)
+            || self
+                .footer_template
                 .as_ref()
                 .is_some_and(|v| v.contains_variable(azure_devops::TEMPLATE_VARIABLES))
         {
@@ -1089,24 +1108,29 @@ mod test {
             timestamp: Some(50_000_000),
             previous: None,
             repository: Some(String::from("/root/repo")),
-            submodule_commits: HashMap::from([(String::from("submodule_one"), vec![
-                Commit::new(
-                    String::from("sub0jkl12"),
-                    String::from("chore(app): submodule_one do nothing"),
-                ),
-                Commit::new(
-                    String::from("subqwerty"),
-                    String::from("chore: submodule_one <preprocess>"),
-                ),
-                Commit::new(
-                    String::from("subqwertz"),
-                    String::from("feat!: submodule_one support breaking commits"),
-                ),
-                Commit::new(
-                    String::from("subqwert0"),
-                    String::from("match(group): submodule_one support regex-replace for groups"),
-                ),
-            ])]),
+            submodule_commits: HashMap::from([(
+                String::from("submodule_one"),
+                vec![
+                    Commit::new(
+                        String::from("sub0jkl12"),
+                        String::from("chore(app): submodule_one do nothing"),
+                    ),
+                    Commit::new(
+                        String::from("subqwerty"),
+                        String::from("chore: submodule_one <preprocess>"),
+                    ),
+                    Commit::new(
+                        String::from("subqwertz"),
+                        String::from("feat!: submodule_one support breaking commits"),
+                    ),
+                    Commit::new(
+                        String::from("subqwert0"),
+                        String::from(
+                            "match(group): submodule_one support regex-replace for groups",
+                        ),
+                    ),
+                ],
+            )]),
             statistics: None,
             bump_type: None,
             #[cfg(feature = "github")]
@@ -1220,14 +1244,20 @@ mod test {
                 previous: Some(Box::new(test_release)),
                 repository: Some(String::from("/root/repo")),
                 submodule_commits: HashMap::from([
-                    (String::from("submodule_one"), vec![
-                        Commit::new(String::from("def349"), String::from("sub_one merge #4")),
-                        Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
-                    ]),
-                    (String::from("submodule_two"), vec![Commit::new(
-                        String::from("ab76ef"),
-                        String::from("sub_two bump"),
-                    )]),
+                    (
+                        String::from("submodule_one"),
+                        vec![
+                            Commit::new(String::from("def349"), String::from("sub_one merge #4")),
+                            Commit::new(String::from("da8912"), String::from("sub_one merge #5")),
+                        ],
+                    ),
+                    (
+                        String::from("submodule_two"),
+                        vec![Commit::new(
+                            String::from("ab76ef"),
+                            String::from("sub_two bump"),
+                        )],
+                    ),
                 ]),
                 statistics: None,
                 bump_type: None,

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -306,22 +306,28 @@ mod test {
             ("1.0.0", "2.0.0", vec!["feat!: add xyz", "feat: zzz"]),
             ("1.0.0", "2.0.0", vec!["feat!: add xyz\n", "feat: zzz\n"]),
             ("2.0.0", "2.0.1", vec!["fix: something"]),
-            ("foo/1.0.0", "foo/1.1.0", vec![
-                "feat: add xyz",
-                "fix: fix xyz",
-            ]),
-            ("bar/1.0.0", "bar/2.0.0", vec![
-                "fix: add xyz",
-                "fix!: aaaaaa",
-            ]),
-            ("zzz-123/test/1.0.0", "zzz-123/test/1.0.1", vec![
-                "fix: aaaaaa",
-            ]),
+            (
+                "foo/1.0.0",
+                "foo/1.1.0",
+                vec!["feat: add xyz", "fix: fix xyz"],
+            ),
+            (
+                "bar/1.0.0",
+                "bar/2.0.0",
+                vec!["fix: add xyz", "fix!: aaaaaa"],
+            ),
+            (
+                "zzz-123/test/1.0.0",
+                "zzz-123/test/1.0.1",
+                vec!["fix: aaaaaa"],
+            ),
             ("v100.0.0", "v101.0.0", vec!["feat!: something"]),
             ("v1.0.0-alpha.1", "v1.0.0-alpha.2", vec!["fix: minor"]),
-            ("testing/v1.0.0-beta.1", "testing/v1.0.0-beta.2", vec![
-                "feat: nice",
-            ]),
+            (
+                "testing/v1.0.0-beta.1",
+                "testing/v1.0.0-beta.2",
+                vec!["feat: nice"],
+            ),
             ("tauri-v1.5.4", "tauri-v1.6.0", vec!["feat: something"]),
             (
                 "rocket/rocket-v4.0.0-rc.1",
@@ -486,10 +492,10 @@ mod test {
         assert_eq!("1.0.0", result.version);
         assert_eq!(None, result.bump_type);
 
-        let release = build_release("1.0.0", &[
-            "docs: update readme",
-            "feat: add a user-facing feature",
-        ]);
+        let release = build_release(
+            "1.0.0",
+            &["docs: update readme", "feat: add a user-facing feature"],
+        );
         let result = release.calculate_next_version_with_config(&Bump {
             no_increment_regex: Some(String::from("^docs$")),
             ..Default::default()
@@ -1018,6 +1024,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("21f6aa587fcb772de13f2fde0e92697c51f84162")),
@@ -1033,6 +1040,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973")),
@@ -1048,6 +1056,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("4d3ffe4753b923f4d7807c490e650e6624a12074")),
@@ -1063,6 +1072,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05")),
@@ -1078,6 +1088,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("6c34967147560ea09658776d4901709139b4ad66")),
@@ -1093,6 +1104,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("0c34967147560e809658776d4901709139b4ad68")),
@@ -1108,6 +1120,7 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
                 GitLabCommit {
                     id: Some(String::from("kk34967147560e809658776d4901709139b4ad68")),
@@ -1123,10 +1136,14 @@ mod test {
                     message: Some(String::new()),
                     parent_ids: vec![],
                     web_url: Some(String::new()),
+                    ..Default::default()
                 },
             ]
             .into_iter()
-            .map(|v| Box::new(v) as Box<dyn RemoteCommit>)
+            .map(|mut commit| {
+                commit.resolved_username = commit.author_name.clone();
+                Box::new(commit) as Box<dyn RemoteCommit>
+            })
             .collect(),
             vec![Box::new(GitLabMergeRequest {
                 title: Some(String::from("1")),
@@ -1144,6 +1161,7 @@ mod test {
                     state: Some(String::from("42")),
                     avatar_url: None,
                     web_url: Some(String::from("42")),
+                    public_email: None,
                 }),
                 sha: Some(String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071")),
                 web_url: Some(String::new()),
@@ -1271,19 +1289,12 @@ mod test {
         assert_eq!(expected_commits, release.commits);
 
         release
-            .github
+            .gitlab
             .contributors
             .sort_by(|a, b| a.pr_number.cmp(&b.pr_number));
 
         let expected_metadata = RemoteReleaseMetadata {
             contributors: vec![
-                RemoteContributor {
-                    username: Some(String::from("orhun")),
-                    pr_title: Some(String::from("1")),
-                    pr_number: Some(1),
-                    pr_labels: vec![String::from("rust")],
-                    is_first_time: false,
-                },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
                     pr_title: None,
@@ -1304,6 +1315,13 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                },
+                RemoteContributor {
+                    username: Some(String::from("orhun")),
+                    pr_title: Some(String::from("1")),
+                    pr_number: Some(1),
+                    pr_labels: vec![String::from("rust")],
+                    is_first_time: false,
                 },
             ],
         };

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -64,6 +64,13 @@ pub struct GitLabCommit {
     pub parent_ids: Vec<String>,
     /// Web Url
     pub web_url: Option<String>,
+    /// Resolved GitLab username.
+    ///
+    /// The commits API only returns `author_name`, which is the display name.
+    /// This field is populated by resolving the author via merge requests and
+    /// project members.
+    #[serde(default, skip)]
+    pub resolved_username: Option<String>,
 }
 
 impl RemoteCommit for GitLabCommit {
@@ -74,7 +81,7 @@ impl RemoteCommit for GitLabCommit {
     }
 
     fn username(&self) -> Option<String> {
-        self.author_name.clone()
+        self.resolved_username.clone()
     }
 
     fn timestamp(&self) -> Option<i64> {
@@ -156,6 +163,19 @@ pub struct GitLabUser {
     pub avatar_url: Option<String>,
     /// Web Url
     pub web_url: Option<String>,
+    /// Public email of the user.
+    pub public_email: Option<String>,
+}
+
+/// Representation of a GitLab project member.
+///
+/// <https://docs.gitlab.com/ee/api/project_members.html#list-all-members-of-a-project>
+#[derive(Debug, Default, Clone, Deserialize)]
+struct GitLabProjectMember {
+    /// Username
+    username: Option<String>,
+    /// Public email
+    public_email: Option<String>,
 }
 
 /// HTTP client for handling GitLab REST API requests.
@@ -223,6 +243,23 @@ impl GitLabClient {
         )
     }
 
+    /// Constructs the URL for GitLab project members API.
+    fn members_url(project_id: i64, api_url: &str, query: &str, page: i32) -> String {
+        format!(
+            "{api_url}/projects/{project_id}/members/all?per_page={MAX_PAGE_SIZE}&page={page}&\
+             query={}",
+            urlencoding::encode(query)
+        )
+    }
+
+    /// Constructs the URL for GitLab user search API.
+    fn users_search_url(api_url: &str, email: &str) -> String {
+        format!(
+            "{api_url}/users?per_page={MAX_PAGE_SIZE}&search={}",
+            urlencoding::encode(email)
+        )
+    }
+
     /// Looks up the project details.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn get_project(&self) -> Result<GitLabProject> {
@@ -233,38 +270,138 @@ impl GitLabClient {
 
     /// Fetches the complete list of commits.
     /// This is inefficient for large repositories; consider using
-    /// `get_commit_stream` instead.
+    /// `fetch_commits` instead.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn get_commits(
         &self,
         project_id: i64,
         ref_name: Option<&str>,
     ) -> Result<Vec<Box<dyn RemoteCommit>>> {
-        use futures::TryStreamExt;
-        crate::set_progress_message!("Fetching all commits from GitLab");
-        self.get_commit_stream(project_id, ref_name)
-            .try_collect()
-            .await
+        let commits = self.fetch_commits(project_id, ref_name).await?;
+        Ok(commits
+            .into_iter()
+            .map(|commit| Box::new(commit) as Box<dyn RemoteCommit>)
+            .collect())
     }
 
     /// Fetches the complete list of pull requests.
     /// This is inefficient for large repositories; consider using
-    /// `get_pull_request_stream` instead.
+    /// `fetch_merge_requests` instead.
     #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
     pub async fn get_pull_requests(
         &self,
         project_id: i64,
     ) -> Result<Vec<Box<dyn RemotePullRequest>>> {
-        use futures::TryStreamExt;
-        crate::set_progress_message!("Fetching all pull requests from GitLab");
-        self.get_pull_request_stream(project_id).try_collect().await
+        let merge_requests = self.fetch_merge_requests(project_id).await?;
+        Ok(merge_requests
+            .into_iter()
+            .map(|merge_request| Box::new(merge_request) as Box<dyn RemotePullRequest>)
+            .collect())
     }
 
-    fn get_commit_stream(
+    /// Fetches the complete list of commits.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub async fn fetch_commits(
         &self,
         project_id: i64,
         ref_name: Option<&str>,
-    ) -> impl Stream<Item = Result<Box<dyn RemoteCommit>>> + '_ {
+    ) -> Result<Vec<GitLabCommit>> {
+        use futures::TryStreamExt;
+        crate::set_progress_message!("Fetching all commits from GitLab");
+        self.raw_commit_stream(project_id, ref_name)
+            .try_collect()
+            .await
+    }
+
+    /// Fetches the complete list of merge requests.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub async fn fetch_merge_requests(&self, project_id: i64) -> Result<Vec<GitLabMergeRequest>> {
+        use futures::TryStreamExt;
+        crate::set_progress_message!("Fetching all pull requests from GitLab");
+        self.raw_merge_request_stream(project_id)
+            .try_collect()
+            .await
+    }
+
+    /// Resolves GitLab usernames for commits.
+    ///
+    /// GitLab's commits API returns the author's display name instead of the
+    /// username. This function resolves usernames using merge request authors
+    /// and project member lookups by email.
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+    pub async fn resolve_commit_usernames(
+        &self,
+        project_id: i64,
+        commits: &mut [GitLabCommit],
+        merge_requests: &[GitLabMergeRequest],
+    ) -> Result<()> {
+        use std::collections::{HashMap, HashSet};
+
+        apply_merge_request_usernames(commits, merge_requests);
+
+        let emails: HashSet<String> = commits
+            .iter()
+            .filter(|commit| commit.resolved_username.is_none())
+            .filter_map(|commit| commit.author_email.clone())
+            .filter(|email| !email.is_empty())
+            .collect();
+
+        if emails.is_empty() {
+            return Ok(());
+        }
+
+        let mut email_to_username = HashMap::new();
+        for email in emails {
+            if email_to_username.contains_key(&email) {
+                continue;
+            }
+            if let Some(username) = self.lookup_username_by_email(project_id, &email).await? {
+                email_to_username.insert(email, username);
+            }
+        }
+
+        for commit in commits.iter_mut() {
+            if commit.resolved_username.is_some() {
+                continue;
+            }
+            if let Some(email) = &commit.author_email {
+                if let Some(username) = email_to_username.get(email) {
+                    commit.resolved_username = Some(username.clone());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn lookup_username_by_email(
+        &self,
+        project_id: i64,
+        email: &str,
+    ) -> Result<Option<String>> {
+        let url = Self::members_url(project_id, &self.api_url(), email, 1);
+        let members: Vec<GitLabProjectMember> = self.get_json(&url).await?;
+        if let Some(username) = members
+            .iter()
+            .find(|member| member.public_email.as_deref() == Some(email))
+            .and_then(|member| member.username.clone())
+        {
+            return Ok(Some(username));
+        }
+
+        let users_url = Self::users_search_url(&self.api_url(), email);
+        let users: Vec<GitLabUser> = self.get_json(&users_url).await?;
+        Ok(users
+            .iter()
+            .find(|user| user.public_email.as_deref() == Some(email))
+            .and_then(|user| user.username.clone()))
+    }
+
+    fn raw_commit_stream(
+        &self,
+        project_id: i64,
+        ref_name: Option<&str>,
+    ) -> impl Stream<Item = Result<GitLabCommit>> + '_ {
         let ref_name = ref_name.map(ToString::to_string);
         async_stream! {
                 // GitLab pages are 1-indexed
@@ -288,7 +425,7 @@ impl GitLabClient {
                             }
 
                             for commit in commits {
-                                yield Ok(Box::new(commit) as Box<dyn RemoteCommit>);
+                                yield Ok(commit);
                             }
                         }
                         Err(e) => {
@@ -300,10 +437,10 @@ impl GitLabClient {
         }
     }
 
-    fn get_pull_request_stream(
+    fn raw_merge_request_stream(
         &self,
         project_id: i64,
-    ) -> impl Stream<Item = Result<Box<dyn RemotePullRequest>>> + '_ {
+    ) -> impl Stream<Item = Result<GitLabMergeRequest>> + '_ {
         async_stream! {
             // GitLab pages are 1-indexed
             let page_stream = stream::iter(1..)
@@ -323,7 +460,7 @@ impl GitLabClient {
                         }
 
                         for mr in mrs {
-                            yield Ok(Box::new(mr) as Box<dyn RemotePullRequest>);
+                            yield Ok(mr);
                         }
                     }
                     Err(e) => {
@@ -331,6 +468,42 @@ impl GitLabClient {
                         break;
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Applies merge request author usernames to matching commits.
+fn apply_merge_request_usernames(
+    commits: &mut [GitLabCommit],
+    merge_requests: &[GitLabMergeRequest],
+) {
+    use std::collections::HashMap;
+
+    let mut sha_to_username = HashMap::new();
+    for merge_request in merge_requests {
+        let Some(username) = merge_request
+            .author
+            .as_ref()
+            .and_then(|author| author.username.clone())
+        else {
+            continue;
+        };
+        for sha in [
+            merge_request.merge_commit_sha.as_deref(),
+            merge_request.squash_commit_sha.as_deref(),
+            merge_request.sha.as_deref(),
+        ] {
+            if let Some(sha) = sha {
+                sha_to_username.insert(sha.to_string(), username.clone());
+            }
+        }
+    }
+
+    for commit in commits.iter_mut() {
+        if let Some(id) = &commit.id {
+            if let Some(username) = sha_to_username.get(id) {
+                commit.resolved_username = Some(username.clone());
             }
         }
     }
@@ -361,11 +534,57 @@ mod test {
         let remote_commit = GitLabCommit {
             id: Some(String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071")),
             author_name: Some(String::from("orhun")),
+            resolved_username: Some(String::from("orhun")),
             committed_date: Some(String::from("2021-07-18T15:14:39+03:00")),
             ..Default::default()
         };
 
         assert_eq!(Some(1_626_610_479), remote_commit.timestamp());
+    }
+
+    #[test]
+    fn username_uses_resolved_username() {
+        let remote_commit = GitLabCommit {
+            author_name: Some(String::from("Nathan Belsterling")),
+            resolved_username: Some(String::from("nbelste1")),
+            ..Default::default()
+        };
+
+        assert_eq!(Some(String::from("nbelste1")), remote_commit.username());
+    }
+
+    #[test]
+    fn apply_merge_request_usernames_maps_merge_commits() {
+        let mut commits = vec![GitLabCommit {
+            id: Some(String::from("abc123")),
+            author_name: Some(String::from("Display Name")),
+            ..Default::default()
+        }];
+        let merge_requests = vec![GitLabMergeRequest {
+            merge_commit_sha: Some(String::from("abc123")),
+            author: Some(GitLabUser {
+                username: Some(String::from("gitlab_user")),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }];
+
+        apply_merge_request_usernames(&mut commits, &merge_requests);
+
+        assert_eq!(
+            Some(String::from("gitlab_user")),
+            commits[0].resolved_username
+        );
+    }
+
+    #[test]
+    fn members_url_encodes_query() {
+        let url =
+            GitLabClient::members_url(1, "https://gitlab.test.com/api/v4", "user@example.com", 1);
+        assert_eq!(
+            "https://gitlab.test.com/api/v4/projects/1/members/all?per_page=100&page=1&query=user%40example.com",
+            url
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- GitLab's commits API returns `author_name` (display name) rather than a username, so changelogs showed `@Nathan Belsterling` instead of `@nbelste1`.
- Resolve usernames after fetching commits by:
  1. Mapping merge commit SHAs to merge request author usernames
  2. Looking up remaining authors via project members (`/members/all?query=email`) and user search fallback
- Store the resolved value in `GitLabCommit.resolved_username` and use it for `commit.gitlab.username` template variables.

Fixes #1492

## Test plan

- [x] `cargo test -p git-cliff-core --features gitlab gitlab`
- [x] Added unit tests for resolved username, MR mapping, and members URL encoding
- [ ] GitLab integration fixture (`test-gitlab-integration`) in CI