### PR TITLE
fix(changelog): assign commits to releases by graph reachability

### DIFF
--- a/.github/fixtures/test-tag-assignment-merged-branch/cliff.toml
+++ b/.github/fixtures/test-tag-assignment-merged-branch/cliff.toml
@@ -1,0 +1,26 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[git]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^chore", group = "Miscellaneous Tasks" },
+]

--- a/.github/fixtures/test-tag-assignment-merged-branch/commit.sh
+++ b/.github/fixtures/test-tag-assignment-merged-branch/commit.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+# Regression test for https://github.com/orhun/git-cliff/issues/498
+#
+# When a feature branch diverges, gets a release tag on the main line, and is
+# then cross-merged, the linearized `git log` can list the feature commit
+# *before* the tag commit even though it is not an ancestor of the tag. The
+# commit must be assigned by graph reachability (it belongs to the release
+# whose tag can actually reach it), not by its position in the flat log.
+#
+# Graph (oldest at the bottom):
+#
+#   *   merge feature into main   (HEAD)
+#   |\
+#   | *   merge main into feature
+#   | |\
+#   | |/
+#   |/|
+#   * | important fix             (tag: v0.2.0)
+#   | * unreleased feature
+#   |/
+#   * initial commit              (tag: v0.1.0)
+#
+# "unreleased feature" is NOT an ancestor of v0.2.0, so it must stay unreleased.
+
+GIT_COMMITTER_DATE="2022-04-06 12:00:00" git commit --allow-empty -m "feat: initial commit"
+git tag v0.1.0
+MAIN=$(git rev-parse --abbrev-ref HEAD)
+
+# Diverge a feature branch from v0.1.0.
+git checkout -b feature
+GIT_COMMITTER_DATE="2022-04-06 12:00:01" git commit --allow-empty -m "feat: unreleased feature"
+
+# Advance the main line and cut the v0.2.0 release.
+git checkout "$MAIN"
+GIT_COMMITTER_DATE="2022-04-06 12:00:02" git commit --allow-empty -m "fix: important fix"
+git tag v0.2.0
+
+# Cross-merge the main line into the feature branch (e.g. to resolve conflicts).
+git checkout feature
+GIT_COMMITTER_DATE="2022-04-06 12:00:03" git merge --no-ff "$MAIN" -m "chore: merge main into feature"
+
+# Merge the feature branch back into the main line.
+git checkout "$MAIN"
+GIT_COMMITTER_DATE="2022-04-06 12:00:04" git merge --no-ff feature -m "chore: merge feature into main"

--- a/.github/fixtures/test-tag-assignment-merged-branch/expected.md
+++ b/.github/fixtures/test-tag-assignment-merged-branch/expected.md
@@ -1,0 +1,23 @@
+## [unreleased]
+
+### Features
+
+- Unreleased feature
+
+### Miscellaneous Tasks
+
+- Merge main into feature
+- Merge feature into main
+
+## [0.2.0] - 2022-04-06
+
+### Bug Fixes
+
+- Important fix
+
+## [0.1.0] - 2022-04-06
+
+### Features
+
+- Initial commit
+

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -138,6 +138,7 @@ jobs:
           - fixtures-name: test-remote-config
             command: --config-url "https://github.com/orhun/git-cliff/blob/main/.github/fixtures/new-fixture-template/cliff.toml?raw=true"
           - fixtures-name: test-topo-order-commits
+          - fixtures-name: test-tag-assignment-merged-branch
           - fixtures-name: test-commit-range
           - fixtures-name: test-commit-statistics
           - fixtures-name: test-commit-range-with-sort-commits

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
@@ -604,6 +605,52 @@ impl Repository {
             .into_iter()
             .map(|(a, b)| (a.id().to_string(), b))
             .collect())
