### PR TITLE
feat: track all PR numbers for release contributors (fixes #1326)

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -786,6 +786,7 @@ Refs: #123
             pr_number: None,
             pr_labels: vec![String::from("feature"), String::from("deprecation")],
             is_first_time: true,
+                    ..Default::default()
         });
         let commit = commit.into_conventional()?;
         let commit = commit.parse_links(&[
@@ -847,6 +848,7 @@ Refs: #123
             pr_number: None,
             pr_labels: vec![String::from("feature"), String::from("deprecation")],
             is_first_time: true,
+                    ..Default::default()
         });
         let commit = commit.into_conventional()?;
         let commit = commit.parse_links(&[
@@ -1022,6 +1024,7 @@ Refs: #123
             pr_number: None,
             pr_labels: Vec::new(),
             is_first_time: true,
+                    ..Default::default()
         });
 
         let parsed_commit = commit.clone().parse(

--- a/git-cliff-core/src/contributor.rs
+++ b/git-cliff-core/src/contributor.rs
@@ -11,14 +11,78 @@ pub struct RemoteContributor {
     pub pr_title: Option<String>,
     /// The pull request that the user created.
     pub pr_number: Option<i64>,
+    /// The first pull request the user created in this release (chronological).
+    pub pr_number_first: Option<i64>,
+    /// All pull request numbers the user created in this release, in merge order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pr_numbers: Vec<i64>,
     /// Labels of the pull request.
     pub pr_labels: Vec<String>,
     /// Whether if the user contributed for the first time.
     pub is_first_time: bool,
 }
 
+impl RemoteContributor {
+    /// Records an earlier pull request for this contributor within a release.
+    pub(crate) fn track_pull_request(&mut self, pr_number: i64) {
+        self.pr_numbers.insert(0, pr_number);
+        self.pr_number_first = self.pr_numbers.first().copied();
+        self.pr_number = self.pr_numbers.last().copied();
+    }
+
+    pub(crate) fn from_pull_request(
+        username: Option<String>,
+        pr_title: Option<String>,
+        pr_number: Option<i64>,
+        pr_labels: Vec<String>,
+    ) -> Self {
+        let pr_numbers: Vec<i64> = pr_number.into_iter().collect();
+        Self {
+            username,
+            pr_title,
+            pr_number: pr_numbers.last().copied(),
+            pr_number_first: pr_numbers.first().copied(),
+            pr_numbers,
+            pr_labels,
+            is_first_time: false,
+        }
+    }
+}
+
 impl Hash for RemoteContributor {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.username.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_pull_request_sets_first_and_latest() {
+        let contributor = RemoteContributor::from_pull_request(
+            Some(String::from("iamkroot")),
+            Some(String::from("feat: defaults")),
+            Some(350),
+            vec![],
+        );
+        assert_eq!(contributor.pr_number, Some(350));
+        assert_eq!(contributor.pr_number_first, Some(350));
+        assert_eq!(contributor.pr_numbers, vec![350]);
+    }
+
+    #[test]
+    fn track_pull_request_preserves_merge_order() {
+        let mut contributor = RemoteContributor::from_pull_request(
+            Some(String::from("iamkroot")),
+            Some(String::from("feat: defaults")),
+            Some(350),
+            vec![],
+        );
+        contributor.track_pull_request(349);
+        assert_eq!(contributor.pr_numbers, vec![349, 350]);
+        assert_eq!(contributor.pr_number_first, Some(349));
+        assert_eq!(contributor.pr_number, Some(350));
     }
 }

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -791,6 +791,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -798,6 +799,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -810,6 +812,7 @@ mod test {
                     pr_number: Some(66),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -817,6 +820,7 @@ mod test {
                     pr_number: Some(66),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -829,6 +833,7 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -836,6 +841,7 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -848,6 +854,7 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -855,6 +862,7 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -867,6 +875,7 @@ mod test {
                     pr_number: Some(999_999),
                     pr_labels: vec![String::from("github")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -874,6 +883,7 @@ mod test {
                     pr_number: Some(999_999),
                     pr_labels: vec![String::from("github")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -886,6 +896,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
@@ -893,6 +904,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -912,6 +924,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -919,6 +932,8 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: true,
+                    pr_number_first: Some(999_999),
+                    pr_numbers: vec![999_999, 66, 42],
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -926,6 +941,8 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: true,
+                    pr_number_first: Some(53),
+                    pr_numbers: vec![53],
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -933,6 +950,8 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: true,
+                    pr_number_first: Some(1_000),
+                    pr_numbers: vec![1_000],
                 },
             ],
         };
@@ -1162,6 +1181,7 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1169,6 +1189,7 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1181,6 +1202,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1188,6 +1210,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1200,6 +1223,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -1207,6 +1231,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1219,6 +1244,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1226,6 +1252,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1238,6 +1265,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1245,6 +1273,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1257,6 +1286,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
@@ -1264,6 +1294,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1283,6 +1314,8 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    pr_number_first: Some(1),
+                    pr_numbers: vec![1],
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -1290,6 +1323,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1297,6 +1331,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
@@ -1304,6 +1339,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
             ],
         };
@@ -1507,6 +1543,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1514,6 +1551,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1526,6 +1564,7 @@ mod test {
                     pr_number: Some(66),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1533,6 +1572,7 @@ mod test {
                     pr_number: Some(66),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1545,6 +1585,7 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -1552,6 +1593,7 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1564,6 +1606,7 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1571,6 +1614,7 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1583,6 +1627,7 @@ mod test {
                     pr_number: Some(999_999),
                     pr_labels: vec![String::from("github")],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1590,6 +1635,7 @@ mod test {
                     pr_number: Some(999_999),
                     pr_labels: vec![String::from("github")],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1602,6 +1648,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
@@ -1609,6 +1656,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1628,6 +1676,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1635,6 +1684,8 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![String::from("rust")],
                     is_first_time: true,
+                    pr_number_first: Some(999_999),
+                    pr_numbers: vec![999_999, 66, 42],
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -1642,6 +1693,8 @@ mod test {
                     pr_number: Some(53),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: true,
+                    pr_number_first: Some(53),
+                    pr_numbers: vec![53],
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1649,6 +1702,8 @@ mod test {
                     pr_number: Some(1_000),
                     pr_labels: vec![String::from("deps")],
                     is_first_time: true,
+                    pr_number_first: Some(1_000),
+                    pr_numbers: vec![1_000],
                 },
             ],
         };
@@ -1806,6 +1861,7 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1813,6 +1869,7 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1825,6 +1882,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1832,6 +1890,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1844,6 +1903,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -1851,6 +1911,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1863,6 +1924,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1870,6 +1932,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1882,6 +1945,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1889,6 +1953,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1901,6 +1966,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
@@ -1908,6 +1974,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1927,6 +1994,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -1934,6 +2002,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
@@ -1941,6 +2010,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -1948,6 +2018,8 @@ mod test {
                     pr_number: Some(1),
                     pr_labels: vec![],
                     is_first_time: false,
+                    pr_number_first: Some(1),
+                    pr_numbers: vec![1],
                 },
             ],
         };
@@ -2120,6 +2192,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -2127,6 +2200,7 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2139,6 +2213,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -2146,6 +2221,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2158,6 +2234,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
@@ -2165,6 +2242,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2177,6 +2255,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -2184,6 +2263,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2196,6 +2276,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -2203,6 +2284,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2215,6 +2297,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
@@ -2222,6 +2305,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: false,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -2241,6 +2325,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
@@ -2248,6 +2333,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
@@ -2255,6 +2341,7 @@ mod test {
                     pr_number: None,
                     pr_labels: vec![],
                     is_first_time: true,
+                    ..Default::default()
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
@@ -2262,6 +2349,8 @@ mod test {
                     pr_number: Some(42),
                     pr_labels: vec![],
                     is_first_time: false,
+                    pr_number_first: Some(42),
+                    pr_numbers: vec![42],
                 },
             ],
         };

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -216,17 +216,20 @@ macro_rules! update_release_metadata {
                         commit.$remote.pr_title = pull_request.and_then(|v| v.title().clone());
                         commit.$remote.pr_labels =
                             pull_request.map(|v| v.labels().clone()).unwrap_or_default();
-                        if !contributors
-                            .iter()
-                            .any(|v| commit.$remote.username == v.username)
+                        if let Some(contributor) = contributors
+                            .iter_mut()
+                            .find(|v| commit.$remote.username == v.username)
                         {
-                            contributors.push(RemoteContributor {
-                                username: commit.$remote.username.clone(),
-                                pr_title: commit.$remote.pr_title.clone(),
-                                pr_number: commit.$remote.pr_number,
-                                pr_labels: commit.$remote.pr_labels.clone(),
-                                is_first_time: false,
-                            });
+                            if let Some(pr_number) = commit.$remote.pr_number {
+                                contributor.track_pull_request(pr_number);
+                            }
+                        } else {
+                            contributors.push(RemoteContributor::from_pull_request(
+                                commit.$remote.username.clone(),
+                                commit.$remote.pr_title.clone(),
+                                commit.$remote.pr_number,
+                                commit.$remote.pr_labels.clone(),
+                            ));
                         }
                         commit.remote = Some(commit.$remote.clone());
                         // if remote commit is the release commit store timestamp for


### PR DESCRIPTION
## Summary

- Add `pr_number_first` and `pr_numbers` to `RemoteContributor`.
- Aggregate multiple pull requests per contributor when building release metadata (e.g. first-time contributors with several PRs in one release).
- Keep `pr_number` as the most recently merged PR for backward compatibility.

Fixes #1326.

When a new contributor lands multiple PRs in the same release, templates can now reference the chronologically first contribution via `contributor.pr_number_first` or iterate `contributor.pr_numbers`.

## Test plan

- [x] `cargo test -p git-cliff-core --features github,gitlab,gitea,bitbucket,azure_devops update_`
- [x] `cargo test -p git-cliff-core contributor::tests`
- [x] Updated existing remote metadata fixture expectations