### PR TITLE
feat(remote): add configurable HTTP timeout for metadata requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "git2",
  "glob",
  "http-cache-reqwest",
+ "humantime-serde",
  "indexmap",
  "next_version",
  "pretty_assertions",
@@ -1290,6 +1291,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
 ]
 
 [[package]]

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -70,6 +70,7 @@ indexmap = { version = "2.13.0", features = ["serde"] }
 toml = "0.9.8"
 next_version = "0.3.2"
 semver = "1.0.27"
+humantime-serde = "1.1.1"
 document-features = { version = "0.2.12", optional = true }
 reqwest = { workspace = true, optional = true }
 http-cache-reqwest = { version = "0.15.0", optional = true }

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -990,6 +990,7 @@ mod test {
                     token: None,
                     is_custom: false,
                     api_url: None,
+                    http_timeout: std::time::Duration::from_secs(30),
                     native_tls: None,
                 },
                 gitlab: Remote {
@@ -998,6 +999,7 @@ mod test {
                     token: None,
                     is_custom: false,
                     api_url: None,
+                    http_timeout: std::time::Duration::from_secs(30),
                     native_tls: None,
                 },
                 gitea: Remote {
@@ -1006,6 +1008,7 @@ mod test {
                     token: None,
                     is_custom: false,
                     api_url: None,
+                    http_timeout: std::time::Duration::from_secs(30),
                     native_tls: None,
                 },
                 bitbucket: Remote {
@@ -1014,6 +1017,7 @@ mod test {
                     token: None,
                     is_custom: false,
                     api_url: None,
+                    http_timeout: std::time::Duration::from_secs(30),
                     native_tls: None,
                 },
                 azure_devops: Remote {
@@ -1022,6 +1026,7 @@ mod test {
                     token: None,
                     is_custom: false,
                     api_url: None,
+                    http_timeout: std::time::Duration::from_secs(30),
                     native_tls: None,
                 },
             },

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::LazyLock;
-use std::{fmt, fs, time::Duration};
+use std::time::Duration;
+use std::{fmt, fs};
 
 use etcetera::{BaseStrategy, choose_base_strategy};
 use glob::Pattern;

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::LazyLock;
-use std::{fmt, fs};
+use std::{fmt, fs, time::Duration};
 
 use etcetera::{BaseStrategy, choose_base_strategy};
 use glob::Pattern;
@@ -288,6 +288,9 @@ pub struct Remote {
     pub is_custom: bool,
     /// Remote API URL.
     pub api_url: Option<String>,
+    /// HTTP request timeout.
+    #[serde(default = "default_http_timeout", with = "humantime_serde")]
+    pub http_timeout: Duration,
     /// Whether to use native TLS.
     pub native_tls: Option<bool>,
 }
@@ -295,6 +298,10 @@ pub struct Remote {
 /// Returns `true` for serde's `default` attribute.
 fn default_true() -> bool {
     true
+}
+
+fn default_http_timeout() -> Duration {
+    Duration::from_secs(30)
 }
 
 impl fmt::Display for Remote {
@@ -318,6 +325,7 @@ impl Remote {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: default_http_timeout(),
             native_tls: None,
         }
     }
@@ -642,6 +650,22 @@ mod test {
         assert!(!Remote::new("", "test").is_set());
         assert!(!Remote::new("test", "").is_set());
         assert!(!Remote::new("", "").is_set());
+        assert_eq!(Duration::from_secs(30), remote1.http_timeout);
+    }
+
+    #[test]
+    fn parse_remote_http_timeout() -> Result<()> {
+        let config = Config::from_str(
+            r#"
+                [remote.github]
+                owner = "orhun"
+                repo = "git-cliff"
+                http_timeout = "60s"
+            "#,
+        )?;
+
+        assert_eq!(Duration::from_secs(60), config.remote.github.http_timeout);
+        Ok(())
     }
 
     #[test]

--- a/git-cliff-core/src/remote/azure_devops.rs
+++ b/git-cliff-core/src/remote/azure_devops.rs
@@ -325,6 +325,7 @@ mod test {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: std::time::Duration::from_secs(30),
             native_tls: None,
         };
 
@@ -344,6 +345,7 @@ mod test {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: std::time::Duration::from_secs(30),
             native_tls: None,
         };
 
@@ -362,6 +364,7 @@ mod test {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: std::time::Duration::from_secs(30),
             native_tls: None,
         };
 
@@ -379,6 +382,7 @@ mod test {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: std::time::Duration::from_secs(30),
             native_tls: None,
         };
 
@@ -398,6 +402,7 @@ mod test {
             token: None,
             is_custom: false,
             api_url: None,
+            http_timeout: std::time::Duration::from_secs(30),
             native_tls: None,
         };
 

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -43,9 +43,6 @@ use crate::error::{Error, Result};
 /// This is needed since GitHub API does not accept empty user agent.
 pub(crate) const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
 
-/// Request timeout value in seconds.
-pub(crate) const REQUEST_TIMEOUT: u64 = 30;
-
 /// TCP keepalive value in seconds.
 pub(crate) const REQUEST_KEEP_ALIVE: u64 = 60;
 
@@ -116,7 +113,7 @@ impl Remote {
         }
         headers.insert(reqwest::header::USER_AGENT, USER_AGENT.parse()?);
         let client_builder = Client::builder()
-            .timeout(Duration::from_secs(REQUEST_TIMEOUT))
+            .timeout(self.http_timeout)
             .tcp_keepalive(Duration::from_secs(REQUEST_KEEP_ALIVE))
             .default_headers(headers)
             .tls_built_in_root_certs(false);

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -639,6 +639,7 @@ fn url_path_segments(url: &str) -> Result<Remote> {
         token: None,
         is_custom: false,
         api_url: None,
+        http_timeout: std::time::Duration::from_secs(30),
         native_tls: None,
     })
 }
@@ -670,6 +671,7 @@ fn ssh_path_segments(url: &str) -> Result<Remote> {
         token: None,
         is_custom: false,
         api_url: None,
+        http_timeout: std::time::Duration::from_secs(30),
         native_tls: None,
     })
 }