+    }
+
+    /// Maps each commit id to the id of the tag that "owns" it.
+    ///
+    /// A commit is owned by the earliest tag (in `tags` order, which must be
+    /// oldest to newest) whose commit can reach it, i.e. the tag whose
+    /// `previous_tag..tag` range contains it. This assigns commits to releases
+    /// by graph reachability rather than by their position in the linearized
+    /// log, which can interleave diverged-then-merged branches
+    /// (<https://github.com/orhun/git-cliff/issues/498>).
+    ///
+    /// Only tags whose commit id is in `boundary_ids` (the commits actually in
+    /// the walk) are considered. Commits not reachable from any such tag are
+    /// absent from the map and should be treated as unreleased.
+    pub fn commit_tag_ownership(
+        &self,
+        tags: &IndexMap<String, Tag>,
+        boundary_ids: &HashSet<String>,
+    ) -> Result<HashMap<String, String>> {
+        let mut ownership = HashMap::new();
+        // Only tags that are part of the walked history can act as boundaries.
+        let tag_ids: Vec<&String> = tags
+            .keys()
+            .filter(|id| boundary_ids.contains(*id))
+            .collect();
+        for (index, tag_id) in tag_ids.iter().enumerate() {
+            let Ok(tag_oid) = Oid::from_str(tag_id) else {
+                continue;
+            };
+            let mut revwalk = self.inner.revwalk()?;
+            revwalk.push(tag_oid)?;
+            // Hide all previous (older) tags so that this walk only yields the
+            // commits belonging to this tag's release range.
+            for prev in &tag_ids[..index] {
+                if let Ok(prev_oid) = Oid::from_str(prev) {
+                    // Ignore errors from hiding unrelated histories.
+                    let _ = revwalk.hide(prev_oid);
+                }
+            }
+            for oid in revwalk.filter_map(StdResult::ok) {
+                ownership
+                    .entry(oid.to_string())
+                    .or_insert_with(|| (*tag_id).clone());
+            }
+        }
+        Ok(ownership)
     }
 
     /// Returns the remote of the upstream repository.

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -626,32 +626,31 @@ impl Repository {
     pub fn commit_tag_ownership(
         &self,
         tags: &IndexMap<String, Tag>,
-        boundary_ids: &HashSet<String>,
-    ) -> Result<HashMap<String, String>> {
+        boundary_ids: &HashSet<Oid>,
+    ) -> Result<HashMap<Oid, String>> {
         let mut ownership = HashMap::new();
         // Only tags that are part of the walked history can act as boundaries.
-        let tag_ids: Vec<&String> = tags
+        let tag_ids: Vec<(Oid, &String)> = tags
             .keys()
-            .filter(|id| boundary_ids.contains(*id))
+            .filter_map(|id| Oid::from_str(id).ok().map(|oid| (oid, id)))
+            .filter(|(oid, _)| boundary_ids.contains(oid))
             .collect();
-        for (index, tag_id) in tag_ids.iter().enumerate() {
-            let Ok(tag_oid) = Oid::from_str(tag_id) else {
-                continue;
-            };
+        for (index, (tag_oid, tag_id)) in tag_ids.iter().enumerate() {
             let mut revwalk = self.inner.revwalk()?;
-            revwalk.push(tag_oid)?;
+            revwalk.push(*tag_oid)?;
             // Hide all previous (older) tags so that this walk only yields the
             // commits belonging to this tag's release range.
-            for prev in &tag_ids[..index] {
-                if let Ok(prev_oid) = Oid::from_str(prev) {
-                    // Ignore errors from hiding unrelated histories.
-                    let _ = revwalk.hide(prev_oid);
-                }
+            for (prev_oid, _) in &tag_ids[..index] {
+                // Ignore errors from hiding unrelated histories.
+                let _ = revwalk.hide(*prev_oid);
             }
             for oid in revwalk.filter_map(StdResult::ok) {
-                ownership
-                    .entry(oid.to_string())
-                    .or_insert_with(|| (*tag_id).clone());
+                if boundary_ids.contains(&oid) {
+                    ownership.entry(oid).or_insert_with(|| (*tag_id).clone());
+                    if ownership.len() == boundary_ids.len() {
+                        return Ok(ownership);
+                    }
+                }
             }
         }
         Ok(ownership)

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -614,11 +614,15 @@ impl Repository {
     /// `previous_tag..tag` range contains it. This assigns commits to releases
     /// by graph reachability rather than by their position in the linearized
     /// log, which can interleave diverged-then-merged branches
-    /// (<https://github.com/orhun/git-cliff/issues/498>).
     ///
     /// Only tags whose commit id is in `boundary_ids` (the commits actually in
     /// the walk) are considered. Commits not reachable from any such tag are
     /// absent from the map and should be treated as unreleased.
+    ///
+    /// # Returns
+    ///
+    /// A map from each owned commit id to the commit id of its owning tag.
+    /// Commits that are not reachable from a considered tag are omitted.
     pub fn commit_tag_ownership(
         &self,
         tags: &IndexMap<String, Tag>,

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -349,7 +349,7 @@ fn process_repository<'a>(
     }
 
     // Assign commits to releases by graph reachability instead of their
-    // position in the linearized log (https://github.com/orhun/git-cliff/issues/498).
+    // position in the linearized log.
     // Only tags present in the walk can be release boundaries.
     let commit_ids: HashSet<String> = commits
         .iter()

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -10,7 +10,7 @@ pub mod args;
 /// Custom logger implementation.
 pub mod logger;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
@@ -351,21 +351,27 @@ fn process_repository<'a>(
     // Assign commits to releases by graph reachability instead of their
     // position in the linearized log.
     // Only tags present in the walk can be release boundaries.
-    let commit_ids: HashSet<String> = commits
-        .iter()
-        .map(|commit| commit.id().to_string())
-        .collect();
+    let commit_ids: HashSet<_> = commits.iter().map(|commit| commit.id()).collect();
     let ownership = repository.commit_tag_ownership(&tags, &commit_ids)?;
 
-    // Group commits by owning tag (oldest to newest), then unreleased, keeping
-    // each group oldest-first so the loop below closes releases in order.
+    // Group commits by owning tag in a single pass, keeping each group
+    // oldest-first. Unowned commits remain unreleased.
+    let mut groups: HashMap<&str, Vec<_>> = HashMap::new();
+    let mut unreleased = Vec::new();
+    for commit in commits.iter().rev() {
+        match ownership.get(&commit.id()) {
+            Some(tag_id) => groups.entry(tag_id).or_default().push(commit),
+            None => unreleased.push(commit),
+        }
+    }
+
+    // Emit tagged groups oldest to newest so the loop below closes releases in
+    // order, followed by the unreleased commits.
     let mut ordered_commits = Vec::with_capacity(commits.len());
     for tag_id in tags.keys() {
-        let mut group: Vec<_> = commits
-            .iter()
-            .rev()
-            .filter(|commit| ownership.get(&commit.id().to_string()) == Some(tag_id))
-            .collect();
+        let Some(mut group) = groups.remove(tag_id.as_str()) else {
+            continue;
+        };
         // The tagged commit is the release tip, so close the group with it.
         if let Some(pos) = group
             .iter()
@@ -376,12 +382,7 @@ fn process_repository<'a>(
         }
         ordered_commits.extend(group);
     }
-    ordered_commits.extend(
-        commits
-            .iter()
-            .rev()
-            .filter(|commit| !ownership.contains_key(&commit.id().to_string())),
-    );
+    ordered_commits.extend(unreleased);
 
     // Process releases.
     let mut previous_release = Release::default();

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -10,6 +10,7 @@ pub mod args;
 /// Custom logger implementation.
 pub mod logger;
 
+use std::collections::HashSet;
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, Write};
@@ -347,11 +348,46 @@ fn process_repository<'a>(
         }
     }
 
+    // Assign commits to releases by graph reachability instead of their
+    // position in the linearized log (https://github.com/orhun/git-cliff/issues/498).
+    // Only tags present in the walk can be release boundaries.
+    let commit_ids: HashSet<String> = commits
+        .iter()
+        .map(|commit| commit.id().to_string())
+        .collect();
+    let ownership = repository.commit_tag_ownership(&tags, &commit_ids)?;
+
+    // Group commits by owning tag (oldest to newest), then unreleased, keeping
+    // each group oldest-first so the loop below closes releases in order.
+    let mut ordered_commits = Vec::with_capacity(commits.len());
+    for tag_id in tags.keys() {
+        let mut group: Vec<_> = commits
+            .iter()
+            .rev()
+            .filter(|commit| ownership.get(&commit.id().to_string()) == Some(tag_id))
+            .collect();
+        // The tagged commit is the release tip, so close the group with it.
+        if let Some(pos) = group
+            .iter()
+            .position(|commit| commit.id().to_string() == *tag_id)
+        {
+            let tag_commit = group.remove(pos);
+            group.push(tag_commit);
+        }
+        ordered_commits.extend(group);
+    }
+    ordered_commits.extend(
+        commits
+            .iter()
+            .rev()
+            .filter(|commit| !ownership.contains_key(&commit.id().to_string())),
+    );
+
     // Process releases.
     let mut previous_release = Release::default();
     let mut first_processed_tag = None;
     let repository_path = repository.root_path()?.to_string_lossy().into_owned();
-    for git_commit in commits.iter().rev() {
+    for git_commit in ordered_commits {
         let release = releases.last_mut().unwrap();
         let mut commit = Commit::from(git_commit);
         commit.statistics = match repository.commit_statistics(git_commit) {


### PR DESCRIPTION
## Description

Commits were assigned to releases based on their position in the linearized `git log`, with a new release "cut" each time a tagged commit was crossed. When branches diverge and are later merged, that flat list interleaves commits from different branches, so a commit could be attributed to a tag it isn't actually part of.

This changes the assignment to use **graph reachability**: each commit is assigned to the earliest tag whose commit can actually reach it (the tag whose `previous_tag..tag` range contains it). Only tags whose commit is present in the walk are treated as release boundaries, so tags on branches that were never merged into the walked history cannot capture commits that should stay unreleased.

- New `Repository::commit_tag_ownership(&tags, &boundary_ids)` in `git-cliff-core` computes the commit→owning-tag map via `revwalk` with previous tags hidden.
- `process_repository` groups the (already filtered) commits by their owning tag before building releases, instead of splitting the linear log positionally.

## Motivation and Context

Fixes the long-standing mis-assignment of commits to tags when branches diverge and merge. `git-cliff --unreleased` / `--current` already produced correct results because those use `prev..tag` range semantics; the full run did not, because it linearized the whole history and split it by position.

Closes #498

## How Has This Been Tested?

- Added a regression fixture `test-tag-assignment-merged-branch` reproducing the cross-merge scenario (a feature commit that is not an ancestor of the release tag). It fails on current `git-cliff` (the feature commit lands in the release) and passes with this change (it stays unreleased). Registered in the `test-fixtures.yml` matrix.
- Verified on a real repository with ~150 tags and many cross-branch merges: the only differences vs. the released binary were two commits moving out of a release that (confirmed via `git merge-base --is-ancestor`) does not actually contain them, into the release whose range does — matching `git log <prev>..<tag>`.
- `cargo test` — all existing + new tests pass.
- `cargo +nightly fmt --all -- --check --verbose` and `cargo clippy --tests --verbose -- -D warnings` — clean.

Environment: macOS; stable Rust for build/test; nightly `rustfmt` (`1.99.0-nightly`) per CONTRIBUTING.

## Screenshots / Logs (if applicable)

Minimal reproduction (feature branch cross-merged after a release tag):

Before (incorrect) — "unreleased feature" wrongly placed in `0.2.0`:
```
## [0.2.0]
### Features
- Unreleased feature   <-- wrong
### Bug Fixes
- Important fix
```

After (correct):
```
## [unreleased]
### Features
- Unreleased feature
## [0.2.0]
### Bug Fixes
- Important fix
```

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`