### PR TITLE
chore(deps): update rustls-webpki to 0.103.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.5"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Description

`cargo update -p rustls-webpki`: 0.103.5 -> 0.103.15, Cargo.lock only. No Cargo.toml or source change.

## Motivation and Context

rustls-webpki is in the reqwest TLS path; 0.103.15 carries the name-constraint fixes (RUSTSEC-2026-0098/0099) and the CRL ones (RUSTSEC-2026-0049/0104). Closes #1628.

## How Has This Been Tested?

`cargo check --workspace` and `cargo test` on the stable toolchain in a clean container, on the full git history (the repo::test cases read the repo's tags): 127 passed, 0 failed.

## Types of Changes

- [x] Other: dependency (lockfile) update

## Checklist:

- [x] My code follows the code style of this project. (no source change)
- [ ] I have updated the documentation accordingly (n/a)
- [ ] rustfmt / clippy (n/a, no source change)
- [ ] I have added tests to cover my changes (n/a)
- [x] All new and existing tests passed. `cargo test`
