### PR TITLE
docs(website): correct global configuration paths

### DIFF
--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -16,24 +16,29 @@ The configuration schema is published on [SchemaStore](https://www.schemastore.o
 
 :::
 
-It looks for the following configuration files in this order:
+It looks for the following project configuration files in this order:
 
 - `cliff.toml`
 - `.cliff.toml`
 - `.config/cliff.toml`
-- `$HOME/cliff.toml`
-- `$HOME/.cliff.toml`
-- `$HOME/.config/cliff.toml`
 
 If no configuration file is found in the current directory, it will search the parent directories.
 
-### Home Directory
+### Global Configuration
 
-The `$HOME` directory is dependent on the platform. For example:
+The global configuration file is located at:
 
-- on Linux: `/home/<user>`
-- on Windows: `C:\Users\<user>\AppData\Roaming`
-- on macOS: `/Users/<user>/Library/Application Support`
+```text
+<CONFIG_DIR>/git-cliff/cliff.toml
+```
+
+`<CONFIG_DIR>` is the `config_dir()` returned by [`etcetera`](https://github.com/lunacookies/etcetera)'s default base strategy and depends on the platform:
+
+- Linux: `$XDG_CONFIG_HOME`, or `~/.config`
+- macOS: `$XDG_CONFIG_HOME`, or `~/.config`
+- Windows: `%APPDATA%` (typically `~\AppData\Roaming`)
+
+On macOS, the legacy `~/Library/Application Support/git-cliff/cliff.toml` path is also supported for backwards compatibility.
 
 ## Environment Configuration Overrides
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix the global configuration path documentation by clarifying that the configuration directory is derived from `etcetera` while preserving the legacy macOS path.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The documentation incorrectly described platform configuration directories as `$HOME` and listed unsupported global paths.

Closes #1586

https://github.com/orhun/git-cliff/blob/89247f4f956b0877be5d96f2bd1857d08c79abf7/git-cliff-core/src/config.rs#L538-L543


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
