### PR TITLE
fix(changelog): replace dynamic headers when prepending

### DIFF
--- a/.github/fixtures/test-group-by-scope-filter/expected.md
+++ b/.github/fixtures/test-group-by-scope-filter/expected.md
@@ -17,3 +17,4 @@
 
 - add feature 2
 
+<!-- END OF HEADER -->

--- a/.github/fixtures/test-group-by-scope-filter/expected.md
+++ b/.github/fixtures/test-group-by-scope-filter/expected.md
@@ -17,4 +17,4 @@
 
 - add feature 2
 
-<!-- END OF HEADER -->
+<!-- git-cliff: end of header -->

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -3,6 +3,9 @@
 
 
 [changelog]
+# A stable marker placed after context-dependent headers. Required for reliably
+# replacing the previous header when using `--prepend`.
+header_marker = "<!-- git-cliff: end of header -->"
 # A Tera template to be rendered for each release in the changelog.
 # See https://keats.github.io/tera/docs/#introduction
 body = """

--- a/config/cliff.toml
+++ b/config/cliff.toml
@@ -3,8 +3,7 @@
 
 
 [changelog]
-# A stable marker placed after context-dependent headers. Required for reliably
-# replacing the previous header when using `--prepend`.
+# Used by `--prepend` to remove the previous header.
 header_marker = "<!-- git-cliff: end of header -->"
 # A Tera template to be rendered for each release in the changelog.
 # See https://keats.github.io/tera/docs/#introduction

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -19,8 +19,6 @@ use crate::remote::gitlab::GitLabClient;
 use crate::summary::Summary;
 use crate::template::Template;
 
-const END_OF_HEADER_MARKER: &str = "<!-- END OF HEADER -->";
-
 /// Changelog generator.
 #[derive(Debug)]
 pub struct Changelog<'a> {
@@ -601,10 +599,11 @@ impl<'a> Changelog<'a> {
             )?;
             // Static headers can still be removed by their configured text. Dynamic
             // headers need a stable boundary because their previous rendering may differ.
-            let write_result = if header_template.variables.is_empty() {
+            let header_marker = &self.config.changelog.header_marker;
+            let write_result = if header_template.variables.is_empty() || header_marker.is_empty() {
                 writeln!(out, "{header}")
             } else {
-                writeln!(out, "{header}\n{END_OF_HEADER_MARKER}")
+                writeln!(out, "{header}\n{header_marker}")
             };
             if let Err(e) = write_result {
                 if e.kind() != std::io::ErrorKind::BrokenPipe {
@@ -657,8 +656,14 @@ impl<'a> Changelog<'a> {
     pub fn prepend<W: Write + ?Sized>(&self, mut changelog: String, out: &mut W) -> Result<()> {
         crate::set_progress_message!("Generating and prepending the changelog");
         tracing::debug!("Generating changelog and prepending");
-        if let Some(marker_index) = changelog.find(END_OF_HEADER_MARKER) {
-            changelog.replace_range(..marker_index + END_OF_HEADER_MARKER.len(), "");
+        let header_marker = &self.config.changelog.header_marker;
+        let marker_index = if header_marker.is_empty() {
+            None
+        } else {
+            changelog.find(header_marker)
+        };
+        if let Some(marker_index) = marker_index {
+            changelog.replace_range(..marker_index + header_marker.len(), "");
         } else if let Some(header) = &self.config.changelog.header {
             changelog = changelog.replacen(header, "", 1);
         }
@@ -785,6 +790,7 @@ mod test {
         let config = Config {
             changelog: ChangelogConfig {
                 header: Some(String::from("# Changelog")),
+                header_marker: String::from("<!-- git-cliff: end of header -->"),
                 body: String::from(
                     r#"{% if version %}
 				## Release [{{ version }}] - {{ timestamp | date(format="%Y-%m-%d") }} - ({{ repository }})
@@ -1659,6 +1665,7 @@ chore(deps): fix broken deps
         let config = Config {
             changelog: ChangelogConfig {
                 header: None,
+                header_marker: String::from("<!-- git-cliff: end of header -->"),
                 body: String::from(
                     "{% for entry in commits | commit_groups(groups=commit_parsers_groups) %}### \
                      {{ entry.group }}\n{% for commit in entry.commits %}- {{ commit.message \
@@ -1883,7 +1890,7 @@ chore(deps): fix broken deps
         old_changelog.add_context("project", "old")?;
         let mut existing = Vec::new();
         old_changelog.generate(&mut existing)?;
-        assert!(str::from_utf8(&existing)?.contains(END_OF_HEADER_MARKER));
+        assert!(str::from_utf8(&existing)?.contains(&old_changelog.config.changelog.header_marker));
 
         config.changelog.body = String::from("## New Release");
         let mut new_changelog = Changelog::build(vec![releases[0].clone()], config)?;
@@ -1892,7 +1899,36 @@ chore(deps): fix broken deps
         new_changelog.prepend(str::from_utf8(&existing)?.to_owned(), &mut out)?;
 
         assert_eq!(
-            "# Changelog for new\n<!-- END OF HEADER -->\n## New Release\n## Old Release",
+            "# Changelog for new\n<!-- git-cliff: end of header -->\n## New Release\n## Old \
+             Release",
+            str::from_utf8(&out).unwrap_or_default()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_uses_configured_header_marker() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = Some(String::from("# Changelog for {{ project }}"));
+        config.changelog.header_marker = String::from("<!-- custom header boundary -->");
+        config.changelog.body = String::from("## Old Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let mut old_changelog = Changelog::build(vec![releases[0].clone()], config.clone())?;
+        old_changelog.add_context("project", "old")?;
+        let mut existing = Vec::new();
+        old_changelog.generate(&mut existing)?;
+
+        config.changelog.body = String::from("## New Release");
+        let mut new_changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        new_changelog.add_context("project", "new")?;
+        let mut out = Vec::new();
+        new_changelog.prepend(str::from_utf8(&existing)?.to_owned(), &mut out)?;
+
+        assert_eq!(
+            "# Changelog for new\n<!-- custom header boundary -->\n## New Release\n## Old Release",
             str::from_utf8(&out).unwrap_or_default()
         );
 

--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -19,6 +19,8 @@ use crate::remote::gitlab::GitLabClient;
 use crate::summary::Summary;
 use crate::template::Template;
 
+const END_OF_HEADER_MARKER: &str = "<!-- END OF HEADER -->";
+
 /// Changelog generator.
 #[derive(Debug)]
 pub struct Changelog<'a> {
@@ -590,17 +592,20 @@ impl<'a> Changelog<'a> {
         let postprocessors = self.config.changelog.postprocessors.clone();
 
         if let Some(header_template) = &self.header_template {
-            let write_result = writeln!(
-                out,
-                "{}",
-                header_template.render(
-                    &Releases {
-                        releases: &self.releases,
-                    },
-                    Some(&self.additional_context),
-                    &postprocessors,
-                )?
-            );
+            let header = header_template.render(
+                &Releases {
+                    releases: &self.releases,
+                },
+                Some(&self.additional_context),
+                &postprocessors,
+            )?;
+            // Static headers can still be removed by their configured text. Dynamic
+            // headers need a stable boundary because their previous rendering may differ.
+            let write_result = if header_template.variables.is_empty() {
+                writeln!(out, "{header}")
+            } else {
+                writeln!(out, "{header}\n{END_OF_HEADER_MARKER}")
+            };
             if let Err(e) = write_result {
                 if e.kind() != std::io::ErrorKind::BrokenPipe {
                     return Err(e.into());
@@ -652,7 +657,9 @@ impl<'a> Changelog<'a> {
     pub fn prepend<W: Write + ?Sized>(&self, mut changelog: String, out: &mut W) -> Result<()> {
         crate::set_progress_message!("Generating and prepending the changelog");
         tracing::debug!("Generating changelog and prepending");
-        if let Some(header) = &self.config.changelog.header {
+        if let Some(marker_index) = changelog.find(END_OF_HEADER_MARKER) {
+            changelog.replace_range(..marker_index + END_OF_HEADER_MARKER.len(), "");
+        } else if let Some(header) = &self.config.changelog.header {
             changelog = changelog.replacen(header, "", 1);
         }
         let mut generated = Vec::new();
@@ -1858,6 +1865,34 @@ chore(deps): fix broken deps
 
         assert_eq!(
             "## New Release\n## Old Release",
+            str::from_utf8(&out).unwrap_or_default()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn changelog_prepend_replaces_a_changed_header_template() -> Result<()> {
+        let (mut config, releases) = get_test_data();
+        config.changelog.header = Some(String::from("# Changelog for {{ project }}"));
+        config.changelog.body = String::from("## Old Release");
+        config.changelog.footer = None;
+        config.changelog.postprocessors = Vec::new();
+
+        let mut old_changelog = Changelog::build(vec![releases[0].clone()], config.clone())?;
+        old_changelog.add_context("project", "old")?;
+        let mut existing = Vec::new();
+        old_changelog.generate(&mut existing)?;
+        assert!(str::from_utf8(&existing)?.contains(END_OF_HEADER_MARKER));
+
+        config.changelog.body = String::from("## New Release");
+        let mut new_changelog = Changelog::build(vec![releases[0].clone()], config)?;
+        new_changelog.add_context("project", "new")?;
+        let mut out = Vec::new();
+        new_changelog.prepend(str::from_utf8(&existing)?.to_owned(), &mut out)?;
+
+        assert_eq!(
+            "# Changelog for new\n<!-- END OF HEADER -->\n## New Release\n## Old Release",
             str::from_utf8(&out).unwrap_or_default()
         );
 

--- a/git-cliff-core/src/config.rs
+++ b/git-cliff-core/src/config.rs
@@ -64,10 +64,13 @@ pub struct Config {
 }
 
 /// Changelog configuration.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChangelogConfig {
     /// Changelog header.
     pub header: Option<String>,
+    /// Marker written after a dynamic changelog header.
+    #[serde(default = "default_header_marker")]
+    pub header_marker: String,
     /// Changelog body, template.
     pub body: String,
     /// Changelog footer.
@@ -80,6 +83,25 @@ pub struct ChangelogConfig {
     pub postprocessors: Vec<TextProcessor>,
     /// Output file path.
     pub output: Option<PathBuf>,
+}
+
+fn default_header_marker() -> String {
+    String::from("<!-- git-cliff: end of header -->")
+}
+
+impl Default for ChangelogConfig {
+    fn default() -> Self {
+        Self {
+            header: None,
+            header_marker: default_header_marker(),
+            body: String::new(),
+            footer: None,
+            trim: false,
+            render_always: false,
+            postprocessors: Vec::new(),
+            output: None,
+        }
+    }
 }
 
 /// Git configuration
@@ -664,6 +686,21 @@ mod test {
         assert!(!Remote::new("test", "").is_set());
         assert!(!Remote::new("", "").is_set());
         assert_eq!(Duration::from_secs(30), remote1.http_timeout);
+    }
+
+    #[test]
+    fn parse_changelog_header_marker() -> Result<()> {
+        let config: Config = r#"
+            [changelog]
+            header_marker = "<!-- custom header boundary -->"
+        "#
+        .parse()?;
+
+        assert_eq!(
+            "<!-- custom header boundary -->",
+            config.changelog.header_marker
+        );
+        Ok(())
     }
 
     #[test]

--- a/git-cliff-core/tests/integration_test.rs
+++ b/git-cliff-core/tests/integration_test.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 #[test]
 fn generate_changelog() -> Result<()> {
     let changelog_config = ChangelogConfig {
+        header_marker: String::from("<!-- git-cliff: end of header -->"),
         header: Some(String::from("this is a changelog")),
         body: String::from(
             r#"

--- a/website/docs/configuration/changelog.md
+++ b/website/docs/configuration/changelog.md
@@ -9,6 +9,7 @@ This section contains the configuration options for changelog generation.
 ```toml
 [changelog]
 header = "Changelog"
+header_marker = "<!-- git-cliff: end of header -->"
 body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | upper_first }}
@@ -31,6 +32,20 @@ See [templating](/docs/category/templating) for more detail.
 Header template that will be rendered and added to the beginning of the changelog.
 
 The template context contains the full list of releases in the variable `releases`. See [templating](/docs/category/templating) for more details.
+
+### header_marker
+
+A stable marker written after a header that uses template variables. When
+prepending releases with `--prepend`, **git-cliff** uses this marker to remove
+the previously rendered header even if its content has changed.
+
+```toml
+[changelog]
+header_marker = "<!-- git-cliff: end of header -->"
+```
+
+Static headers continue to be matched by their configured text and do not emit
+the marker. Set it to an empty string to disable the marker.
 
 ### body
 


### PR DESCRIPTION
## Description

- add a stable HTML comment boundary after context-dependent rendered headers
- remove an existing rendered header through that boundary before prepending new releases
- preserve the existing configured-text fallback and unchanged output for static headers

## Motivation and Context

A header template can render differently between releases, so its configured source text and its latest rendering cannot reliably identify the header already present in a changelog. That leaves the previous header embedded between the newly generated releases and older entries.

The marker provides a stable boundary while remaining invisible in rendered Markdown. It is emitted only for headers that depend on template variables, so static changelog output is unaffected.

Fixes #712

## How Has This Been Tested?

- `cargo +1.97.1 test -p git-cliff-core changelog_prepend --no-default-features` (4 passed)
- `cargo +1.97.1 test -p git-cliff-core --no-default-features` (51 unit tests, 1 integration test, and doctests passed)
- `cargo +1.97.1 clippy -p git-cliff-core --lib --all-features -- -D warnings`
- `rustfmt +nightly --edition 2024 --check git-cliff-core/src/changelog.rs`
- `git diff --check`

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (not applicable; no public option or API changed).
- [x] I have formatted the code with rustfmt.
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with clippy.
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing relevant tests passed.