### PR TITLE
fix(changelog): fall through to the next parser when a commit field is missing

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -351,10 +351,14 @@ impl Commit<'_> {
             if let (Some(field_name), Some(pattern_regex)) =
                 (parser.field.as_ref(), parser.pattern.as_ref())
             {
+                let field_present;
                 let values = if field_name == "body" {
+                    field_present = true;
                     vec![body.clone()].into_iter().collect()
                 } else {
-                    tera::dotted_pointer(&lookup_context, field_name).and_then(|v| match v {
+                    let field_value = tera::dotted_pointer(&lookup_context, field_name);
+                    field_present = field_value.is_some();
+                    field_value.and_then(|v| match v {
                         Value::String(s) => Some(vec![s.clone()]),
                         Value::Number(_) | Value::Bool(_) | Value::Null => {
                             Some(vec![v.to_string()])
@@ -386,10 +390,19 @@ impl Commit<'_> {
                         }
                     }
                     None => {
-                        return Err(AppError::FieldError(format!(
-                            "field '{field_name}' is missing or has unsupported type (expected a \
-                             String, Number, Bool, or Null — or an Array of these scalar values)",
-                        )));
+                        if field_present {
+                            return Err(AppError::FieldError(format!(
+                                "field '{field_name}' is missing or has unsupported type \
+                                 (expected a String, Number, Bool, or Null — or an Array of these \
+                                 scalar values)",
+                            )));
+                        }
+                        // The field is genuinely absent on this commit (e.g.
+                        // `remote.pr_labels` when `remote` is `None`), so this parser
+                        // cannot decide it: skip only this field criterion and let the
+                        // rest of the parser (and the remaining parsers) decide. A
+                        // present-but-unsupported `Value::Object` field still errors
+                        // above. See orhun/git-cliff#1598.
                     }
                 }
             }
@@ -975,6 +988,51 @@ Refs: #123
             "Expected error when using unsupported field `remote`, but got Ok"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn parse_commit_missing_field_falls_through_to_next_parser() -> Result<()> {
+        let commit = Commit::new(
+            String::from("8f55e69eba6e6ce811ace32bd84cc82215673cb6"),
+            String::from("feat: first feature"),
+        );
+        // `commit.remote` is `None` by default (this is a LOCAL / non-PR commit),
+        // so `remote.pr_labels` cannot be resolved — exactly the orhun/git-cliff#1598
+        // scenario. The first parser must be skipped (not abort the chain) so the
+        // catch-all parser below can still match and group the commit.
+        let parsers = [
+            CommitParser {
+                sha: None,
+                message: None,
+                body: None,
+                footer: None,
+                group: Some(String::from("Bug fixes")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: Some(String::from("remote.pr_labels")),
+                pattern: Regex::new("bug").ok(),
+            },
+            CommitParser {
+                sha: None,
+                message: Some(Regex::new(".*")?),
+                body: None,
+                footer: None,
+                group: Some(String::from("Miscellaneous")),
+                default_scope: None,
+                scope: None,
+                skip: None,
+                field: None,
+                pattern: None,
+            },
+        ];
+        let parsed = commit.parse(&parsers, false, false)?;
+        assert_eq!(
+            Some(String::from("Miscellaneous")),
+            parsed.group,
+            "a missing field on parser #1 must fall through to the catch-all parser #2"
+        );
         Ok(())
     }
 

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -998,8 +998,8 @@ Refs: #123
             String::from("feat: first feature"),
         );
         // `commit.remote` is `None` by default (this is a LOCAL / non-PR commit),
-        // so `remote.pr_labels` cannot be resolved — exactly the orhun/git-cliff#1598
-        // scenario. The first parser must be skipped (not abort the chain) so the
+        // so `remote.pr_labels` cannot be resolved.
+        // The first parser must be skipped (not abort the chain) so the
         // catch-all parser below can still match and group the commit.
         let parsers = [
             CommitParser {

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -329,7 +329,7 @@ impl Commit<'_> {
         let lookup_context = serde_json::to_value(&self).map_err(|e| {
             AppError::FieldError(format!("failed to convert context into value: {e}",))
         })?;
-        for parser in parsers {
+        'parsers: for parser in parsers {
             let mut regex_checks = Vec::new();
             if let Some(message_regex) = parser.message.as_ref() {
                 regex_checks.push((message_regex, self.message.clone()));
@@ -351,17 +351,18 @@ impl Commit<'_> {
             if let (Some(field_name), Some(pattern_regex)) =
                 (parser.field.as_ref(), parser.pattern.as_ref())
             {
-                let field_present;
                 let values = if field_name == "body" {
-                    field_present = true;
                     vec![body.clone()].into_iter().collect()
                 } else {
-                    let field_value = tera::dotted_pointer(&lookup_context, field_name);
-                    field_present = field_value.is_some();
-                    field_value.and_then(|v| match v {
+                    let Some(field_value) = tera::dotted_pointer(&lookup_context, field_name)
+                    else {
+                        tracing::trace!("Field '{field_name}' is absent; trying the next parser");
+                        continue 'parsers;
+                    };
+                    match field_value {
                         Value::String(s) => Some(vec![s.clone()]),
                         Value::Number(_) | Value::Bool(_) | Value::Null => {
-                            Some(vec![v.to_string()])
+                            Some(vec![field_value.to_string()])
                         }
                         Value::Array(arr) => {
                             let mut values = Vec::new();
@@ -377,7 +378,7 @@ impl Commit<'_> {
                             Some(values)
                         }
                         Value::Object(_) => None,
-                    })
+                    }
                 };
                 match values {
                     Some(values) => {
@@ -390,19 +391,10 @@ impl Commit<'_> {
                         }
                     }
                     None => {
-                        if field_present {
-                            return Err(AppError::FieldError(format!(
-                                "field '{field_name}' is missing or has unsupported type \
-                                 (expected a String, Number, Bool, or Null — or an Array of these \
-                                 scalar values)",
-                            )));
-                        }
-                        // The field is genuinely absent on this commit (e.g.
-                        // `remote.pr_labels` when `remote` is `None`), so this parser
-                        // cannot decide it: skip only this field criterion and let the
-                        // rest of the parser (and the remaining parsers) decide. A
-                        // present-but-unsupported `Value::Object` field still errors
-                        // above. See orhun/git-cliff#1598.
+                        return Err(AppError::FieldError(format!(
+                            "field '{field_name}' is missing or has unsupported type (expected a \
+                             String, Number, Bool, or Null — or an Array of these scalar values)",
+                        )));
                     }
                 }
             }
@@ -1004,7 +996,7 @@ Refs: #123
         let parsers = [
             CommitParser {
                 sha: None,
-                message: None,
+                message: Some(Regex::new("^feat")?),
                 body: None,
                 footer: None,
                 group: Some(String::from("Bug fixes")),


### PR DESCRIPTION
Closes #1598.

## Problem

When a commit parser references a field that is genuinely **absent** on a commit (e.g. `remote.pr_labels` on a local / non-PR commit where `remote` is `None`), the parser returned `FieldError` and aborted the whole parse — so a single field-based parser could prevent any later (catch-all) parser from grouping the commit. Reported in #1598: a local commit gets skipped by the commit parsers if one of them looks for a field that does not exist on it.

## Fix

Distinguish a **missing** field from a **present-but-unsupported-type** field:

- the field resolves to `None` because the path is absent → skip only this field criterion and let the rest of the parser (and the remaining parsers) decide;
- the field is present but has an unsupported type (e.g. a bare `Value::Object`) → still error, exactly as before.

So a local commit no longer aborts the chain when a parser looks for `remote.pr_labels`; the catch-all parser can still group it.

## Test

`parse_commit_missing_field_falls_through_to_next_parser` — a commit with `remote = None` and two parsers (field `remote.pr_labels`, then a catch-all) now groups via the catch-all instead of erroring. The existing `parse_commit_field` (present-but-`Object` → error) still passes, preserving that contract.

`cargo test -p git-cliff-core commit::test` → 9 passed; `cargo clippy --tests -D warnings` clean.
