### PR TITLE
chore(nix): update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "lastModified": 1788614874,
+        "narHash": "sha256-7QYjT2vHLuX9Z1pdxHXDKCbh1CR3D/2rywB9Tx0MPRg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "rev": "c043004d1c6985732bcc1cbc5a9c9aecbbb4e0f0",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1775963625,
-        "narHash": "sha256-OmwF0Rd/HDbEGC0ZcBS2jPMvmCcn3HDqUypjXrR7KfM=",
+        "lastModified": 1788678114,
+        "narHash": "sha256-pcqbpV4ZI79al6KAlr+WJjaEo/PYfgctRlG43D5BSJM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "573a61faa8ec910a6b8576cc3c145844245574f3",
+        "rev": "4748ec2f5ed4a881474ed4c98aa71a5308cdac8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

Update `flake.lock` to pull in a newer `nixpkgs` that includes the fix for `crates.io` `403` errors when fetching crate tarballs during cargo vendor fetches:

https://github.com/NixOS/nixpkgs/pull/524985

## Motivation and Context

GitHub Actions CI builds started failing with errors like:

```sh
error: cannot download crate-async-compression-0.4.30.tar.gz from any mirror
```

This was caused by `crates.io` blocking Nix's default User-Agent (`curl/* Nixpkgs/*`) on the `api/v1/.../download` endpoint, returning HTTP `403`. The fix was backported to `nixpkgs`:

 - [NixOS/nixpkgs#524985](https://github.com/NixOS/nixpkgs/pull/524985)
 - [NixOS/nixpkgs#558620](https://github.com/NixOS/nixpkgs/issues/558620)
 
 which switches `importCargoLock` to download directly from `static.crates.io` instead.

## How Has This Been Tested?

- Ran `nix flake update` locally
- Verified `nix flake check` passes

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [x] Other <!--- (provide information) -->

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`
