### PR TITLE
fix(args): use default help literal color

### DIFF
--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -27,7 +27,6 @@ pub enum Sort {
 const STYLES: Styles = Styles::styled()
     .header(Ansi256Color(208).on_default().bold())
     .usage(Ansi256Color(208).on_default().bold())
-    .literal(AnsiColor::White.on_default())
     .placeholder(AnsiColor::Green.on_default());
 
 /// Command-line arguments to parse.


### PR DESCRIPTION
## Description

Use the default color for the literal strings in the help message, instead of hardcoding white.

## Motivation and Context

closes #1575

## How Has This Been Tested?

Locally.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
