### PR TITLE
chore(deps)!: update to git2 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,15 +1110,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -1718,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -93,7 +93,7 @@ tracing.workspace = true
 tracing-indicatif = { workspace = true, optional = true }
 
 [dependencies.git2]
-version = "0.20.4"
+version = "0.21"
 default-features = false
 optional = true
 

--- a/git-cliff-core/src/commit.rs
+++ b/git-cliff-core/src/commit.rs
@@ -71,8 +71,8 @@ pub struct Signature {
 impl<'a> From<CommitSignature<'a>> for Signature {
     fn from(signature: CommitSignature<'a>) -> Self {
         Self {
-            name: signature.name().map(String::from),
-            email: signature.email().map(String::from),
+            name: signature.name().ok().map(String::from),
+            email: signature.email().ok().map(String::from),
             timestamp: signature.when().seconds(),
         }
     }

--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -518,6 +518,7 @@ impl Repository {
                 name: tag.name().unwrap_or_default().to_owned(),
                 message: tag
                     .message()
+                    .unwrap_or_default()
                     .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
             },
             _ => Tag {
@@ -566,6 +567,7 @@ impl Repository {
         for name in tag_names
             .iter()
             .flatten()
+            .flatten()
             .filter(|tag_name| pattern.as_ref().is_none_or(|pat| pat.is_match(tag_name)))
             .map(String::from)
         {
@@ -593,6 +595,8 @@ impl Repository {
                         name: tag.name().map(String::from).unwrap_or(name),
                         message: tag
                             .message()
+                            .ok()
+                            .flatten()
                             .map(|msg| TAG_SIGNATURE_REGEX.replace(msg, "").trim().to_owned()),
                     }));
                 }
@@ -674,13 +678,15 @@ impl Repository {
                         "branch name is not valid"
                     )))?
                 ))?;
-                let upstream_name = upstream.as_str().ok_or_else(|| {
-                    Error::RepoError(String::from("name of the upstream remote is not valid"))
+                let upstream_name = upstream.as_str().map_err(|err| {
+                    Error::RepoError(format!("name of the upstream remote is not valid: {err}"))
                 })?;
                 let origin = &self.inner.find_remote(upstream_name)?;
                 let url = origin
                     .url()
-                    .ok_or_else(|| Error::RepoError(String::from("failed to get the remote URL")))?
+                    .map_err(|err| {
+                        Error::RepoError(format!("failed to get the remote URL: {err}"))
+                    })?
                     .to_string();
                 tracing::trace!("Upstream URL: {url}");
                 return find_remote(&url);


### PR DESCRIPTION
## Description

Updates the `git2` dependency of `git-cliff-core` from 0.20 to 0.21.

## Motivation and Context

As part of my effort to package git-cliff for Debian, I need it to work with git2 0.21.
Since I wrote a patch for it, I thought I would submit it upstream.

## How Has This Been Tested?

Running the test suite.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: dependency update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`: it fails but the failures seem to be pre-existing
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
