### PR TITLE
feat(changelog): warn when template uses remote variables without matching feature

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -660,29 +660,24 @@ impl<'a> Changelog<'a> {
     }
 }
 
-/// Emits a warning when a template references remote-specific variables
-/// (e.g. `github.contributors`) for a provider whose Cargo feature is not
-/// compiled in.  The render itself will fail later with a confusing
-/// "variable not found in context" message; this warning gives users a
-/// clear, actionable hint before that happens.
+/// Emits a warning when a template references remote-specific variables for a
+/// provider whose Cargo feature is not compiled in.
 fn warn_if_remote_template_variables_without_feature(changelog: &Changelog<'_>) {
-    let templates: Vec<&Template> = [
-        Some(&changelog.body_template),
-        changelog.header_template.as_ref(),
-        changelog.footer_template.as_ref(),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
-
     macro_rules! warn_missing_feature {
         ($feature:literal, $vars:expr, $example:literal) => {
             #[cfg(not(feature = $feature))]
-            if templates.iter().any(|t| t.contains_variable($vars)) {
+            if [
+                Some(&changelog.body_template),
+                changelog.header_template.as_ref(),
+                changelog.footer_template.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            .any(|t| t.contains_variable($vars))
+            {
                 tracing::warn!(
-                    "Template uses a `{}` variable (e.g. `{}`) but the `{}` feature is not \
-                     enabled. Rebuild git-cliff with `--features {}` or use a binary that \
-                     includes all remote features.",
+                    "Template uses `{}` variables (e.g. `{}`) but the `{}` feature is not \
+                     enabled. Rebuild with `--features {}`.",
                     $feature,
                     $example,
                     $feature,

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -663,6 +663,9 @@ impl<'a> Changelog<'a> {
 /// Emits a warning when a template references remote-specific variables for a
 /// provider whose Cargo feature is not compiled in.
 fn warn_if_remote_template_variables_without_feature(changelog: &Changelog<'_>) {
+    // `changelog` is only referenced inside #[cfg(not(feature = "..."))] blocks;
+    // when all remote features are enabled every block is compiled out.
+    let _ = changelog;
     macro_rules! warn_missing_feature {
         ($feature:literal, $vars:expr, $example:literal) => {
             #[cfg(not(feature = $feature))]
@@ -687,8 +690,16 @@ fn warn_if_remote_template_variables_without_feature(changelog: &Changelog<'_>) 
         };
     }
 
-    warn_missing_feature!("github", &["github", "commit.github"], "github.contributors");
-    warn_missing_feature!("gitlab", &["gitlab", "commit.gitlab"], "gitlab.contributors");
+    warn_missing_feature!(
+        "github",
+        &["github", "commit.github"],
+        "github.contributors"
+    );
+    warn_missing_feature!(
+        "gitlab",
+        &["gitlab", "commit.gitlab"],
+        "gitlab.contributors"
+    );
     warn_missing_feature!("gitea", &["gitea", "commit.gitea"], "gitea.contributors");
     warn_missing_feature!(
         "bitbucket",

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -52,7 +52,7 @@ impl<'a> Changelog<'a> {
     /// Builds a changelog from releases and config.
     fn build(releases: Vec<Release<'a>>, config: Config) -> Result<Self> {
         let trim = config.changelog.trim;
-        Ok(Self {
+        let changelog = Self {
             releases,
             header_template: match &config.changelog.header {
                 Some(header) => Some(Template::new("header", header.clone(), trim)?),
@@ -65,7 +65,9 @@ impl<'a> Changelog<'a> {
             },
             config,
             additional_context: HashMap::new(),
-        })
+        };
+        warn_if_remote_template_variables_without_feature(&changelog);
+        Ok(changelog)
     }
 
     /// Constructs an instance from a serialized context object.
@@ -656,6 +658,53 @@ impl<'a> Changelog<'a> {
         writeln!(out, "{output}")?;
         Ok(())
     }
+}
+
+/// Emits a warning when a template references remote-specific variables
+/// (e.g. `github.contributors`) for a provider whose Cargo feature is not
+/// compiled in.  The render itself will fail later with a confusing
+/// "variable not found in context" message; this warning gives users a
+/// clear, actionable hint before that happens.
+fn warn_if_remote_template_variables_without_feature(changelog: &Changelog<'_>) {
+    let templates: Vec<&Template> = [
+        Some(&changelog.body_template),
+        changelog.header_template.as_ref(),
+        changelog.footer_template.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    macro_rules! warn_missing_feature {
+        ($feature:literal, $vars:expr, $example:literal) => {
+            #[cfg(not(feature = $feature))]
+            if templates.iter().any(|t| t.contains_variable($vars)) {
+                tracing::warn!(
+                    "Template uses a `{}` variable (e.g. `{}`) but the `{}` feature is not \
+                     enabled. Rebuild git-cliff with `--features {}` or use a binary that \
+                     includes all remote features.",
+                    $feature,
+                    $example,
+                    $feature,
+                    $feature,
+                );
+            }
+        };
+    }
+
+    warn_missing_feature!("github", &["github", "commit.github"], "github.contributors");
+    warn_missing_feature!("gitlab", &["gitlab", "commit.gitlab"], "gitlab.contributors");
+    warn_missing_feature!("gitea", &["gitea", "commit.gitea"], "gitea.contributors");
+    warn_missing_feature!(
+        "bitbucket",
+        &["bitbucket", "commit.bitbucket"],
+        "bitbucket.contributors"
+    );
+    warn_missing_feature!(
+        "azure_devops",
+        &["azure_devops", "commit.azure_devops"],
+        "azure_devops.contributors"
+    );
 }
 
 fn get_body_template(config: &Config, trim: bool) -> Result<Template> {


### PR DESCRIPTION
Fixes #659.

## Problem

When a template references variables like `github.contributors` or `commit.gitlab` but the binary was compiled without the corresponding feature flag, the output is silently empty — no error, no warning, just missing data. This is confusing because the template looks correct but produces nothing for those fields.

## Solution

Added a `warn_if_remote_template_variables_without_feature` function that is called from `Changelog::build`. It checks each template (header, body, footer) for remote-specific variable names and emits a `tracing::warn` when the relevant Cargo feature is absent.

The check uses the existing `Template::contains_variable` method and is gated with `#[cfg(not(feature = "..."))]` so there is zero overhead when the feature is enabled.

```
WARN git_cliff_core::changelog: Template uses a `github` variable (e.g. `github.contributors`) 
but the `github` feature is not enabled. Rebuild git-cliff with `--features github` or use a 
binary that includes all remote features.
```

All five remotes are covered: `github`, `gitlab`, `gitea`, `bitbucket`, `azure_devops`.