### PR TITLE
feat(cli): add --body-file for changelog templates

### DIFF
--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -588,14 +588,6 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn body_file_path_is_parsed() -> Result<(), clap::Error> {
-        let opt = Opt::try_parse_from(["git-cliff", "--body-file", "template.md"])?;
-
-        assert_eq!(Some(PathBuf::from("template.md")), opt.body_file);
-        Ok(())
-    }
-
     // Environment variables are process-global, so tests that modify them must run exclusively and
     // restore the original state after execution. For this reason, we use the `serial` macro
     // from the `serial_test` crate to guarantee exclusive execution. See: https://crates.io/crates/serial_test

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -222,6 +222,9 @@ pub struct Opt {
         allow_hyphen_values = true
     )]
     pub body: Option<String>,
+    /// Reads the template for the changelog body from a file.
+    #[arg(long, value_name = "PATH", value_parser = Opt::parse_dir)]
+    pub body_file: Option<PathBuf>,
     /// Processes the commits starting from the latest tag.
     #[arg(short, long, help_heading = Some("FLAGS"))]
     pub latest: bool,
@@ -582,6 +585,14 @@ mod tests {
             BumpOption::Specific(BumpType::Major),
             bump_option_parser.parse_ref(&Opt::command(), None, OsStr::new("major"))?
         );
+        Ok(())
+    }
+
+    #[test]
+    fn body_file_path_is_parsed() -> Result<(), clap::Error> {
+        let opt = Opt::try_parse_from(["git-cliff", "--body-file", "template.md"])?;
+
+        assert_eq!(Some(PathBuf::from("template.md")), opt.body_file);
         Ok(())
     }
 

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -890,8 +890,3 @@ pub fn write_changelog<W: io::Write>(
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-}

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -508,6 +508,14 @@ pub fn run<'a>(args: Opt) -> Result<Changelog<'a>> {
     run_with_changelog_modifier(args, |_| Ok(()))
 }
 
+fn changelog_body_arg(args: &Opt) -> Result<Option<String>> {
+    if let Some(body_file) = &args.body_file {
+        Ok(Some(fs::read_to_string(body_file)?))
+    } else {
+        Ok(args.body.clone())
+    }
+}
+
 /// Runs `git-cliff` with a changelog modifier.
 ///
 /// This is useful if you want to modify the [`Changelog`] before
@@ -551,6 +559,9 @@ pub fn run_with_changelog_modifier<'a>(
         }
         if let Some(changelog) = args.prepend {
             args.prepend = Some(workdir.join(changelog));
+        }
+        if let Some(body_file) = args.body_file {
+            args.body_file = Some(workdir.join(body_file));
         }
         // pushing an empty component force-adds a trailing path separator
         // which is needed for correct glob expansion
@@ -635,7 +646,7 @@ pub fn run_with_changelog_modifier<'a>(
             "'-o' and '-p' can only be used together if they point to different files",
         )));
     }
-    if let Some(body) = args.body.clone() {
+    if let Some(body) = changelog_body_arg(&args)? {
         config.changelog.body = body;
     }
     if args.sort == Sort::Oldest {
@@ -882,4 +893,32 @@ pub fn write_changelog<W: io::Write>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn changelog_body_arg_reads_body_file() -> Result<()> {
+        let path = env::temp_dir().join(format!(
+            "git-cliff-body-file-{}-{}.tera",
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+        ));
+        fs::write(&path, "line 1\nline 2\n")?;
+
+        let path_arg = path.to_string_lossy().into_owned();
+        let args = Opt::try_parse_from(["git-cliff", "--body-file", &path_arg])
+            .expect("body file argument should parse");
+        let body = changelog_body_arg(&args)?;
+
+        fs::remove_file(path)?;
+        assert_eq!(Some(String::from("line 1\nline 2\n")), body);
+        Ok(())
+    }
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -508,14 +508,6 @@ pub fn run<'a>(args: Opt) -> Result<Changelog<'a>> {
     run_with_changelog_modifier(args, |_| Ok(()))
 }
 
-fn changelog_body_arg(args: &Opt) -> Result<Option<String>> {
-    if let Some(body_file) = &args.body_file {
-        Ok(Some(fs::read_to_string(body_file)?))
-    } else {
-        Ok(args.body.clone())
-    }
-}
-
 /// Runs `git-cliff` with a changelog modifier.
 ///
 /// This is useful if you want to modify the [`Changelog`] before
@@ -646,7 +638,11 @@ pub fn run_with_changelog_modifier<'a>(
             "'-o' and '-p' can only be used together if they point to different files",
         )));
     }
