### PR TITLE
fix(remote): use the default HTTP timeout for unconfigured remotes

### DIFF
--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -275,7 +275,7 @@ impl RemoteConfig {
 }
 
 /// A single remote.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Remote {
     /// Owner of the remote.
     pub owner: String,
@@ -305,6 +305,22 @@ fn default_http_timeout() -> Duration {
     Duration::from_secs(30)
 }
 
+/// This is implemented manually to avoid deriving a zero [`Remote::http_timeout`]
+/// which would make every request time out immediately.
+impl Default for Remote {
+    fn default() -> Self {
+        Self {
+            owner: String::new(),
+            repo: String::new(),
+            token: None,
+            is_custom: false,
+            api_url: None,
+            http_timeout: default_http_timeout(),
+            native_tls: None,
+        }
+    }
+}
+
 impl fmt::Display for Remote {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", self.owner, self.repo)
@@ -323,11 +339,7 @@ impl Remote {
         Self {
             owner: owner.into(),
             repo: repo.into(),
-            token: None,
-            is_custom: false,
-            api_url: None,
-            http_timeout: default_http_timeout(),
-            native_tls: None,
+            ..Default::default()
         }
     }
 
@@ -652,6 +664,23 @@ mod test {
         assert!(!Remote::new("test", "").is_set());
         assert!(!Remote::new("", "").is_set());
         assert_eq!(Duration::from_secs(30), remote1.http_timeout);
+    }
+
+    #[test]
+    fn default_remote_http_timeout() -> Result<()> {
+        assert_eq!(default_http_timeout(), Remote::default().http_timeout);
+
+        // remotes that are not present in the configuration file are still
+        // expected to have a usable timeout.
+        let config = Config::from_str(
+            r#"
+                [changelog]
+                body = "test"
+            "#,
+        )?;
+        assert_eq!(default_http_timeout(), config.remote.github.http_timeout);
+        assert_eq!(default_http_timeout(), config.remote.gitlab.http_timeout);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fix for https://github.com/orhun/git-cliff/issues/1596

## Motivation and Context

`Remote` derived `Default`, so `http_timeout` was `Duration::ZERO` unless the field went through serde. Any configuration file without a `[remote.*]` table (e.g. the default configuration) therefore ended up with a zero timeout, which made every remote request fail instantly with "operation timed out", such as when the remote is set via `--github-repo`.

Implement `Default` manually so the default timeout is used in that case as well.

## How Has This Been Tested?

Unittest

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
