### PR TITLE
fix(statistics): don't compute statistics when templates do not use them

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -583,9 +583,19 @@ impl Config {
         })
     }
 
-    /// Returns whether any configured changelog template references per-commit
-    /// diff statistics.
+    /// Returns whether per-commit diff statistics are used by a changelog
+    /// template or commit parser.
     pub fn uses_commit_statistics(&self) -> Result<bool> {
+        if self
+            .git
+            .commit_parsers
+            .iter()
+            .filter_map(|parser| parser.field.as_deref())
+            .any(|field| field.starts_with("statistics."))
+        {
+            return Ok(true);
+        }
+
         let trim = self.changelog.trim;
         let body_template = Template::new("body", self.changelog.body.clone(), trim)?;
         if body_template.contains_variable(statistics::TEMPLATE_VARIABLES) {

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
+use crate::statistics;
+use crate::template::Template;
 use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error};
 
 /// Default initial tag.
@@ -581,6 +583,29 @@ impl Config {
             if path.is_file() { Some(path) } else { None }
         })
     }
+
+    /// Returns whether any configured changelog template references per-commit
+    /// diff statistics.
+    pub fn uses_commit_statistics(&self) -> Result<bool> {
+        let trim = self.changelog.trim;
+        let body_template = Template::new("body", self.changelog.body.clone(), trim)?;
+        if body_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+            return Ok(true);
+        }
+        if let Some(header) = &self.changelog.header {
+            let header_template = Template::new("header", header.clone(), trim)?;
+            if header_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+                return Ok(true);
+            }
+        }
+        if let Some(footer) = &self.changelog.footer {
+            let footer_template = Template::new("footer", footer.clone(), trim)?;
+            if footer_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 impl FromStr for Config {
@@ -719,6 +744,23 @@ mod test {
             Config::retrieve_project_config_path(dir.path()),
             Some(dir.path().join("cliff.toml")),
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn detects_commit_statistics_usage_in_templates() -> Result<()> {
+        let mut config = EmbeddedConfig::parse()?;
+        assert!(!config.uses_commit_statistics()?);
+
+        config.changelog.body = String::from(
+            "{% for commit in commits %}{{ commit.statistics.files_changed }}{% endfor %}",
+        );
+        assert!(config.uses_commit_statistics()?);
+
+        config.changelog.body = String::from("{{ version }}");
+        config.changelog.footer = Some(String::from("{{ commit.statistics.additions }}"));
+        assert!(config.uses_commit_statistics()?);
 
         Ok(())
     }

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -11,9 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
-use crate::statistics;
 use crate::template::Template;
-use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error};
+use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error, statistics};
 
 /// Default initial tag.
 const DEFAULT_INITIAL_TAG: &str = "0.1.0";

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -12,9 +12,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
-use crate::statistics;
 use crate::template::Template;
-use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error};
+use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error, statistics};
 
 /// Default initial tag.
 const DEFAULT_INITIAL_TAG: &str = "0.1.0";

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::embed::EmbeddedConfig;
 use crate::error::Result;
+use crate::statistics;
+use crate::template::Template;
 use crate::{CONFIG_FILES, DEFAULT_CONFIG, command, error};
 
 /// Default initial tag.
@@ -560,6 +562,29 @@ impl Config {
             if path.is_file() { Some(path) } else { None }
         })
     }