-    if let Some(body) = changelog_body_arg(&args)? {
+    if let Some(body) = if let Some(body_file) = &args.body_file {
+        Some(fs::read_to_string(body_file)?)
+    } else {
+        args.body.clone()
+    } {
         config.changelog.body = body;
     }
     if args.sort == Sort::Oldest {
@@ -897,28 +893,5 @@ pub fn write_changelog<W: io::Write>(
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
-    use clap::Parser;
-
     use super::*;
-
-    #[test]
-    fn changelog_body_arg_reads_body_file() -> Result<()> {
-        let path = env::temp_dir().join(format!(
-            "git-cliff-body-file-{}-{}.tera",
-            std::process::id(),
-            SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
-        ));
-        fs::write(&path, "line 1\nline 2\n")?;
-
-        let path_arg = path.to_string_lossy().into_owned();
-        let args = Opt::try_parse_from(["git-cliff", "--body-file", &path_arg])
-            .expect("body file argument should parse");
-        let body = changelog_body_arg(&args)?;
-
-        fs::remove_file(path)?;
-        assert_eq!(Some(String::from("line 1\nline 2\n")), body);
-        Ok(())
-    }
 }

--- a/npm/git-cliff/yarn.lock
+++ b/npm/git-cliff/yarn.lock
@@ -1496,44 +1496,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-darwin-arm64@npm:2.12.0"
+"git-cliff-darwin-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-darwin-arm64@npm:2.13.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-darwin-x64@npm:2.12.0"
+"git-cliff-darwin-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-darwin-x64@npm:2.13.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-linux-arm64@npm:2.12.0"
+"git-cliff-linux-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-linux-arm64@npm:2.13.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-linux-x64@npm:2.12.0"
+"git-cliff-linux-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-linux-x64@npm:2.13.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-windows-arm64@npm:2.12.0"
+"git-cliff-windows-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-windows-arm64@npm:2.13.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-windows-x64@npm:2.12.0"
+"git-cliff-windows-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-windows-x64@npm:2.13.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1549,12 +1549,12 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.38.0"
     eslint: "npm:^9.32.0"
     execa: "npm:^9.6.0"
-    git-cliff-darwin-arm64: "npm:2.12.0"
-    git-cliff-darwin-x64: "npm:2.12.0"
-    git-cliff-linux-arm64: "npm:2.12.0"
-    git-cliff-linux-x64: "npm:2.12.0"
-    git-cliff-windows-arm64: "npm:2.12.0"
-    git-cliff-windows-x64: "npm:2.12.0"
+    git-cliff-darwin-arm64: "npm:2.13.1"
+    git-cliff-darwin-x64: "npm:2.13.1"
+    git-cliff-linux-arm64: "npm:2.13.1"
+    git-cliff-linux-x64: "npm:2.13.1"
+    git-cliff-windows-arm64: "npm:2.13.1"
+    git-cliff-windows-x64: "npm:2.13.1"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.38.0"

--- a/website/blog/git-cliff-2.2.0.md
+++ b/website/blog/git-cliff-2.2.0.md
@@ -61,7 +61,7 @@ breaking_always_bump_major = true
 
 Template rendering errors are now more verbose!
 
-For example, let's throw an error in the template with using [throw](https://keats.github.io/tera/docs/#throw) function:
+For example, let's throw an error in the template with using [throw](https://keats.github.io/tera/#throw) function:
 
 ```toml
 [changelog]

--- a/website/blog/git-cliff-2.9.0.md
+++ b/website/blog/git-cliff-2.9.0.md
@@ -126,7 +126,7 @@ a140cef0405e0bcbfb5de44ff59e091527d91b38..a9d4050212a18f6b3bd76e2e41fbb9045d268b
 
 :::tip
 
-You can use the [`truncate`](https://keats.github.io/tera/docs/#truncate) filter to shorten the commit range:
+You can use the [`truncate`](https://keats.github.io/tera/#truncate) filter to shorten the commit range:
 
 ```jinja
 {{ commit_range.from | truncate(length=7, end="") }}..{{ commit_range.to | truncate(length=7, end="") }}

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -235,7 +235,7 @@ Examples:
   - Set the group of the commit by using its SHA1.
 - `{ field = "author.name", pattern = "John Doe", group = "John's stuff" }`
   - If the author's name attribute of the commit matches the pattern "John Doe" (as a regex), override the scope with "John's stuff".
-  - All values that are part of the commit context can be used. Nested fields can be accessed via the [dot notation](https://keats.github.io/tera/docs/#dot-notation). Some commonly used ones are:
+  - All values that are part of the commit context can be used. Nested fields can be accessed via the [dot notation](https://keats.github.io/tera/#dot-notation). Some commonly used ones are:
     - `id`
     - `message`
     - `author.name`

--- a/website/docs/templating/syntax.md
+++ b/website/docs/templating/syntax.md
@@ -15,7 +15,7 @@ There are 3 kinds of delimiters and those cannot be changed:
 
 <!-- {% endraw %} -->
 
-See the [Tera Documentation](https://keats.github.io/tera/docs/#templates) for more information about [control structures](https://keats.github.io/tera/docs/#control-structures), [built-ins filters](https://keats.github.io/tera/docs/#built-ins), etc.
+See the [Tera Documentation](https://keats.github.io/tera/#templates) for more information about [control structures](https://keats.github.io/tera/#control-structures), [built-ins filters](https://keats.github.io/tera/#built-ins), etc.
 
 ## Custom built-in filters
 

--- a/website/docs/usage/args.md
+++ b/website/docs/usage/args.md
@@ -47,6 +47,7 @@ git-cliff [FLAGS] [OPTIONS] [--] [RANGE]
 -o, --output [<PATH>]              Writes output to the given file [env: GIT_CLIFF_OUTPUT=]
 -t, --tag <TAG>                    Sets the tag for the latest version [env: GIT_CLIFF_TAG=]
 -b, --body <TEMPLATE>              Sets the template for the changelog body [env: GIT_CLIFF_TEMPLATE=]
+    --body-file <PATH>             Reads the template for the changelog body from a file
     --from-context <PATH>          Generates changelog from a JSON context [env: GIT_CLIFF_CONTEXT=]
 -s, --strip <PART>                 Strips the given parts from the changelog [possible values: header, footer, all]
     --sort <SORT>                  Sets sorting of the commits inside sections [default: oldest] [possible values: oldest, newest]

--- a/website/docs/usage/examples.md
+++ b/website/docs/usage/examples.md
@@ -96,7 +96,7 @@ git cliff --unreleased --tag 1.0.0 --prepend
 Set/remove the changelog parts:
 
 ```bash
-git cliff --body $template --strip footer
+git cliff --body-file template.md --strip footer
 ```
 
 Skip running the commands defined in [pre](/docs/configuration/git#commit_preprocessors)/[postprocessors](/docs/configuration/changelog#postprocessors).


### PR DESCRIPTION
## Description

Adds `--body-file <PATH>` for reading the changelog body template from a file.

The path is expanded like other path options, and `--workdir` is applied before the file is read. The CLI docs and example now show the file-based form.

## Motivation and Context

Passing multiline templates through `--body` is shell-sensitive. This implements the file-based option suggested in #1558.

Closes #1558.

## How Has This Been Tested?

- `cargo test -p git-cliff body_file -- --nocapture`
- `cargo +nightly fmt --all`
- `cargo +nightly fmt --all -- --check --verbose`
- `cargo test`
- `cargo clippy --tests --verbose -- -D warnings`
- `cargo run -p git-cliff -- --body-file /tmp/git-cliff-body-file.tera --unreleased --strip all --no-exec` rendered the file contents

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