@@ -849,6 +851,7 @@ mod test {
                 token: None,
                 is_custom: false,
                 api_url: remote.api_url.clone(),
+                http_timeout: std::time::Duration::from_secs(30),
                 native_tls: None,
             },
             remote

--- a/git-cliff/src/args.rs
+++ b/git-cliff/src/args.rs
@@ -363,6 +363,16 @@ pub struct Opt {
 		hide = !cfg!(feature = "azure_devops"),
 	)]
     pub azure_devops_repo: Option<RemoteValue>,
+    /// Sets the HTTP timeout for remote metadata requests in seconds.
+    #[arg(
+		long,
+		help_heading = "REMOTE OPTIONS",
+		env = "GIT_CLIFF_HTTP_TIMEOUT",
+		value_name = "SECS",
+		hide = !cfg!(feature = "remote"),
+		value_parser = clap::value_parser!(u64)
+	)]
+    pub http_timeout: Option<u64>,
     /// Sets the commit range to process.
     #[arg(value_name = "RANGE", help_heading = Some("ARGS"))]
     pub range: Option<String>,

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -680,6 +680,14 @@ pub fn run_with_changelog_modifier<'a>(
             .token
             .clone_from(&args.azure_devops_token);
     }
+    if let Some(http_timeout) = args.http_timeout {
+        let timeout = std::time::Duration::from_secs(http_timeout);
+        config.remote.github.http_timeout = timeout;
+        config.remote.gitlab.http_timeout = timeout;
+        config.remote.gitea.http_timeout = timeout;
+        config.remote.bitbucket.http_timeout = timeout;
+        config.remote.azure_devops.http_timeout = timeout;
+    }
     if args.offline {
         config.remote.offline = args.offline;
     }

--- a/website/docs/configuration/remote.md
+++ b/website/docs/configuration/remote.md
@@ -56,6 +56,19 @@ Same applies for GitLab/Bitbucket with `--gitlab-token`/`--gitea-token`/`--bitbu
 
 Sets the API URL for a particular remote.
 
+### http_timeout
+
+Sets the HTTP request timeout for remote metadata fetches.
+
+This value is a duration, for example:
+
+```toml
+[remote.github]
+http_timeout = "60s"
+```
+
+You can also override it from the CLI with `--http-timeout <SECS>` or via the `GIT_CLIFF_HTTP_TIMEOUT` environment variable.
+
 ### native_tls
 
 When set to `true`, the TLS certificates are loaded from the platform's native certificate store.
@@ -85,5 +98,6 @@ owner = "archlinux"
 repo = "arch-repro-status"
 api_url = "https://gitlab.archlinux.org/api/v4"
 token = "deadbeef"
+http_timeout = "60s"
 native_tls = false
 ```

--- a/website/docs/usage/args.md
+++ b/website/docs/usage/args.md
@@ -66,6 +66,7 @@ git-cliff [FLAGS] [OPTIONS] [--] [RANGE]
     --bitbucket-repo <OWNER/REPO>     Sets the Bitbucket repository [env: BITBUCKET_REPO=]
     --azure-devops-token <TOKEN>      Sets the Azure DevOps API token [env: AZURE_DEVOPS_TOKEN]
     --azure-devops-repo <OWNER/REPO>  Sets the Azure DevOps repository [env: AZURE_DEVOPS_REPO=]
+    --http-timeout <SECS>             Sets the HTTP timeout for remote metadata requests [env: GIT_CLIFF_HTTP_TIMEOUT=]
     --offline                         Disable network access for remote repositories [env: GIT_CLIFF_OFFLINE]
 ```
 


### PR DESCRIPTION
## Description

Adds configurable HTTP request timeout to the configuration / CLI arguments.

```toml
[remote.github]
http_timeout = "60s"
```

## Motivation and Context

closes #1544

## How Has This Been Tested?

Locally

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
