### PR TITLE
docs: document how git-cliff interacts with existing changelogs

### DIFF
--- a/website/docs/usage/migrating-existing-changelog.md
+++ b/website/docs/usage/migrating-existing-changelog.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 14
+---
+
+# Migrating an Existing Changelog
+
+If you have an existing `CHANGELOG.md` and want to start using `git-cliff`
+without losing your legacy history, you can do so by aligning your header and
+using the `--prepend` flag.
+
+## Prerequisites
+
+`git-cliff` finds the injection point by matching the rendered `header` value
+from your config. It strips that header, prepends the newly generated entries,
+and re-inserts it. For this to work your existing `CHANGELOG.md` **must** start
+with the exact same text that the `header` template in your `cliff.toml`
+renders to.
+
+For example, if your config contains:
+
+```toml
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+```
+
+then the top of your `CHANGELOG.md` must be exactly those lines.
+
+:::tip
+Keep your `header` value as **static text** (no Tera template variables).
+If the header changes between runs, `--prepend` cannot find the insertion point.
+:::
+
+## Prepending New Releases
+
+Once the header matches, use `--prepend` together with `--unreleased` so
+`git-cliff` only generates entries for commits that have not been released yet,
+avoiding duplicate sections:
+
+```bash
+# append unreleased commits to the top of an existing changelog
+git cliff --unreleased --prepend CHANGELOG.md
+
+# same, but also set the tag for the upcoming release
+git cliff --unreleased --tag 1.2.0 --prepend CHANGELOG.md
+```
+
+## Limitations
+
+| Issue | Cause | Workaround |
+|-------|-------|------------|
+| `--prepend` inserts nothing / fails | `header` in config does not match the file's opening text exactly | Copy the rendered header into the file verbatim |
+| Duplicate release sections | Running without `--unreleased` causes git-cliff to process the full history | Always pair `--prepend` with `--unreleased` |
+| Full overwrite of legacy history | Using `-o` / `--output` instead of `--prepend` | Use `--prepend` for existing changelogs; reserve `-o` for fresh ones |
+
+## Marking the Legacy Section (Optional)
+
+To make the boundary between generated and legacy content visible, add an HTML
+comment just above the old entries:
+
+```markdown
+<!-- changelog managed by git-cliff below this line -->
+```
+
+This comment is not processed by `git-cliff` — it exists purely as a
+human-readable marker.


### PR DESCRIPTION
Closes #1607

## Description

Adds a new usage page documenting how to migrate a pre-existing CHANGELOG.md to git-cliff without losing legacy history. Covers header matching requirements, the `--prepend` + `--unreleased` workflow, common pitfalls, and an optional HTML marker for the legacy section.

## Motivation and Context

Users migrating from a manual or pre-git-cliff changelog workflow have no clear guidance on how to do so safely. The `--prepend` flag has subtle requirements (the `header` in cliff.toml must match the file's opening text exactly) that are easy to miss and cause silent failures or duplicate entries. 

This addresses the documentation gap raised in #1607.

## How Has This Been Tested?

Documentation-only change. Verified the page renders correctly by reading the existing Docusaurus usage pages for structure and formatting consistency.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [ ] `cargo +nightly fmt --all`
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - [ ] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
