### PR TITLE
chore(deps): update http-cache-reqwest to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e883defacf53960c7717d9e928dc8667be9501d9f54e6a8b7703d7a30320e9c"
+checksum = "1437561a949a2168929d7559aecd2f0ecb18b9e676080396388cdc399ddb723a"
 dependencies = [
  "async-trait",
  "bincode 1.3.3",
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076afd9d376f09073b515ce95071b29393687d98ed521948edb899195595ddf"
+checksum = "8ccca775a066b2a65da33611921e078ebdcfc27065c8bee96794703541101886"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/git-cliff-core/Cargo.toml
+++ b/git-cliff-core/Cargo.toml
@@ -73,7 +73,7 @@ semver = "1.0.28"
 humantime-serde = "1.1.1"
 document-features = { version = "0.2.12", optional = true }
 reqwest = { workspace = true, optional = true }
-http-cache-reqwest = { version = "0.15.1", optional = true }
+http-cache-reqwest = { version = "0.16", optional = true }
 reqwest-middleware = { version = "0.4.2", optional = true }
 tokio = { version = "1.53.1", features = [
   "rt-multi-thread",

--- a/git-cliff-core/src/remote/mod.rs
+++ b/git-cliff-core/src/remote/mod.rs
@@ -22,6 +22,7 @@ use std::env;
 use std::fmt::Debug;
 use std::time::Duration;
 
+use cacache::RemoveOpts;
 use dyn_clone::DynClone;
 use etcetera::{BaseStrategy, choose_base_strategy};
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
@@ -134,6 +135,7 @@ impl Remote {
                 mode: CacheMode::Default,
                 manager: CACacheManager {
                     path: strategy.cache_dir().join(env!("CARGO_PKG_NAME")),
+                    remove_opts: RemoveOpts::default(),
                 },
                 options: HttpCacheOptions::default(),
             }))


### PR DESCRIPTION
## Description

Updates http-cache-reqwest from 0.15 to 0.16

## Motivation and Context

Still motivated by Debian packaging.

## How Has This Been Tested?
Running the test suite.

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other: dependency update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [ ] <s>I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).</s> because linting already fails on the main branch
  - [ ] `cargo clippy --tests --verbose -- -D warnings`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
