### PR TITLE
feat(remote)!: expose the pull request author as `commit.remote.pr_author`

### DIFF
--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -787,6 +787,7 @@ Refs: #123
         };
         commit.remote = Some(crate::contributor::RemoteContributor {
             username: None,
+            pr_author: None,
             pr_title: Some("feat: do something".to_string()),
             pr_number: None,
             pr_numbers: vec![],
@@ -849,6 +850,7 @@ Refs: #123
         };
         commit.remote = Some(crate::contributor::RemoteContributor {
             username: None,
+            pr_author: None,
             pr_title: Some("feat: do something".to_string()),
             pr_number: None,
             pr_numbers: vec![],
@@ -1070,6 +1072,7 @@ Refs: #123
         };
         commit.remote = Some(crate::contributor::RemoteContributor {
             username: None,
+            pr_author: None,
             pr_title: Some("feat: do something".to_string()),
             pr_number: None,
             pr_numbers: vec![],

--- a/git-cliff-core/src/contributor.rs
+++ b/git-cliff-core/src/contributor.rs
@@ -7,6 +7,12 @@ use serde::{Deserialize, Serialize};
 pub struct RemoteContributor {
     /// Username.
     pub username: Option<String>,
+    /// Account that opened the pull request.
+    ///
+    /// Unlike `username`, this is not resolved from the commit author. Only set
+    /// per commit; contributor entries leave it empty because they are
+    /// deduplicated by `username`.
+    pub pr_author: Option<String>,
     /// Title of the pull request.
     pub pr_title: Option<String>,
     /// The pull request that the user created.

--- a/git-cliff-core/src/release.rs
+++ b/git-cliff-core/src/release.rs
@@ -873,6 +873,9 @@ mod test {
             .collect(),
             vec![
                 GitHubPullRequest {
+                    user: Some(GitHubCommitAuthor {
+                        login: Some(String::from("author-1")),
+                    }),
                     title: Some(String::from("1")),
                     number: 42,
                     merge_commit_sha: Some(String::from(
@@ -883,6 +886,9 @@ mod test {
                     }],
                 },
                 GitHubPullRequest {
+                    user: Some(GitHubCommitAuthor {
+                        login: Some(String::from("author-2")),
+                    }),
                     title: Some(String::from("2")),
                     number: 66,
                     merge_commit_sha: Some(String::from(
@@ -893,6 +899,9 @@ mod test {
                     }],
                 },
                 GitHubPullRequest {
+                    user: Some(GitHubCommitAuthor {
+                        login: Some(String::from("author-3")),
+                    }),
                     title: Some(String::from("3")),
                     number: 53,
                     merge_commit_sha: Some(String::from(
@@ -903,6 +912,9 @@ mod test {
                     }],
                 },
                 GitHubPullRequest {
+                    user: Some(GitHubCommitAuthor {
+                        login: Some(String::from("author-4")),
+                    }),
                     title: Some(String::from("4")),
                     number: 1_000,
                     merge_commit_sha: Some(String::from(
@@ -913,6 +925,9 @@ mod test {
                     }],
                 },
                 GitHubPullRequest {
+                    user: Some(GitHubCommitAuthor {
+                        login: Some(String::from("author-5")),
+                    }),
                     title: Some(String::from("5")),
                     number: 999_999,
                     merge_commit_sha: Some(String::from(
@@ -934,6 +949,7 @@ mod test {
                 message: String::from("add github integration"),
                 github: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -942,6 +958,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -955,6 +972,7 @@ mod test {
                 message: String::from("fix github integration"),
                 github: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-2")),
                     pr_title: Some(String::from("2")),
                     pr_number: Some(66),
                     pr_numbers: vec![],
@@ -963,6 +981,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-2")),
                     pr_title: Some(String::from("2")),
                     pr_number: Some(66),
                     pr_numbers: vec![],
@@ -976,6 +995,7 @@ mod test {
                 message: String::from("update metadata"),
                 github: RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: Some(String::from("author-3")),
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![],
@@ -984,6 +1004,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: Some(String::from("author-3")),
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![],
@@ -997,6 +1018,7 @@ mod test {
                 message: String::from("do some stuff"),
                 github: RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: Some(String::from("author-4")),
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![],
@@ -1005,6 +1027,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: Some(String::from("author-4")),
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![],
@@ -1018,6 +1041,7 @@ mod test {
                 message: String::from("alright"),
                 github: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-5")),
                     pr_title: Some(String::from("5")),
                     pr_number: Some(999_999),
                     pr_numbers: vec![],
@@ -1026,6 +1050,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-5")),
                     pr_title: Some(String::from("5")),
                     pr_number: Some(999_999),
                     pr_numbers: vec![],
@@ -1039,6 +1064,7 @@ mod test {
                 message: String::from("should be fine"),
                 github: RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1047,6 +1073,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1064,6 +1091,7 @@ mod test {
             contributors: vec![
                 RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1072,6 +1100,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![42, 66, 999_999],
@@ -1080,6 +1109,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![53],
@@ -1088,6 +1118,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![1_000],
@@ -1300,7 +1331,7 @@ mod test {
                 author: Some(GitLabUser {
                     id: Some(1),
                     name: Some(String::from("42")),
-                    username: Some(String::from("42")),
+                    username: Some(String::from("author-1")),
                     state: Some(String::from("42")),
                     avatar_url: None,
                     web_url: Some(String::from("42")),
@@ -1318,6 +1349,7 @@ mod test {
                 message: String::from("add github integration"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![],
@@ -1326,6 +1358,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![],
@@ -1339,6 +1372,7 @@ mod test {
                 message: String::from("fix github integration"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1347,6 +1381,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1360,6 +1395,7 @@ mod test {
                 message: String::from("update metadata"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1368,6 +1404,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1381,6 +1418,7 @@ mod test {
                 message: String::from("do some stuff"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1389,6 +1427,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1402,6 +1441,7 @@ mod test {
                 message: String::from("alright"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1410,6 +1450,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1423,6 +1464,7 @@ mod test {
                 message: String::from("should be fine"),
                 gitlab: RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1431,6 +1473,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1448,6 +1491,7 @@ mod test {
             contributors: vec![
                 RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![1],
@@ -1456,6 +1500,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1464,6 +1509,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1472,6 +1518,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1615,6 +1662,9 @@ mod test {
             .collect(),
             vec![
                 GiteaPullRequest {
+                    user: Some(GiteaCommitAuthor {
+                        login: Some(String::from("author-1")),
+                    }),
                     title: Some(String::from("1")),
                     number: 42,
                     merge_commit_sha: Some(String::from(
@@ -1625,6 +1675,9 @@ mod test {
                     }],
                 },
                 GiteaPullRequest {
+                    user: Some(GiteaCommitAuthor {
+                        login: Some(String::from("author-2")),
+                    }),
                     title: Some(String::from("2")),
                     number: 66,
                     merge_commit_sha: Some(String::from(
@@ -1635,6 +1688,9 @@ mod test {
                     }],
                 },
                 GiteaPullRequest {
+                    user: Some(GiteaCommitAuthor {
+                        login: Some(String::from("author-3")),
+                    }),
                     title: Some(String::from("3")),
                     number: 53,
                     merge_commit_sha: Some(String::from(
@@ -1645,6 +1701,9 @@ mod test {
                     }],
                 },
                 GiteaPullRequest {
+                    user: Some(GiteaCommitAuthor {
+                        login: Some(String::from("author-4")),
+                    }),
                     title: Some(String::from("4")),
                     number: 1_000,
                     merge_commit_sha: Some(String::from(
@@ -1655,6 +1714,9 @@ mod test {
                     }],
                 },
                 GiteaPullRequest {
+                    user: Some(GiteaCommitAuthor {
+                        login: Some(String::from("author-5")),
+                    }),
                     title: Some(String::from("5")),
                     number: 999_999,
                     merge_commit_sha: Some(String::from(
@@ -1676,6 +1738,7 @@ mod test {
                 message: String::from("add github integration"),
                 gitea: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -1684,6 +1747,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -1697,6 +1761,7 @@ mod test {
                 message: String::from("fix github integration"),
                 gitea: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-2")),
                     pr_title: Some(String::from("2")),
                     pr_number: Some(66),
                     pr_numbers: vec![],
@@ -1705,6 +1770,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-2")),
                     pr_title: Some(String::from("2")),
                     pr_number: Some(66),
                     pr_numbers: vec![],
@@ -1718,6 +1784,7 @@ mod test {
                 message: String::from("update metadata"),
                 gitea: RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: Some(String::from("author-3")),
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![],
@@ -1726,6 +1793,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: Some(String::from("author-3")),
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![],
@@ -1739,6 +1807,7 @@ mod test {
                 message: String::from("do some stuff"),
                 gitea: RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: Some(String::from("author-4")),
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![],
@@ -1747,6 +1816,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: Some(String::from("author-4")),
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![],
@@ -1760,6 +1830,7 @@ mod test {
                 message: String::from("alright"),
                 gitea: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-5")),
                     pr_title: Some(String::from("5")),
                     pr_number: Some(999_999),
                     pr_numbers: vec![],
@@ -1768,6 +1839,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-5")),
                     pr_title: Some(String::from("5")),
                     pr_number: Some(999_999),
                     pr_numbers: vec![],
@@ -1781,6 +1853,7 @@ mod test {
                 message: String::from("should be fine"),
                 gitea: RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1789,6 +1862,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1806,6 +1880,7 @@ mod test {
             contributors: vec![
                 RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -1814,6 +1889,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![42, 66, 999_999],
@@ -1822,6 +1898,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: Some(String::from("3")),
                     pr_number: Some(53),
                     pr_numbers: vec![53],
@@ -1830,6 +1907,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: Some(String::from("4")),
                     pr_number: Some(1_000),
                     pr_numbers: vec![1_000],
@@ -1913,6 +1991,7 @@ mod test {
                     hash: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("orhun")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:14:39+03:00"),
                 },
@@ -1920,6 +1999,7 @@ mod test {
                     hash: String::from("21f6aa587fcb772de13f2fde0e92697c51f84162"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("orhun")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:12:19+03:00"),
                 },
@@ -1927,6 +2007,7 @@ mod test {
                     hash: String::from("35d8c6b6329ecbcf131d7df02f93c3bbc5ba5973"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("nuhro")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:07:23+03:00"),
                 },
@@ -1934,6 +2015,7 @@ mod test {
                     hash: String::from("4d3ffe4753b923f4d7807c490e650e6624a12074"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("awesome_contributor")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:05:10+03:00"),
                 },
@@ -1941,6 +2023,7 @@ mod test {
                     hash: String::from("5a55e92e5a62dc5bf9872ffb2566959fad98bd05"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("orhun")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:03:30+03:00"),
                 },
@@ -1948,6 +2031,7 @@ mod test {
                     hash: String::from("6c34967147560ea09658776d4901709139b4ad66"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("someone")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:00:38+03:00"),
                 },
@@ -1955,6 +2039,7 @@ mod test {
                     hash: String::from("0c34967147560e809658776d4901709139b4ad68"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("idk")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-18T15:00:01+03:00"),
                 },
@@ -1962,6 +2047,7 @@ mod test {
                     hash: String::from("kk34967147560e809658776d4901709139b4ad68"),
                     author: Some(BitbucketCommitAuthor {
                         login: Some(String::from("orhun")),
+                        nickname: None,
                     }),
                     date: String::from("2021-07-14T21:25:24+03:00"),
                 },
@@ -1974,6 +2060,7 @@ mod test {
                 title: Some(String::from("1")),
                 author: BitbucketCommitAuthor {
                     login: Some(String::from("42")),
+                    nickname: Some(String::from("author-1")),
                 },
                 merge_commit: BitbucketPullRequestMergeCommit {
                     // Bitbucket merge commits returned in short format
@@ -1988,6 +2075,7 @@ mod test {
                 message: String::from("add bitbucket integration"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![],
@@ -1996,6 +2084,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![],
@@ -2009,6 +2098,7 @@ mod test {
                 message: String::from("fix bitbucket integration"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2017,6 +2107,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2030,6 +2121,7 @@ mod test {
                 message: String::from("update metadata"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2038,6 +2130,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2051,6 +2144,7 @@ mod test {
                 message: String::from("do some stuff"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2059,6 +2153,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2072,6 +2167,7 @@ mod test {
                 message: String::from("alright"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2080,6 +2176,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2093,6 +2190,7 @@ mod test {
                 message: String::from("should be fine"),
                 bitbucket: RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2101,6 +2199,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2118,6 +2217,7 @@ mod test {
             contributors: vec![
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2126,6 +2226,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2134,6 +2235,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2142,6 +2244,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: Some(String::from("1")),
                     pr_number: Some(1),
                     pr_numbers: vec![1],
@@ -2160,7 +2263,7 @@ mod test {
     fn update_azure_devops_metadata() -> Result<()> {
         use crate::remote::azure_devops::{
             AzureDevOpsCommit, AzureDevOpsCommitAuthor, AzureDevOpsCommitRef,
-            AzureDevOpsPullRequest,
+            AzureDevOpsPullRequest, AzureDevOpsUser,
         };
 
         let mut release = Release {
@@ -2301,7 +2404,10 @@ mod test {
                 pull_request_id: 42,
                 title: Some(String::from("1")),
                 status: String::from("completed"),
-                created_by: None,
+                created_by: Some(AzureDevOpsUser {
+                    display_name: Some(String::from("author-1")),
+                    unique_name: None,
+                }),
                 last_merge_commit: Some(AzureDevOpsCommitRef {
                     commit_id: Some(String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071")),
                 }),
@@ -2315,6 +2421,7 @@ mod test {
                 message: String::from("add azure devops integration"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -2323,6 +2430,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: Some(String::from("author-1")),
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![],
@@ -2336,6 +2444,7 @@ mod test {
                 message: String::from("fix azure devops integration"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2344,6 +2453,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2357,6 +2467,7 @@ mod test {
                 message: String::from("update metadata"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2365,6 +2476,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2378,6 +2490,7 @@ mod test {
                 message: String::from("do some stuff"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2386,6 +2499,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2399,6 +2513,7 @@ mod test {
                 message: String::from("alright"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2407,6 +2522,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2420,6 +2536,7 @@ mod test {
                 message: String::from("should be fine"),
                 azure_devops: RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2428,6 +2545,7 @@ mod test {
                 },
                 remote: Some(RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2448,6 +2566,7 @@ mod test {
             contributors: vec![
                 RemoteContributor {
                     username: Some(String::from("nuhro")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2456,6 +2575,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("awesome_contributor")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2464,6 +2584,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("someone")),
+                    pr_author: None,
                     pr_title: None,
                     pr_number: None,
                     pr_numbers: vec![],
@@ -2472,6 +2593,7 @@ mod test {
                 },
                 RemoteContributor {
                     username: Some(String::from("orhun")),
+                    pr_author: None,
                     pr_title: Some(String::from("1")),
                     pr_number: Some(42),
                     pr_numbers: vec![42],

--- a/git-cliff-core/src/remote/azure_devops.rs
+++ b/git-cliff-core/src/remote/azure_devops.rs
@@ -100,6 +100,10 @@ impl RemotePullRequest for AzureDevOpsPullRequest {
         self.title.clone()
     }
 
+    fn author(&self) -> Option<String> {
+        self.created_by.clone().and_then(|v| v.display_name)
+    }
+
     fn labels(&self) -> Vec<String> {
         self.labels.iter().map(|v| v.name.clone()).collect()
     }
@@ -426,5 +430,40 @@ mod test {
         };
 
         assert_eq!(None, pr.merge_commit());
+    }
+
+    #[test]
+    fn pull_request_author() {
+        let pull_request: AzureDevOpsPullRequest = serde_json::from_str(
+            r#"{
+                "pullRequestId": 42,
+                "title": "feat: add pr_author",
+                "status": "completed",
+                "createdBy": { "displayName": "contributor" },
+                "lastMergeCommit": {
+                    "commitId": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071"
+                }
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(Some(String::from("contributor")), pull_request.author());
+    }
+
+    #[test]
+    fn pull_request_author_missing() {
+        let pull_request: AzureDevOpsPullRequest = serde_json::from_str(
+            r#"{
+                "pullRequestId": 42,
+                "title": "feat: add pr_author",
+                "status": "completed",
+                "lastMergeCommit": {
+                    "commitId": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071"
+                }
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(None, pull_request.author());
     }
 }

--- a/git-cliff-core/src/remote/bitbucket.rs
+++ b/git-cliff-core/src/remote/bitbucket.rs
@@ -58,12 +58,17 @@ pub struct BitbucketPagination<T> {
     pub values: Vec<T>,
 }
 
-/// Author of the commit.
+/// Author of a commit or a pull request.
+///
+/// A commit carries the raw `Name <email>` string; a pull request carries an
+/// account object, whose handle is `nickname`.
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BitbucketCommitAuthor {
-    /// Username.
+    /// Raw `Name <email>` string, set on commit authors.
     #[serde(rename = "raw")]
     pub login: Option<String>,
+    /// Account handle, set on pull request authors.
+    pub nickname: Option<String>,
 }
 
 /// Label of the pull request.
@@ -101,6 +106,10 @@ impl RemotePullRequest for BitbucketPullRequest {
 
     fn title(&self) -> Option<String> {
         self.title.clone()
+    }
+
+    fn author(&self) -> Option<String> {
+        self.author.nickname.clone()
     }
 
     fn labels(&self) -> Vec<String> {
@@ -267,7 +276,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::remote::RemoteCommit;
+    use crate::remote::{RemoteCommit, RemotePullRequest};
 
     #[test]
     fn timestamp() {
@@ -275,10 +284,41 @@ mod test {
             hash: String::from("1d244937ee6ceb8e0314a4a201ba93a7a61f2071"),
             author: Some(BitbucketCommitAuthor {
                 login: Some(String::from("orhun")),
+                nickname: None,
             }),
             date: String::from("2021-07-18T15:14:39+03:00"),
         };
 
         assert_eq!(Some(1_626_610_479), remote_commit.timestamp());
+    }
+
+    #[test]
+    fn pull_request_author() {
+        let pull_request: BitbucketPullRequest = serde_json::from_str(
+            r#"{
+                "id": 42,
+                "title": "feat: add pr_author",
+                "merge_commit": { "hash": "1d244937ee6c" },
+                "author": { "nickname": "contributor" }
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(Some(String::from("contributor")), pull_request.author());
+    }
+
+    #[test]
+    fn pull_request_author_missing() {
+        let pull_request: BitbucketPullRequest = serde_json::from_str(
+            r#"{
+                "id": 42,
+                "title": "feat: add pr_author",
+                "merge_commit": { "hash": "1d244937ee6c" },
+                "author": {}
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(None, pull_request.author());
     }
 }

--- a/git-cliff-core/src/remote/gitea.rs
+++ b/git-cliff-core/src/remote/gitea.rs
@@ -57,6 +57,8 @@ pub struct GiteaPullRequest {
     pub number: i64,
     /// Pull request title.
     pub title: Option<String>,
+    /// Account that opened the pull request.
+    pub user: Option<GiteaCommitAuthor>,
     /// SHA of the merge commit.
     pub merge_commit_sha: Option<String>,
     /// Labels of the pull request.
@@ -70,6 +72,10 @@ impl RemotePullRequest for GiteaPullRequest {
 
     fn title(&self) -> Option<String> {
         self.title.clone()
+    }
+
+    fn author(&self) -> Option<String> {
+        self.user.clone().and_then(|v| v.login)
     }
 
     fn labels(&self) -> Vec<String> {
@@ -234,7 +240,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::remote::RemoteCommit;
+    use crate::remote::{RemoteCommit, RemotePullRequest};
 
     #[test]
     fn timestamp() {
@@ -247,5 +253,36 @@ mod test {
         };
 
         assert_eq!(Some(1_626_610_479), remote_commit.timestamp());
+    }
+
+    #[test]
+    fn pull_request_author() {
+        let pull_request: GiteaPullRequest = serde_json::from_str(
+            r#"{
+                "number": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": [],
+                "user": { "login": "contributor" }
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(Some(String::from("contributor")), pull_request.author());
+    }
+
+    #[test]
+    fn pull_request_author_missing() {
+        let pull_request: GiteaPullRequest = serde_json::from_str(
+            r#"{
+                "number": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": []
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(None, pull_request.author());
     }
 }

--- a/git-cliff-core/src/remote/github.rs
+++ b/git-cliff-core/src/remote/github.rs
@@ -73,6 +73,8 @@ pub struct GitHubPullRequest {
     pub number: i64,
     /// Pull request title.
     pub title: Option<String>,
+    /// Account that opened the pull request.
+    pub user: Option<GitHubCommitAuthor>,
     /// SHA of the merge commit.
     pub merge_commit_sha: Option<String>,
     /// Labels of the pull request.
@@ -86,6 +88,10 @@ impl RemotePullRequest for GitHubPullRequest {
 
     fn title(&self) -> Option<String> {
         self.title.clone()
+    }
+
+    fn author(&self) -> Option<String> {
+        self.user.clone().and_then(|v| v.login)
     }
 
     fn labels(&self) -> Vec<String> {
@@ -250,7 +256,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::remote::RemoteCommit;
+    use crate::remote::{RemoteCommit, RemotePullRequest};
 
     #[test]
     fn timestamp() {
@@ -267,5 +273,37 @@ mod test {
         };
 
         assert_eq!(Some(1_626_610_479), remote_commit.timestamp());
+    }
+
+    #[test]
+    fn pull_request_author() {
+        let pull_request: GitHubPullRequest = serde_json::from_str(
+            r#"{
+                "number": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": [],
+                "user": { "login": "contributor" }
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(Some(String::from("contributor")), pull_request.author());
+    }
+
+    #[test]
+    fn pull_request_author_missing() {
+        let pull_request: GitHubPullRequest = serde_json::from_str(
+            r#"{
+                "number": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": [],
+                "user": null
+            }"#,
+        )
+        .expect("failed to deserialize pull request");
+
+        assert_eq!(None, pull_request.author());
     }
 }

--- a/git-cliff-core/src/remote/gitlab.rs
+++ b/git-cliff-core/src/remote/gitlab.rs
@@ -128,6 +128,10 @@ impl RemotePullRequest for GitLabMergeRequest {
         self.title.clone()
     }
 
+    fn author(&self) -> Option<String> {
+        self.author.clone().and_then(|v| v.username)
+    }
+
     fn labels(&self) -> Vec<String> {
         self.labels.clone()
     }
@@ -341,6 +345,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
+    use crate::remote::RemotePullRequest;
 
     #[test]
     fn gitlab_project_url_encodes_owner() {
@@ -384,5 +389,36 @@ mod test {
             ..Default::default()
         };
         assert!(mr.merge_commit().is_some());
+    }
+
+    #[test]
+    fn pull_request_author() {
+        let merge_request: GitLabMergeRequest = serde_json::from_str(
+            r#"{
+                "iid": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": [],
+                "author": { "username": "contributor" }
+            }"#,
+        )
+        .expect("failed to deserialize merge request");
+
+        assert_eq!(Some(String::from("contributor")), merge_request.author());
+    }
+
+    #[test]
+    fn merge_request_author_missing() {
+        let merge_request: GitLabMergeRequest = serde_json::from_str(
+            r#"{
+                "iid": 42,
+                "title": "feat: add pr_author",
+                "merge_commit_sha": "1d244937ee6ceb8e0314a4a201ba93a7a61f2071",
+                "labels": []
+            }"#,
+        )
+        .expect("failed to deserialize merge request");
+
+        assert_eq!(None, merge_request.author());
     }
 }

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -73,6 +73,12 @@ pub trait RemotePullRequest: DynClone {
     fn number(&self) -> i64;
     /// Title.
     fn title(&self) -> Option<String>;
+    /// Account that opened the pull request.
+    ///
+    /// Defaults to `None` for backends that cannot provide it.
+    fn author(&self) -> Option<String> {
+        None
+    }
     /// Labels of the pull request.
     fn labels(&self) -> Vec<String>;
     /// Merge commit SHA.
@@ -209,6 +215,7 @@ macro_rules! update_release_metadata {
                                 pr.merge_commit() == sha_short
                         });
                         commit.$remote.username = v.username();
+                        commit.$remote.pr_author = pull_request.and_then(|v| v.author());
                         commit.$remote.pr_number = pull_request.map(|v| v.number());
                         commit.$remote.pr_title = pull_request.and_then(|v| v.title().clone());
                         commit.$remote.pr_labels =
@@ -225,6 +232,11 @@ macro_rules! update_release_metadata {
                         } else {
                             contributors.push(RemoteContributor {
                                 username: commit.$remote.username.clone(),
+                                // Left empty: contributors are deduplicated by
+                                // username, so one entry can cover pull requests
+                                // opened by different people. `pr_author` is only
+                                // unambiguous per commit.
+                                pr_author: None,
                                 pr_title: commit.$remote.pr_title.clone(),
                                 pr_number: commit.$remote.pr_number,
                                 pr_numbers: commit.$remote.pr_number.into_iter().collect(),

--- a/website/docs/integration/azure-devops.md
+++ b/website/docs/integration/azure-devops.md
@@ -116,6 +116,7 @@ For each commit, Azure DevOps related values are added as a nested object (named
 
   "remote": {
     "username": "orhun",
+    "pr_author": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
     "pr_labels": ["enhancement"],
@@ -140,6 +141,19 @@ This will result in:
 - feat(commit): add merge_commit flag to the context by @orhun in #389
 - feat(args): set `CHANGELOG.md` as default missing value for output option by @sh-cho in #354
 ```
+
+`username` is resolved from the commit author, whereas `pr_author` is the account that
+opened the pull request. They can differ, so a template that wants to credit the contributor
+rather than whoever the commit resolves to can prefer `pr_author`. Note that Azure DevOps
+returns a display name (`createdBy.displayName`) rather than a mention handle, so it is not
+prefixed with `@`:
+
+```jinja2
+{% if commit.remote.pr_author or commit.remote.username %} by {{ commit.remote.pr_author | default(value=commit.remote.username) }}{% endif %}
+```
+
+The guard matters: `commit.remote` is absent for any commit the remote API did not return, and an
+unguarded lookup on it aborts the whole render.
 
 ### Contributors
 

--- a/website/docs/integration/bitbucket.md
+++ b/website/docs/integration/bitbucket.md
@@ -108,6 +108,7 @@ For each commit, Bitbucket related values are added as a nested object (named `r
 
   "remote": {
     "username": "orhun",
+    "pr_author": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
     "pr_labels": ["rust"],
@@ -132,6 +133,18 @@ The will result in:
 - feat(commit): add merge_commit flag to the context by @orhun in #389
 - feat(args): set `CHANGELOG.md` as default missing value for output option by @sh-cho in #354
 ```
+
+`username` is resolved from the commit author, whereas `pr_author` is the account that
+opened the pull request. On Bitbucket the two are different kinds of value: `pr_author` is the
+account's `nickname`, while `username` is the raw `Name <email>` string from the commit. Falling
+back therefore yields `@Name <email>` rather than a handle, so prefer `pr_author` on its own:
+
+```jinja2
+{% if commit.remote.pr_author %} by @{{ commit.remote.pr_author }}{% endif %}
+```
+
+The guard matters: `commit.remote` is absent for any commit the remote API did not return, and an
+unguarded lookup on it aborts the whole render.
 
 ### Contributors
 

--- a/website/docs/integration/gitea.md
+++ b/website/docs/integration/gitea.md
@@ -108,6 +108,7 @@ For each commit, Gitea related values are added as a nested object (named `remot
 
   "remote": {
     "username": "orhun",
+    "pr_author": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
     "pr_labels": ["rust"],
@@ -132,6 +133,17 @@ The will result in:
 - feat(commit): add merge_commit flag to the context by @orhun in #389
 - feat(args): set `CHANGELOG.md` as default missing value for output option by @sh-cho in #354
 ```
+
+`username` is resolved from the commit author, whereas `pr_author` is the account that
+opened the pull request. They can differ, so a template that wants to credit the
+contributor rather than whoever the commit resolves to can prefer `pr_author`:
+
+```jinja2
+{% if commit.remote.pr_author or commit.remote.username %} by @{{ commit.remote.pr_author | default(value=commit.remote.username) }}{% endif %}
+```
+
+The guard matters: `commit.remote` is absent for any commit the remote API did not return, and an
+unguarded lookup on it aborts the whole render.
 
 ### Contributors
 

--- a/website/docs/integration/github.md
+++ b/website/docs/integration/github.md
@@ -112,6 +112,7 @@ For each commit, GitHub related values are added as a nested object (named `remo
 
   "remote": {
     "username": "orhun",
+    "pr_author": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
     "pr_labels": ["rust"],
@@ -136,6 +137,19 @@ The will result in:
 - feat(commit): add merge_commit flag to the context by @orhun in #389
 - feat(args): set `CHANGELOG.md` as default missing value for output option by @sh-cho in #354
 ```
+
+`username` is resolved from the commit author, whereas `pr_author` is the account that
+opened the pull request. They can differ: a squash-merge can produce a commit that
+carries the contributor's name with the merging user's email, which GitHub resolves to
+the merging user's account. A template that wants to credit the contributor can prefer
+`pr_author`:
+
+```jinja2
+{% if commit.remote.pr_author or commit.remote.username %} by @{{ commit.remote.pr_author | default(value=commit.remote.username) }}{% endif %}
+```
+
+The guard matters: `commit.remote` is absent for any commit the remote API did not return, and an
+unguarded lookup on it aborts the whole render.
 
 ### Contributors
 

--- a/website/docs/integration/gitlab.md
+++ b/website/docs/integration/gitlab.md
@@ -120,6 +120,7 @@ For each commit, GitLab related values are added as a nested object (named `remo
 
   "remote": {
     "username": "orhun",
+    "pr_author": "orhun",
     "pr_title": "some things have changed",
     "pr_number": 420,
     "pr_labels": ["rust"],
@@ -144,6 +145,17 @@ The will result in:
 - feat(commit): add merge_commit flag to the context by @orhun in #389
 - feat(args): set `CHANGELOG.md` as default missing value for output option by @sh-cho in #354
 ```
+
+`username` is resolved from the commit author, whereas `pr_author` is the account that
+opened the pull request. They can differ, so a template that wants to credit the
+contributor rather than whoever the commit resolves to can prefer `pr_author`:
+
+```jinja2
+{% if commit.remote.pr_author or commit.remote.username %} by @{{ commit.remote.pr_author | default(value=commit.remote.username) }}{% endif %}
+```
+
+The guard matters: `commit.remote` is absent for any commit the remote API did not return, and an
+unguarded lookup on it aborts the whole render.
 
 ### Contributors
 

--- a/website/docs/templating/context.md
+++ b/website/docs/templating/context.md
@@ -103,7 +103,7 @@ following context is generated to use for templating:
 
 :::info
 
-See the [GitHub integration](/docs/integration/github) for the additional values you can use in the template.
+See [Remote metadata](#remote-metadata) for additional commit values provided by remote integrations.
 
 :::
 
@@ -153,6 +153,27 @@ Breaking changes will not be skipped if [`protect_breaking_commits`](/docs/confi
 From [Git docs](https://git-scm.com/book/en/v2/Git-Basics-Viewing-the-Commit-History):
 
 > You may be wondering what the difference is between author and committer. The author is the person who originally wrote the work, whereas the committer is the person who last applied the work. So, if you send in a patch to a project and one of the core members applies the patch, both of you get credit — you as the author, and the core member as the committer.
+
+### Remote metadata
+
+When a remote integration returns a commit, it adds the following `remote`
+object to the commit context. Pull request fields are populated when that commit
+is matched with a pull request:
+
+```json
+{
+  "username": "commit-author",
+  "pr_author": "pull-request-author",
+  "pr_title": "feat: add a feature",
+  "pr_number": 42,
+  "pr_labels": ["enhancement"]
+}
+```
+
+`username` is resolved from the commit author, while `pr_author` is the account
+that opened the pull request. These values can differ, particularly for squash
+merges. See the [integration documentation](/docs/category/integration) for
+provider-specific behavior.
 
 ## Non-Conventional Commits
 
@@ -222,7 +243,7 @@ If [`conventional_commits`](/docs/configuration/git#conventional_commits) is set
 
 :::info
 
-See the [GitHub integration](/docs/integration/github) for the additional values you can use in the template.
+See [Remote metadata](#remote-metadata) for additional commit values provided by remote integrations.
 
 :::
 


### PR DESCRIPTION
## Description

Adds `pr_author` to the remote context, alongside the existing `username`:

```jinja2
by @{{ commit.remote.pr_author | default(value=commit.remote.username) }}
```

- `RemotePullRequest` gains `fn author(&self) -> Option<String>` with a default
  implementation returning `None`, so out-of-tree backends keep compiling.
- All five backends implement it: GitHub `user.login`, Gitea `user.login`,
  GitLab `author.username`, Bitbucket `author.nickname`, Azure DevOps
  `createdBy.displayName`.
- `update_release_metadata!` sets `commit.$remote.pr_author` from the pull
  request that was already matched to the commit.
- `username` is unchanged, so no existing configuration changes behavior.

Two notes for review:

- `pr_author` is set **per commit only**. `RemoteContributor` backs both
  `commit.remote` and the per-release `contributors` list, but contributors are
  deduplicated by `username` — so one entry can span pull requests opened by
  different people, and populating it there would credit the first PR's author
  for all of them. Contributor entries leave it empty.
- Bitbucket returns a raw `Name <email>` string for a commit author but an
  account object for a pull request author, so `BitbucketCommitAuthor` gained a
  `nickname` field rather than a new type, to avoid changing a public field's
  type. Note this also means Bitbucket's `username` is not a handle, so the
  docs there recommend `pr_author` on its own rather than a fallback chain.

Azure DevOps has no `@`-mentionable handle — `createdBy.displayName` is a
display name, and `uniqueName` is a UPN/email that would leak addresses into
changelogs — so that page documents `pr_author` without the `@` prefix.

`RemoteContributor` is not `#[non_exhaustive]`, so adding a field is a
source-breaking change for downstream crates constructing it by struct literal.

## Motivation and Context

Closes #1608.

`commit.remote.username` is resolved from the commit author's email. GitHub's
squash-merge can produce a commit whose author is the contributor's *name* with
the merging user's *email*, which GitHub resolves to the merging user's account
— so the changelog reads `by @maintainer` for a PR written by someone else. In
one repository this affected 10 of 31 squash-merged PRs (32%) across four
releases.

git-cliff renders what the API returns; the gap was that the better data, the
pull request's author, was already fetched and then dropped.

Per your comment on the issue, this adds `pr_author` and leaves `username`
alone.

## How Has This Been Tested?

- `cargo test --workspace --all-features` — all green.
- New `pull_request_author` and `pull_request_author_missing` unit tests per
  backend, deserializing the forge's actual JSON payload shape so the serde
  field names are covered, including the absent-author case (GitHub returns
  `"user": null` for ghost accounts).
- The existing `update_*_metadata` tests in `release.rs` now give each fixture
  pull request its own author, distinct from the commit author, so every
  assertion pins the PR-to-author mapping rather than a single shared value.
- `cargo +nightly fmt --all -- --check` clean.
- `cargo clippy --tests -- -D warnings` reports one pre-existing
  `iter_next_slice` error in `changelog.rs:567`, untouched by this change; no
  new lints from these files.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (no code change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

