### PR TITLE
fix(args): resolve --workdir to a repo-relative include path

### DIFF
--- a/.github/fixtures/test-workdir-empty-commit/cliff.toml
+++ b/.github/fixtures/test-workdir-empty-commit/cliff.toml
@@ -1,0 +1,20 @@
+[changelog]
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[git]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+]

--- a/.github/fixtures/test-workdir-empty-commit/commit.sh
+++ b/.github/fixtures/test-workdir-empty-commit/commit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Regression test for https://github.com/orhun/git-cliff/issues/1369
+# A relative `--workdir .` on a repo whose commits have no file changes must
+# still list them. Setting --workdir used to add an include-path, which
+# filtered out file-less commits and produced an empty changelog.
+
+GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit --allow-empty -m "feat: add readme"
+GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit --allow-empty -m "fix: add main module"

--- a/.github/fixtures/test-workdir-empty-commit/expected.md
+++ b/.github/fixtures/test-workdir-empty-commit/expected.md
@@ -1,0 +1,10 @@
+## [unreleased]
+
+### Bug Fixes
+
+- Add main module
+
+### Features
+
+- Add readme
+

--- a/.github/fixtures/test-workdir-repo-root/cliff.toml
+++ b/.github/fixtures/test-workdir-repo-root/cliff.toml
@@ -1,0 +1,20 @@
+[changelog]
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[git]
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+]

--- a/.github/fixtures/test-workdir-repo-root/commit.sh
+++ b/.github/fixtures/test-workdir-repo-root/commit.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+# Regression test for https://github.com/orhun/git-cliff/issues/1369
+# Pointing `--workdir` at the repository root must include every commit,
+# not scope the changelog to an empty path (which produced empty output).
+
+echo "readme" > README.md
+git add README.md
+GIT_COMMITTER_DATE="2022-04-06 01:25:08" git commit -m "feat: add readme"
+
+mkdir -p src
+echo "main" > src/main.rs
+git add src/
+GIT_COMMITTER_DATE="2022-04-06 01:25:09" git commit -m "fix: add main module"

--- a/.github/fixtures/test-workdir-repo-root/expected.md
+++ b/.github/fixtures/test-workdir-repo-root/expected.md
@@ -1,0 +1,10 @@
+## [unreleased]
+
+### Bug Fixes
+
+- Add main module
+
+### Features
+
+- Add readme
+

--- a/.github/workflows/test-fixtures.yml
+++ b/.github/workflows/test-fixtures.yml
@@ -161,6 +161,17 @@ jobs:
             previous-release-timestamp: "2022-04-06 01:25:12"
           - fixtures-name: test-workdir-include-path
             command: v2.6.1..v2.7.0 --workdir .github/fixtures/
+          # Regression test for #1369: `--workdir` at the repository root must
+          # include every commit instead of producing empty output. Using an
+          # absolute path ($PWD) exercises the path that previously built an
+          # absolute include pattern that matched no repo-relative diff paths.
+          - fixtures-name: test-workdir-repo-root
+            command: --workdir "$PWD"
+          # Regression test for #1369: a relative `--workdir .` must not filter
+          # out file-less commits. Setting --workdir added an include-path, so
+          # commits with no file changes were dropped and the output was empty.
+          - fixtures-name: test-workdir-empty-commit
+            command: --workdir .
           - fixtures-name: test-fail-on-unmatched-commit
           # NOTE: The following four include-path tests all use identical
           # expected.md content. They verify that the same result is produced

--- a/git-cliff/src/lib.rs
+++ b/git-cliff/src/lib.rs
@@ -310,6 +310,25 @@ fn process_repository<'a>(
     // Additionally, if `include_path` is already explicitly set, it might be preferable to append.
     let cwd = env::current_dir()?;
     let mut include_path = config.git.include_paths.clone();
+    // When `--workdir` is set, scope the changelog to that directory by turning it
+    // into a repo-relative include pattern. Diff paths are relative to the repo
+    // root, so the pattern must be too; an absolute or cwd-relative pattern would
+    // match nothing and produce an empty changelog (see #1369). If `workdir`
+    // resolves to the repo root itself, no filter is added so everything is kept.
+    if let Some(workdir) = &args.workdir &&
+        let Ok(root) = repository.root_path()
+    {
+        let workdir_abs = fs::canonicalize(cwd.join(workdir)).unwrap_or_else(|_| cwd.join(workdir));
+        if let Ok(rel) = workdir_abs.strip_prefix(&root) &&
+            !rel.as_os_str().is_empty()
+        {
+            // Trailing separator makes the directory expand to a `**` glob.
+            let pattern = Pattern::new(rel.join("").to_string_lossy().as_ref())?;
+            if !include_path.iter().any(|p| p.as_str() == pattern.as_str()) {
+                include_path.push(pattern);
+            }
+        }
+    }
     if let Ok(root) = repository.root_path() &&
         cwd.starts_with(&root) &&
         cwd != root &&
@@ -618,11 +637,6 @@ pub fn run_with_changelog_modifier<'a>(
         if let Some(body_file) = args.body_file {
             args.body_file = Some(workdir.join(body_file));
         }
-        // pushing an empty component force-adds a trailing path separator
-        // which is needed for correct glob expansion
-        args.include_path = Some(vec![Pattern::new(
-            workdir.join("").to_string_lossy().as_ref(),
-        )?]);
     }
 
     // Parse the configuration file, loading the default configuration if none


### PR DESCRIPTION
Fixes #1369.

## Problem
Pointing `--workdir` at the repository root produces an empty changelog.

## Root cause
When `--workdir` is set, the changelog is scoped by turning the workdir path into an include pattern. That pattern was absolute (built from `workdir.join("")`), but diff paths are relative to the repo root — so an absolute pattern matches nothing and the changelog comes out empty.

## Approach
Resolve `--workdir` to a **repo-relative** include pattern inside `process_repository`. If `workdir` resolves to the repo root itself, no filter is added so everything is kept. Removed the old absolute-pattern assignment in `run_with_changelog_modifier`.

## Testing
- Added the `test-workdir-repo-root` fixture (`commit.sh` + `expected.md`) and wired it into `test-fixtures.yml` with `--workdir "$PWD"`, which exercises the previously-broken absolute-path case. It produces the full changelog with the fix and empty output without it.

Note on formatting: my added lines are within your `max_width`/`comment_width` and add no imports, so they match your nightly rustfmt config; I don't have nightly locally, so a quick `cargo +nightly fmt` on your side is worth a glance.

## A note on direction
I noticed you're planning a more holistic rework of the workdir/include-path handling and that @o1x3 offered to help. This is a minimal, test-backed fix for the empty-output regression specifically — happy for it to serve as a stopgap or a reference for the larger refactor, and equally happy to close it if you'd rather fold it into that work. Per CONTRIBUTING I'm flagging it here rather than assuming a direction; let me know how you'd like to proceed.
