### PR TITLE
chore(clippy): remove redundant reference in format! argument

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -618,7 +618,7 @@ impl Repository {
             if branch.is_head() {
                 let upstream = &self.inner.branch_upstream_remote(&format!(
                     "refs/heads/{}",
-                    &branch.name()?.ok_or_else(|| Error::RepoError(String::from(
+                    branch.name()?.ok_or_else(|| Error::RepoError(String::from(
                         "branch name is not valid"
                     )))?
                 ))?;


### PR DESCRIPTION
## Description

`branch.name()?` is passed to `format!` by reference. clippy 1.97 flags that as `useless_borrows_in_formatting`, so this drops the `&`.

## Motivation and Context

The `Lints` job is currently failing on `main` because of it:

```
error: redundant reference in `format!` argument
   --> git-cliff-core/src/repo.rs:621:21
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
```

The lint is new in clippy 1.97, so nothing changed in the code, the toolchain moved. Run 30181888210 on `main` from 2026-07-26 shows it, and every run since fails the same way.

## How Has This Been Tested?

Rust 1.97.1 on Windows 11.

- `cargo clippy --tests -- -D warnings` — the `repo.rs` error is gone. What still fires locally is `command.rs:57` `unused import: super::*`, which only happens on Windows, since the single test in that module is `#[cfg(target_family = "unix")]`. It doesn't appear on the Linux runners, which is why `Lints` reports just the one error.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo test` — same results as on `main`. The Windows-only failures there are unrelated and covered in #1593.

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other — lint fix, to get the `Lints` job passing again

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
