### PR TITLE
test(args): cover configuration file resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "secrecy",
  "serial_test",
  "shellexpand",
+ "temp-dir",
  "tracing",
  "tracing-indicatif",
  "tracing-subscriber",

--- a/git-cliff/Cargo.toml
+++ b/git-cliff/Cargo.toml
@@ -73,6 +73,7 @@ path = "../git-cliff-core"
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 serial_test = { version = "3.5.0", default-features = false }
+temp-dir = "0.1.16"
 
 [lints]
 workspace = true

--- a/git-cliff/src/config_path.rs
+++ b/git-cliff/src/config_path.rs
@@ -1,0 +1,160 @@
+//! Resolution of the configuration file path.
+
+use std::path::{Path, PathBuf};
+
+use git_cliff_core::config::Config;
+
+/// Determines which configuration file to use.
+///
+/// An explicit path is used when it exists. When the given path does not
+/// exist, another configuration source is used instead.
+///
+/// When `--config` is omitted, a project configuration is discovered by
+/// searching a starting directory and its ancestors, then the user
+/// configuration directory. Discovery starts from `--workdir` when it is
+/// given, so that it follows the directory git-cliff was asked to operate on
+/// rather than the directory it was invoked from.
+pub fn resolve_config_path(
+    config: Option<&Path>,
+    workdir: Option<&Path>,
+    current_dir: &Path,
+    user_config: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    match config {
+        Some(path) if path.exists() => Some(path.to_path_buf()),
+        Some(_) => user_config(),
+        None => workdir
+            .unwrap_or(current_dir)
+            .ancestors()
+            .find_map(Config::retrieve_project_config_path)
+            .or_else(user_config),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use git_cliff_core::DEFAULT_CONFIG;
+    use git_cliff_core::error::Result;
+    use pretty_assertions::assert_eq;
+    use temp_dir::TempDir;
+
+    use super::*;
+
+    /// Creates a temporary directory.
+    fn temp_dir() -> Result<TempDir> {
+        Ok(TempDir::with_prefix("git-cliff-")?)
+    }
+
+    /// Creates a project configuration file in the given directory.
+    fn write_config(dir: &Path) -> Result<PathBuf> {
+        let path = dir.join(DEFAULT_CONFIG);
+        fs::write(&path, "[changelog]\n")?;
+        Ok(path)
+    }
+
+    #[test]
+    fn explicit_config_is_used_when_it_exists() -> Result<()> {
+        let config_dir = temp_dir()?;
+        let current_dir = temp_dir()?;
+        // The configuration lives outside the directory discovery would
+        // search, so only the explicit branch can return this path.
+        let config = write_config(config_dir.path())?;
+        assert_eq!(
+            Some(config),
+            resolve_config_path(
+                Some(&config_dir.path().join(DEFAULT_CONFIG)),
+                None,
+                current_dir.path(),
+                || None
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_explicit_config_skips_discovery_and_uses_the_user_config() -> Result<()> {
+        let dir = temp_dir()?;
+        // A discoverable project configuration is present, so this also
+        // proves that giving `--config` skips discovery entirely rather
+        // than falling through to it.
+        write_config(dir.path())?;
+        let user_config = dir.path().join("user-cliff.toml");
+        assert_eq!(
+            Some(user_config.clone()),
+            resolve_config_path(
+                Some(&dir.path().join("does-not-exist.toml")),
+                None,
+                dir.path(),
+                || Some(user_config.clone())
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_the_working_directory() -> Result<()> {
+        let workdir = temp_dir()?;
+        let current_dir = temp_dir()?;
+        let config = write_config(workdir.path())?;
+        // Both directories hold a configuration, so this asserts which one
+        // wins rather than merely that something was found.
+        write_config(current_dir.path())?;
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, Some(workdir.path()), current_dir.path(), || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_the_current_directory_without_workdir() -> Result<()> {
+        let dir = temp_dir()?;
+        let config = write_config(dir.path())?;
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, None, dir.path(), || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_a_parent_directory() -> Result<()> {
+        let dir = temp_dir()?;
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested)?;
+        let config = write_config(dir.path())?;
+        // Discovery walks up from the starting directory, so a configuration
+        // in a parent is found from a subdirectory.
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, None, &nested, || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn user_config_is_used_when_no_project_config_is_discovered() -> Result<()> {
+        let dir = temp_dir()?;
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested)?;
+        // Discovery walks to the filesystem root here, so this assumes no
+        // configuration file exists above the temporary directory.
+        assert_eq!(
+            None,
+            dir.path()
+                .ancestors()
+                .find_map(Config::retrieve_project_config_path),
+            "a configuration file above the temporary directory defeats this test"
+        );
+        let user_config = dir.path().join("user-cliff.toml");
+        assert_eq!(
+            Some(user_config.clone()),
+            resolve_config_path(None, Some(&nested), dir.path(), || Some(
+                user_config.clone()
+            ))
+        );
+        Ok(())
+    }
+}

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -1011,9 +1011,15 @@ pub fn write_changelog<W: io::Write>(
 mod tests {
     use std::fs;
 
+    use pretty_assertions::assert_eq;
     use temp_dir::TempDir;
 
     use super::*;
+
+    /// Creates a temporary directory.
+    fn temp_dir() -> Result<TempDir> {
+        Ok(TempDir::with_prefix("git-cliff-")?)
+    }
 
     /// Creates a project configuration file in the given directory.
     fn write_config(dir: &Path) -> Result<PathBuf> {
@@ -1024,18 +1030,30 @@ mod tests {
 
     #[test]
     fn explicit_config_is_used_when_it_exists() -> Result<()> {
-        let dir = TempDir::new()?;
-        let config = write_config(dir.path())?;
+        let config_dir = temp_dir()?;
+        let current_dir = temp_dir()?;
+        // The configuration lives outside the directory discovery would
+        // search, so only the explicit branch can return this path.
+        let config = write_config(config_dir.path())?;
         assert_eq!(
-            Some(config.clone()),
-            resolve_config_path(Some(&config), None, dir.path(), || None)
+            Some(config),
+            resolve_config_path(
+                Some(&config_dir.path().join(DEFAULT_CONFIG)),
+                None,
+                current_dir.path(),
+                || None
+            )
         );
         Ok(())
     }
 
     #[test]
-    fn missing_explicit_config_falls_back_to_the_user_config() -> Result<()> {
-        let dir = TempDir::new()?;
+    fn missing_explicit_config_skips_discovery_and_uses_the_user_config() -> Result<()> {
+        let dir = temp_dir()?;
+        // A discoverable project configuration is present, so this also
+        // proves that giving `--config` skips discovery entirely rather
+        // than falling through to it.
+        write_config(dir.path())?;
         let user_config = dir.path().join("user-cliff.toml");
         assert_eq!(
             Some(user_config.clone()),
@@ -1051,11 +1069,12 @@ mod tests {
 
     #[test]
     fn config_is_discovered_from_the_working_directory() -> Result<()> {
-        let workdir = TempDir::new()?;
-        let current_dir = TempDir::new()?;
+        let workdir = temp_dir()?;
+        let current_dir = temp_dir()?;
         let config = write_config(workdir.path())?;
-        // Discovery follows `--workdir` rather than the directory git-cliff
-        // was invoked from.
+        // Both directories hold a configuration, so this asserts which one
+        // wins rather than merely that something was found.
+        write_config(current_dir.path())?;
         assert_eq!(
             Some(config),
             resolve_config_path(None, Some(workdir.path()), current_dir.path(), || None)
@@ -1065,7 +1084,7 @@ mod tests {
 
     #[test]
     fn config_is_discovered_from_the_current_directory_without_workdir() -> Result<()> {
-        let dir = TempDir::new()?;
+        let dir = temp_dir()?;
         let config = write_config(dir.path())?;
         assert_eq!(
             Some(config),
@@ -1076,7 +1095,7 @@ mod tests {
 
     #[test]
     fn config_is_discovered_from_a_parent_directory() -> Result<()> {
-        let dir = TempDir::new()?;
+        let dir = temp_dir()?;
         let nested = dir.path().join("nested");
         fs::create_dir(&nested)?;
         let config = write_config(dir.path())?;
@@ -1091,9 +1110,18 @@ mod tests {
 
     #[test]
     fn user_config_is_used_when_no_project_config_is_discovered() -> Result<()> {
-        let dir = TempDir::new()?;
+        let dir = temp_dir()?;
         let nested = dir.path().join("nested");
         fs::create_dir(&nested)?;
+        // Discovery walks to the filesystem root here, so this assumes no
+        // configuration file exists above the temporary directory.
+        assert_eq!(
+            None,
+            dir.path()
+                .ancestors()
+                .find_map(Config::retrieve_project_config_path),
+            "a configuration file above the temporary directory defeats this test"
+        );
         let user_config = dir.path().join("user-cliff.toml");
         assert_eq!(
             Some(user_config.clone()),

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -6,6 +6,7 @@
 
 /// Command-line argument parser.
 pub mod args;
+mod config_path;
 
 /// Custom logger implementation.
 pub mod logger;
@@ -550,33 +551,6 @@ fn process_repository<'a>(
     Ok(releases)
 }
 
-/// Determines which configuration file to use.
-///
-/// An explicit path is used when it exists. When the given path does not
-/// exist, another configuration source is used instead.
-///
-/// When `--config` is omitted, a project configuration is discovered by
-/// searching a starting directory and its ancestors, then the user
-/// configuration directory. Discovery starts from `--workdir` when it is
-/// given, so that it follows the directory git-cliff was asked to operate on
-/// rather than the directory it was invoked from.
-fn resolve_config_path(
-    config: Option<&Path>,
-    workdir: Option<&Path>,
-    current_dir: &Path,
-    user_config: impl FnOnce() -> Option<PathBuf>,
-) -> Option<PathBuf> {
-    match config {
-        Some(path) if path.exists() => Some(path.to_path_buf()),
-        Some(_) => user_config(),
-        None => workdir
-            .unwrap_or(current_dir)
-            .ancestors()
-            .find_map(Config::retrieve_project_config_path)
-            .or_else(user_config),
-    }
-}
-
 /// Runs `git-cliff`.
 ///
 /// # Example
@@ -673,7 +647,7 @@ pub fn run_with_changelog_modifier<'a>(
     } else if let Some(Ok((config, name))) = builtin_config {
         tracing::info!("Using built-in configuration file: {name}");
         config
-    } else if let Some(config_path) = resolve_config_path(
+    } else if let Some(config_path) = config_path::resolve_config_path(
         args.config.as_deref(),
         args.workdir.as_deref(),
         &env::current_dir()?,
@@ -1005,130 +979,4 @@ pub fn write_changelog<W: io::Write>(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use pretty_assertions::assert_eq;
-    use temp_dir::TempDir;
-
-    use super::*;
-
-    /// Creates a temporary directory.
-    fn temp_dir() -> Result<TempDir> {
-        Ok(TempDir::with_prefix("git-cliff-")?)
-    }
-
-    /// Creates a project configuration file in the given directory.
-    fn write_config(dir: &Path) -> Result<PathBuf> {
-        let path = dir.join(DEFAULT_CONFIG);
-        fs::write(&path, "[changelog]\n")?;
-        Ok(path)
-    }
-
-    #[test]
-    fn explicit_config_is_used_when_it_exists() -> Result<()> {
-        let config_dir = temp_dir()?;
-        let current_dir = temp_dir()?;
-        // The configuration lives outside the directory discovery would
-        // search, so only the explicit branch can return this path.
-        let config = write_config(config_dir.path())?;
-        assert_eq!(
-            Some(config),
-            resolve_config_path(
-                Some(&config_dir.path().join(DEFAULT_CONFIG)),
-                None,
-                current_dir.path(),
-                || None
-            )
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn missing_explicit_config_skips_discovery_and_uses_the_user_config() -> Result<()> {
-        let dir = temp_dir()?;
-        // A discoverable project configuration is present, so this also
-        // proves that giving `--config` skips discovery entirely rather
-        // than falling through to it.
-        write_config(dir.path())?;
-        let user_config = dir.path().join("user-cliff.toml");
-        assert_eq!(
-            Some(user_config.clone()),
-            resolve_config_path(
-                Some(&dir.path().join("does-not-exist.toml")),
-                None,
-                dir.path(),
-                || Some(user_config.clone())
-            )
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn config_is_discovered_from_the_working_directory() -> Result<()> {
-        let workdir = temp_dir()?;
-        let current_dir = temp_dir()?;
-        let config = write_config(workdir.path())?;
-        // Both directories hold a configuration, so this asserts which one
-        // wins rather than merely that something was found.
-        write_config(current_dir.path())?;
-        assert_eq!(
-            Some(config),
-            resolve_config_path(None, Some(workdir.path()), current_dir.path(), || None)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn config_is_discovered_from_the_current_directory_without_workdir() -> Result<()> {
-        let dir = temp_dir()?;
-        let config = write_config(dir.path())?;
-        assert_eq!(
-            Some(config),
-            resolve_config_path(None, None, dir.path(), || None)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn config_is_discovered_from_a_parent_directory() -> Result<()> {
-        let dir = temp_dir()?;
-        let nested = dir.path().join("nested");
-        fs::create_dir(&nested)?;
-        let config = write_config(dir.path())?;
-        // Discovery walks up from the starting directory, so a configuration
-        // in a parent is found from a subdirectory.
-        assert_eq!(
-            Some(config),
-            resolve_config_path(None, None, &nested, || None)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn user_config_is_used_when_no_project_config_is_discovered() -> Result<()> {
-        let dir = temp_dir()?;
-        let nested = dir.path().join("nested");
-        fs::create_dir(&nested)?;
-        // Discovery walks to the filesystem root here, so this assumes no
-        // configuration file exists above the temporary directory.
-        assert_eq!(
-            None,
-            dir.path()
-                .ancestors()
-                .find_map(Config::retrieve_project_config_path),
-            "a configuration file above the temporary directory defeats this test"
-        );
-        let user_config = dir.path().join("user-cliff.toml");
-        assert_eq!(
-            Some(user_config.clone()),
-            resolve_config_path(None, Some(&nested), dir.path(), || Some(
-                user_config.clone()
-            ))
-        );
-        Ok(())
-    }
 }

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -1006,3 +1006,101 @@ pub fn write_changelog<W: io::Write>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use temp_dir::TempDir;
+
+    use super::*;
+
+    /// Creates a project configuration file in the given directory.
+    fn write_config(dir: &Path) -> Result<PathBuf> {
+        let path = dir.join(DEFAULT_CONFIG);
+        fs::write(&path, "[changelog]\n")?;
+        Ok(path)
+    }
+
+    #[test]
+    fn explicit_config_is_used_when_it_exists() -> Result<()> {
+        let dir = TempDir::new()?;
+        let config = write_config(dir.path())?;
+        assert_eq!(
+            Some(config.clone()),
+            resolve_config_path(Some(&config), None, dir.path(), || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_explicit_config_falls_back_to_the_user_config() -> Result<()> {
+        let dir = TempDir::new()?;
+        let user_config = dir.path().join("user-cliff.toml");
+        assert_eq!(
+            Some(user_config.clone()),
+            resolve_config_path(
+                Some(&dir.path().join("does-not-exist.toml")),
+                None,
+                dir.path(),
+                || Some(user_config.clone())
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_the_working_directory() -> Result<()> {
+        let workdir = TempDir::new()?;
+        let current_dir = TempDir::new()?;
+        let config = write_config(workdir.path())?;
+        // Discovery follows `--workdir` rather than the directory git-cliff
+        // was invoked from.
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, Some(workdir.path()), current_dir.path(), || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_the_current_directory_without_workdir() -> Result<()> {
+        let dir = TempDir::new()?;
+        let config = write_config(dir.path())?;
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, None, dir.path(), || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn config_is_discovered_from_a_parent_directory() -> Result<()> {
+        let dir = TempDir::new()?;
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested)?;
+        let config = write_config(dir.path())?;
+        // Discovery walks up from the starting directory, so a configuration
+        // in a parent is found from a subdirectory.
+        assert_eq!(
+            Some(config),
+            resolve_config_path(None, None, &nested, || None)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn user_config_is_used_when_no_project_config_is_discovered() -> Result<()> {
+        let dir = TempDir::new()?;
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested)?;
+        let user_config = dir.path().join("user-cliff.toml");
+        assert_eq!(
+            Some(user_config.clone()),
+            resolve_config_path(None, Some(&nested), dir.path(), || Some(
+                user_config.clone()
+            ))
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
Follow-up to #1584.

`resolve_config_path` went in without direct tests, so the `--workdir` discovery behaviour you spotted there is currently not guarded by anything. This adds six tests for it and changes no production code.

## What is covered

- an explicit `--config` path that exists is used as given
- an explicit path that does not exist skips discovery and uses the user configuration
- discovery follows `--workdir` rather than the directory git-cliff was invoked from, which is the regression from #1584
- discovery uses the current directory when `--workdir` is absent
- discovery walks up to a parent directory
- the user configuration is used when no project configuration is found

## Verification

Each test was checked to fail when the behaviour it names is broken, rather than only to pass as written. Removing the explicit-config arm, making a missing explicit path fall through to discovery, ignoring `--workdir`, and limiting the ancestor walk to a single directory each fail exactly one test, and it is the test named for that behaviour.

Each test also isolates its own branch: the explicit-path test keeps its configuration outside the directory discovery would search, the missing-path test leaves a discoverable configuration in place to prove discovery is skipped, and the `--workdir` test puts a competing configuration in the current directory so it asserts precedence rather than merely finding something.

`cargo test --workspace` passes (22 in git-cliff, 113 in git-cliff-core), `cargo clippy --tests -- -D warnings` is clean, and `cargo +nightly fmt --all --check` is clean.

## Scope

These are unit tests of the resolver itself. The call site in `run_with_changelog_modifier` that passes `args.workdir` into it is not covered here, so reverting that single argument would reproduce the original bug with these tests still green. Covering that would need a CLI fixture rather than a unit test, which felt like a separate change; happy to add one if you would like the plumbing guarded too.

`temp-dir` is added as a dev-dependency of the `git-cliff` crate, matching the version and usage already present in `git-cliff-core`.