### PR TITLE
fix(bump): evaluate increment regexes against the commit subject only

### DIFF
--- a/git-cliff-core/src/changelog.rs
+++ b/git-cliff-core/src/changelog.rs
@@ -566,7 +566,10 @@ impl<'a> Changelog<'a> {
         crate::set_progress_message!("Bumping the version for unreleased changes");
         if let Some(ref mut last_release) = self.releases.iter_mut().next() {
             if last_release.version.is_none() {
-                let next = last_release.calculate_next_version_with_config(&self.config.bump)?;
+                let next = last_release.calculate_next_version_from_commits(
+                    &self.config.bump,
+                    self.config.git.conventional_commits,
+                )?;
                 tracing::debug!("Bumping the version to {}", next.version);
                 last_release.bump_type = next.bump_type;
                 last_release.version = Some(next.version.clone());

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -118,6 +118,17 @@ impl Release<'_> {
     ///
     /// It uses the given bump version configuration to calculate the next
     /// version.
+    pub(super) fn calculate_next_version_with_config(&self, config: &Bump) -> Result<NextVersion> {
+        self.calculate_next_version_from_commits(config, true)
+    }
+
+    /// Calculates the next version based on the commits.
+    ///
+    /// When `conventional_commits` is disabled, bump evaluation uses only the
+    /// commit subject (the first line), so commit body text cannot trigger an
+    /// unintended version bump through the custom increment regular
+    /// expressions (`custom_major_increment_regex`,
+    /// `custom_minor_increment_regex` and `no_increment_regex`).
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -128,7 +139,11 @@ impl Release<'_> {
             )
         )
     )]
-    pub(super) fn calculate_next_version_with_config(&self, config: &Bump) -> Result<NextVersion> {
+    pub(super) fn calculate_next_version_from_commits(
+        &self,
+        config: &Bump,
+        conventional_commits: bool,
+    ) -> Result<NextVersion> {
         crate::set_progress_message!(
             "Calculating the next version from commits with custom bump rules"
         );
@@ -190,7 +205,19 @@ impl Release<'_> {
                             &old_semver,
                             self.commits
                                 .iter()
-                                .map(|commit| commit.raw_message().trim_end().to_string())
+                                .map(|commit| {
+                                    let message = commit.raw_message().trim_end();
+                                    // When conventional commits are disabled,
+                                    // evaluate the bump regular expressions
+                                    // against the commit subject only, so body
+                                    // text cannot trigger an unintended version
+                                    // bump.
+                                    if conventional_commits {
+                                        message.to_string()
+                                    } else {
+                                        message.lines().next().unwrap_or_default().to_string()
+                                    }
+                                })
                                 .collect::<Vec<String>>(),
                         );
                         let bump_type = determine_bump_type(&old_semver, &new_semver);
@@ -519,6 +546,54 @@ mod test {
         })?;
         assert_eq!("1.0.0", result.version);
         assert_eq!(None, result.bump_type);
