### PR TITLE
fix(git): match directory include/exclude patterns on Windows

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::path::{self, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 use std::sync::LazyLock;
 
@@ -330,7 +330,9 @@ impl Repository {
     /// It removes the leading `./` and adds `**` to the end if the pattern is a
     /// directory.
     fn normalize_pattern(pattern: Pattern) -> Pattern {
-        let star_added = if pattern.as_str().ends_with(path::MAIN_SEPARATOR) {
+        // glob patterns and git's diff paths always use '/', whatever the host
+        // OS, so this must not be `path::MAIN_SEPARATOR`
+        let star_added = if pattern.as_str().ends_with('/') {
             Pattern::new(&format!("{pattern}**")).expect("failed to add '**' to the end of glob")
         } else {
             pattern
@@ -1191,6 +1193,20 @@ mod test {
             before,
             "no .git-blame-ignore-revs file present"
         );
+    }
+
+    #[test]
+    fn test_normalize_pattern() {
+        let normalize = |input: &str| {
+            Repository::normalize_pattern(Pattern::new(input).expect("valid pattern"))
+                .as_str()
+                .to_string()
+        };
+
+        assert_eq!(normalize("dir/"), "dir/**");
+        assert_eq!(normalize("./dir/"), "dir/**");
+        assert_eq!(normalize("./file.txt"), "file.txt");
+        assert_eq!(normalize("dir/file.txt"), "dir/file.txt");
     }
 
     #[test]

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -1031,7 +1031,7 @@ mod test {
         assert!(result.is_err());
         if let Err(error) = result {
             assert!(
-                format!("{error:?}").contains(
+                error.to_string().contains(
                     format!("could not find repository at '{}'", path.display()).as_str()
                 )
             );
@@ -1101,7 +1101,7 @@ mod test {
         assert!(result.is_err());
         if let Err(error) = result {
             assert!(
-                format!("{error:?}").contains(
+                error.to_string().contains(
                     format!("could not find repository at '{}'", path.display()).as_str()
                 )
             );


### PR DESCRIPTION
## Description

`normalize_pattern` decided whether a glob pattern refers to a directory by testing `pattern.as_str().ends_with(path::MAIN_SEPARATOR)`. Glob patterns and the paths git reports in a diff always use `/`, on every platform, but `MAIN_SEPARATOR` is `\` on Windows, so the test never matched there and the trailing `**` was never appended.

The effect is that `include`/`exclude` entries written as directories, like `docs/`, silently match nothing on Windows. No error, just an empty result. On Unix nothing changes, since `MAIN_SEPARATOR` is already `/`.

The second commit is separate and changes no behaviour. `propagate_error_if_no_repo_exist` and `propagate_error_if_no_repo_found` compared `format!("{error:?}")` against `path.display()`. Debug escapes backslashes and Display doesn't, so on Windows the assertion compared `\\` against `\`. They now go through `error.to_string()`.

## Motivation and Context

Found by running `cargo test -p git-cliff-core` on Windows, where three tests fail on a clean checkout. `test_should_retain_commit` already covers the `dir/` case, but it only fails on Windows, and the `test` job runs on `ubuntu-22.04` (Windows appears only in `cd.yml`, which builds release binaries and runs no tests), so this has never shown up in CI.

The new `test_normalize_pattern` asserts the output directly. It fails on Windows before this change and passes after; on Linux both versions behave identically, since `MAIN_SEPARATOR` is `/` there.

Fixes #1589.

## How Has This Been Tested?

Windows 11, stable Rust 1.96.1 for tests, nightly for rustfmt.

- `cargo test` — `git-cliff-core` goes from 66 passed / 3 failed to 69 passed / 0 failed; the rest of the workspace is unchanged.
- `cargo clippy --tests --verbose -- -D warnings` — nothing in `repo.rs`. The findings in `command.rs` and `changelog.rs` are identical on a clean `main`; `command.rs:57` only appears on Windows, because the one test in that module is `#[cfg(target_family = "unix")]` and `use super::*` is then unused.
- `cargo +nightly fmt --all -- --check` — clean.

`git_upstream_remote` reads the tracking config of the branch the working copy is on, so it fails on a local branch with no upstream yet and passes once pushed.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
