### PR TITLE
fix(bump): honor no_increment_regex for raw messages

### DIFF
--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -190,7 +190,7 @@ impl Release<'_> {
                             &old_semver,
                             self.commits
                                 .iter()
-                                .map(|commit| commit.message.trim_end().to_string())
+                                .map(|commit| commit.raw_message().trim_end().to_string())
                                 .collect::<Vec<String>>(),
                         );
                         let bump_type = determine_bump_type(&old_semver, &new_semver);
@@ -496,6 +496,29 @@ mod test {
         })?;
         assert_eq!("1.1.0", result.version);
         assert_eq!(Some(BumpType::Minor), result.bump_type);
+
+        let release = Release {
+            version: None,
+            commits: vec![
+                Commit {
+                    message: String::from("test"),
+                    raw_message: Some(String::from("ci: test")),
+                    ..Default::default()
+                }
+                .into_conventional()?,
+            ],
+            previous: Some(Box::new(Release {
+                version: Some(String::from("1.0.0")),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let result = release.calculate_next_version_with_config(&Bump {
+            no_increment_regex: Some(String::from("^ci$")),
+            ..Default::default()
+        })?;
+        assert_eq!("1.0.0", result.version);
+        assert_eq!(None, result.bump_type);
 
         Ok(())
     }

--- a/npm/git-cliff/yarn.lock
+++ b/npm/git-cliff/yarn.lock
@@ -1496,44 +1496,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-darwin-arm64@npm:2.12.0"
+"git-cliff-darwin-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-darwin-arm64@npm:2.13.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-darwin-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-darwin-x64@npm:2.12.0"
+"git-cliff-darwin-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-darwin-x64@npm:2.13.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-linux-arm64@npm:2.12.0"
+"git-cliff-linux-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-linux-arm64@npm:2.13.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-linux-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-linux-x64@npm:2.12.0"
+"git-cliff-linux-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-linux-x64@npm:2.13.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-arm64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-windows-arm64@npm:2.12.0"
+"git-cliff-windows-arm64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-windows-arm64@npm:2.13.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"git-cliff-windows-x64@npm:2.12.0":
-  version: 2.12.0
-  resolution: "git-cliff-windows-x64@npm:2.12.0"
+"git-cliff-windows-x64@npm:2.13.1":
+  version: 2.13.1
+  resolution: "git-cliff-windows-x64@npm:2.13.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1549,12 +1549,12 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.38.0"
     eslint: "npm:^9.32.0"
     execa: "npm:^9.6.0"
-    git-cliff-darwin-arm64: "npm:2.12.0"
-    git-cliff-darwin-x64: "npm:2.12.0"
-    git-cliff-linux-arm64: "npm:2.12.0"
-    git-cliff-linux-x64: "npm:2.12.0"
-    git-cliff-windows-arm64: "npm:2.12.0"
-    git-cliff-windows-x64: "npm:2.12.0"
+    git-cliff-darwin-arm64: "npm:2.13.1"
+    git-cliff-darwin-x64: "npm:2.13.1"
+    git-cliff-linux-arm64: "npm:2.13.1"
+    git-cliff-linux-x64: "npm:2.13.1"
+    git-cliff-windows-arm64: "npm:2.13.1"
+    git-cliff-windows-x64: "npm:2.13.1"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.38.0"

--- a/website/blog/git-cliff-2.2.0.md
+++ b/website/blog/git-cliff-2.2.0.md
@@ -61,7 +61,7 @@ breaking_always_bump_major = true
 
 Template rendering errors are now more verbose!
 
-For example, let's throw an error in the template with using [throw](https://keats.github.io/tera/docs/#throw) function:
+For example, let's throw an error in the template with using [throw](https://keats.github.io/tera/#throw) function:
 
 ```toml
 [changelog]

--- a/website/blog/git-cliff-2.9.0.md
+++ b/website/blog/git-cliff-2.9.0.md
@@ -126,7 +126,7 @@ a140cef0405e0bcbfb5de44ff59e091527d91b38..a9d4050212a18f6b3bd76e2e41fbb9045d268b
 
 :::tip
 
-You can use the [`truncate`](https://keats.github.io/tera/docs/#truncate) filter to shorten the commit range:
+You can use the [`truncate`](https://keats.github.io/tera/#truncate) filter to shorten the commit range:
 
 ```jinja
 {{ commit_range.from | truncate(length=7, end="") }}..{{ commit_range.to | truncate(length=7, end="") }}

--- a/website/docs/configuration/git.md
+++ b/website/docs/configuration/git.md
@@ -235,7 +235,7 @@ Examples:
   - Set the group of the commit by using its SHA1.
 - `{ field = "author.name", pattern = "John Doe", group = "John's stuff" }`
   - If the author's name attribute of the commit matches the pattern "John Doe" (as a regex), override the scope with "John's stuff".
-  - All values that are part of the commit context can be used. Nested fields can be accessed via the [dot notation](https://keats.github.io/tera/docs/#dot-notation). Some commonly used ones are:
+  - All values that are part of the commit context can be used. Nested fields can be accessed via the [dot notation](https://keats.github.io/tera/#dot-notation). Some commonly used ones are:
     - `id`
     - `message`
     - `author.name`

--- a/website/docs/templating/syntax.md
+++ b/website/docs/templating/syntax.md
@@ -15,7 +15,7 @@ There are 3 kinds of delimiters and those cannot be changed:
 
 <!-- {% endraw %} -->
 
-See the [Tera Documentation](https://keats.github.io/tera/docs/#templates) for more information about [control structures](https://keats.github.io/tera/docs/#control-structures), [built-ins filters](https://keats.github.io/tera/docs/#built-ins), etc.
+See the [Tera Documentation](https://keats.github.io/tera/#templates) for more information about [control structures](https://keats.github.io/tera/#control-structures), [built-ins filters](https://keats.github.io/tera/#built-ins), etc.
 
 ## Custom built-in filters
 


### PR DESCRIPTION
## Summary

- Use each commit's raw message when calculating the next version bump.
- Add coverage for conventional commits whose rendered message no longer includes the commit type.

## Why

Fixes #1570. A conventional commit like `ci: test` can be represented with `message: "test"` and `raw_message: "ci: test"`, so `no_increment_regex = "chore|ci|docs"` was not applied to the commit type during bump calculation.

## Validation

- `cargo test -p git-cliff-core no_increment_regex_skips_matching_commit_types -- --nocapture` — passed
- `cargo test -p git-cliff-core` — passed
- temp-repo smoke with `ci: test` after `v1.6.26`: `cargo run -q -p git-cliff -- --repository <repo> --config <config> --bumped-version` — returned `v1.6.26`
- `cargo +nightly fmt --all -- --check --verbose` — passed
- `cargo clippy -p git-cliff-core --tests --verbose` — passed