+
+    /// Returns whether any configured changelog template references per-commit
+    /// diff statistics.
+    pub fn uses_commit_statistics(&self) -> Result<bool> {
+        let trim = self.changelog.trim;
+        let body_template = Template::new("body", self.changelog.body.clone(), trim)?;
+        if body_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+            return Ok(true);
+        }
+        if let Some(header) = &self.changelog.header {
+            let header_template = Template::new("header", header.clone(), trim)?;
+            if header_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+                return Ok(true);
+            }
+        }
+        if let Some(footer) = &self.changelog.footer {
+            let footer_template = Template::new("footer", footer.clone(), trim)?;
+            if footer_template.contains_variable(statistics::TEMPLATE_VARIABLES) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }
 
 impl FromStr for Config {
@@ -665,6 +690,23 @@ mod test {
             Config::retrieve_project_config_path(dir.path()),
             Some(dir.path().join("cliff.toml")),
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn detects_commit_statistics_usage_in_templates() -> Result<()> {
+        let mut config = EmbeddedConfig::parse()?;
+        assert!(!config.uses_commit_statistics()?);
+
+        config.changelog.body = String::from(
+            "{% for commit in commits %}{{ commit.statistics.files_changed }}{% endfor %}",
+        );
+        assert!(config.uses_commit_statistics()?);
+
+        config.changelog.body = String::from("{{ version }}");
+        config.changelog.footer = Some(String::from("{{ commit.statistics.additions }}"));
+        assert!(config.uses_commit_statistics()?);
 
         Ok(())
     }

--- a/git-cliff-core/src/statistics.rs
+++ b/git-cliff-core/src/statistics.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::release::Release;
 
+/// Template variables related to statistics context.
+pub(crate) const TEMPLATE_VARIABLES: &[&str] = &["commit.statistics"];
+
 /// Aggregated information about how many times a specific link appeared in
 /// commit messages.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -365,7 +365,8 @@ fn process_repository<'a>(
                     ) =>
                 {
                     tracing::warn!(
-                        "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                        "Skipping diff statistics for commit {} because a Git object is missing: \
+                         {err}",
                         commit.id,
                     );
                     CommitStatistics::default()

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -202,7 +202,7 @@ fn process_repository<'a>(
     let ignore_regex = config.git.ignore_tags.as_ref();
     let count_tags = config.git.count_tags.as_ref();
     let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
-    let compute_commit_statistics = config.uses_commit_statistics()?;
+    let compute_commit_statistics = args.context || config.uses_commit_statistics()?;
     tags.retain(|_, tag| {
         let name = &tag.name;
 

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -202,6 +202,7 @@ fn process_repository<'a>(
     let ignore_regex = config.git.ignore_tags.as_ref();
     let count_tags = config.git.count_tags.as_ref();
     let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
+    let compute_commit_statistics = config.uses_commit_statistics()?;
     tags.retain(|_, tag| {
         let name = &tag.name;
 
@@ -354,22 +355,24 @@ fn process_repository<'a>(
     for git_commit in commits.iter().rev() {
         let release = releases.last_mut().unwrap();
         let mut commit = Commit::from(git_commit);
-        commit.statistics = match repository.commit_statistics(git_commit) {
-            Ok(statistics) => statistics,
-            Err(err)
-                if matches!(
-                    &err,
-                    Error::GitError(git_err) if git_err.message().contains("object not found")
-                ) =>
-            {
-                tracing::warn!(
-                    "Skipping diff statistics for commit {} because a Git object is missing: {err}",
-                    commit.id,
-                );
-                CommitStatistics::default()
+        if compute_commit_statistics {
+            commit.statistics = match repository.commit_statistics(git_commit) {
+                Ok(statistics) => statistics,
+                Err(err)
+                    if matches!(
+                        &err,
+                        Error::GitError(git_err) if git_err.message().contains("object not found")
+                    ) =>
+                {
+                    tracing::warn!(
+                        "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                        commit.id,
+                    );
+                    CommitStatistics::default()
+                }
+                Err(err) => return Err(err),
             }
-            Err(err) => return Err(err),
-        };
+        }
         let commit_id = commit.id.clone();
         release.commits.push(commit);
         release.repository = Some(repository_path.clone());

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -202,6 +202,7 @@ fn process_repository<'a>(
     let ignore_regex = config.git.ignore_tags.as_ref();
     let count_tags = config.git.count_tags.as_ref();
     let recurse_submodules = config.git.recurse_submodules.unwrap_or(false);
+    let compute_commit_statistics = config.uses_commit_statistics()?;
     tags.retain(|_, tag| {
         let name = &tag.name;
 
@@ -353,22 +354,24 @@ fn process_repository<'a>(
     for git_commit in commits.iter().rev() {
         let release = releases.last_mut().unwrap();
         let mut commit = Commit::from(git_commit);
-        commit.statistics = match repository.commit_statistics(git_commit) {
-            Ok(statistics) => statistics,
-            Err(err)
-                if matches!(
-                    &err,
-                    Error::GitError(git_err) if git_err.message().contains("object not found")
-                ) =>
-            {
-                tracing::warn!(
-                    "Skipping diff statistics for commit {} because a Git object is missing: {err}",
-                    commit.id,
-                );
-                CommitStatistics::default()
+        if compute_commit_statistics {
+            commit.statistics = match repository.commit_statistics(git_commit) {
+                Ok(statistics) => statistics,
+                Err(err)
+                    if matches!(
+                        &err,
+                        Error::GitError(git_err) if git_err.message().contains("object not found")
+                    ) =>
+                {
+                    tracing::warn!(
+                        "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                        commit.id,
+                    );
+                    CommitStatistics::default()
+                }
+                Err(err) => return Err(err),
             }
-            Err(err) => return Err(err),
-        };
+        }
         let commit_id = commit.id.clone();
         release.commits.push(commit);
         release.repository = Some(repository_path.clone());

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -364,7 +364,8 @@ fn process_repository<'a>(
                     ) =>
                 {
                     tracing::warn!(
-                        "Skipping diff statistics for commit {} because a Git object is missing: {err}",
+                        "Skipping diff statistics for commit {} because a Git object is missing: \
+                         {err}",
                         commit.id,
                     );
                     CommitStatistics::default()


### PR DESCRIPTION
## Description

Do not compute statistics if they are not being used in the template.

## Motivation and Context

closes #1604
closes #1519

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