+
+        Ok(())
+    }
+
+    #[test]
+    fn custom_increment_regex_matches_subject_only_when_non_conventional() -> Result<()> {
+        fn build_release<'a>(version: &str, commits: &'a [&str]) -> Release<'a> {
+            Release {
+                version: None,
+                commits: commits
+                    .iter()
+                    .map(|v| Commit::from((*v).to_string()))
+                    .collect(),
+                previous: Some(Box::new(Release {
+                    version: Some(String::from(version)),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+        }
+
+        let bump = Bump {
+            custom_major_increment_regex: Some(String::from("breaking")),
+            custom_minor_increment_regex: Some(String::from("feat")),
+            ..Default::default()
+        };
+
+        // The subject does not match any increment regex, but the body mentions
+        // both "breaking" and "feat". With conventional commits disabled, the
+        // body must be ignored so only a patch bump is produced.
+        // (https://github.com/orhun/git-cliff/issues/1476)
+        let release = build_release("1.0.0", &[
+            "fix a bug\n\nThe body mentions breaking and feat as plain words."
+        ]);
+        let result = release.calculate_next_version_from_commits(&bump, false)?;
+        assert_eq!("1.0.1", result.version);
+        assert_eq!(Some(BumpType::Patch), result.bump_type);
+
+        // Sanity: a matching subject still drives the expected bump.
+        let release = build_release("1.0.0", &["breaking: remove v1 endpoints\n\nBody text."]);
+        let result = release.calculate_next_version_from_commits(&bump, false)?;
+        assert_eq!("2.0.0", result.version);
+        assert_eq!(Some(BumpType::Major), result.bump_type);
+
+        let release = build_release("1.0.0", &["feat: add a thing\n\nBody text."]);
+        let result = release.calculate_next_version_from_commits(&bump, false)?;
+        assert_eq!("1.1.0", result.version);
+        assert_eq!(Some(BumpType::Minor), result.bump_type);
 
         Ok(())
     }

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -599,6 +599,55 @@ mod test {
     }
 
     #[test]
+    fn no_increment_regex_uses_subject_only_when_non_conventional() -> Result<()> {
+        fn build_release<'a>(version: &str, commits: &'a [&str]) -> Release<'a> {
+            Release {
+                version: None,
+                commits: commits
+                    .iter()
+                    .map(|v| Commit::from((*v).to_string()))
+                    .collect(),
+                previous: Some(Box::new(Release {
+                    version: Some(String::from(version)),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+        }
+
+        // The subject does not match `no_increment_regex`, but the body does.
+        // With conventional commits disabled, the body must be ignored so the
+        // commit is not suppressed and still produces a patch bump.
+        // (https://github.com/orhun/git-cliff/issues/1476)
+        let release = build_release("1.0.0", &[
+            "fix a bug\n\nThis is a chore cleanup and must not skip the bump."
+        ]);
+        let result = release.calculate_next_version_from_commits(
+            &Bump {
+                no_increment_regex: Some(String::from("chore")),
+                ..Default::default()
+            },
+            false,
+        )?;
+        assert_eq!("1.0.1", result.version);
+        assert_eq!(Some(BumpType::Patch), result.bump_type);
+
+        // Sanity: a matching subject still suppresses the bump.
+        let release = build_release("1.0.0", &["chore cleanup\n\nBody text."]);
+        let result = release.calculate_next_version_from_commits(
+            &Bump {
+                no_increment_regex: Some(String::from("chore")),
+                ..Default::default()
+            },
+            false,
+        )?;
+        assert_eq!("1.0.0", result.version);
+        assert_eq!(None, result.bump_type);
+
+        Ok(())
+    }
+
+    #[test]
     fn bump_version_type() -> Result<()> {
         fn build_release<'a>(version: &str, commits: &'a [&str]) -> Release<'a> {
             Release {

--- a/website/docs/usage/bump-version.md
+++ b/website/docs/usage/bump-version.md
@@ -24,6 +24,12 @@ How it works is that for a semantic versioning such as `<MAJOR>.<MINOR>.<PATCH>`
 
 :::note
 
+For unconventional commits, only the subject line (the first line) is used while calculating the next version.
+
+:::
+
+:::note
+
 The next version is checked against the regex value set by [tag_pattern](/docs/configuration/git#tag_pattern).
 
 :::


### PR DESCRIPTION
## Description

When `conventional_commits` is disabled, `calculate_next_version_with_config` forwarded each commit's **full** raw message (subject + body) to `next_version::VersionUpdater::increment`. The `next_version` crate applies `custom_major_increment_regex`, `custom_minor_increment_regex` and `no_increment_regex` against the whole string for any commit that does not parse as conventional, so a commit whose **body** happens to contain the configured token drove a wrong version bump.

Concrete case from #1476: with `conventional_commits = false` and `custom_major_increment_regex = "breaking"`, a commit `fix: real bug\n\nnotes: breaking change discussed` bumps to a **major** release (the body word "breaking" matches) instead of a **patch** release.

This PR threads the `conventional_commits` flag into the bump calculation. When conventional commits are disabled, only the commit **subject** (first line) is handed to the version calculator, so body text can no longer trigger an increment. The conventional path is untouched — the full message is still passed when `conventional_commits = true`, so `BREAKING CHANGE:` footer detection and `!`-flag handling behave exactly as before.

The change reuses the existing `calculate_next_version_with_config` entry point (now a thin delegate that passes `conventional_commits = true`, preserving every existing caller/test) and moves the real work into `calculate_next_version_from_commits(config, conventional_commits)`, which `Changelog::bump_version` calls with `self.config.git.conventional_commits`.

## Motivation and Context

A body-driven major/minor bump is a silent, severe defect in a release tool: the resulting version is plausible enough to ship before anyone notices. This fixes the root cause described in #1476.

Note: the `^`-anchored reproducer from the original report no longer reproduces on `main` (it resolves through conventional-commit type matching), but the unanchored — and far more common — form of the bug remains, and this addresses the same root cause for both.

Closes #1476

## How Has This Been Tested?

- New unit test `release::test::custom_increment_regex_matches_subject_only_when_non_conventional`: a commit whose subject matches no regex but whose body contains both `breaking` and `feat`. With the fix it yields a **patch** bump (`1.0.1`); without the fix it yields a **major** bump (`2.0.0`). The test also asserts that a matching subject still drives major/minor bumps.
- Verified red → green: the new test fails on `main` behavior (`assert 1.0.1 == 2.0.0`) and passes on this branch.
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --tests -- -D warnings`
- `cargo test -p git-cliff-core --lib` (all `release::` tests pass)
- Manual CLI reproduction with `--with-commit` of the exact multiline messages from the issue: body-only `breaking`/`feat` no longer bump the version; `BREAKING CHANGE:` footer detection in the default (conventional) path still produces a major bump.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
