### PR TITLE
fix(git): keep commits without file changes when only `exclude_paths` is set

### DIFF
--- a/git-cliff-core/src/repo.rs
+++ b/git-cliff-core/src/repo.rs
@@ -380,6 +380,10 @@ impl Repository {
                 })
             }
             (None, Some(exclude_pattern)) => {
+                // don't exclude empty commits
+                if changed_files.is_empty() {
+                    return true;
+                }
                 // check if the commit has at least one changed file that does not
                 // match all exclude patterns.
                 changed_files.iter().any(|path| {
@@ -1194,6 +1198,26 @@ mod test {
             .expect("failed to get the last commit")
     }
 
+    fn create_empty_commit(repo: &Repository) -> Commit<'_> {
+        let output = Command::new("git")
+            .args([
+                "commit",
+                "--allow-empty",
+                "--no-gpg-sign",
+                "--message",
+                "empty commit",
+            ])
+            .current_dir(&repo.path)
+            .output()
+            .expect("failed to execute git commit");
+        assert!(output.status.success(), "git commit failed {output:?}");
+
+        repo.inner
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("failed to get the last commit")
+    }
+
     #[test]
     fn filter_git_blame_ignore_revs_removes_listed_and_ignore_file_only_commits() {
         let (repo, _temp_dir) = create_temp_repo();
@@ -1362,6 +1386,31 @@ mod test {
                 Some(vec![new_pattern("**/*.txt")]).as_ref(),
             );
             assert!(!retain, "exclude: **/*.txt");
+        }
+
+        let empty_commit = create_empty_commit(&repo);
+
+        {
+            let retain = repo.should_retain_commit(&empty_commit, None, None);
+            assert!(retain, "empty commit, no include/exclude patterns");
+        }
+
+        {
+            let retain = repo.should_retain_commit(
+                &empty_commit,
+                None,
+                Some(vec![new_pattern("**/*.txt")]).as_ref(),
+            );
+            assert!(retain, "empty commit, exclude: **/*.txt");
+        }
+
+        {
+            let retain = repo.should_retain_commit(
+                &empty_commit,
+                Some(vec![new_pattern("**")]).as_ref(),
+                None,
+            );
+            assert!(!retain, "empty commit, include: **");
         }
     }
 }


### PR DESCRIPTION
## Description

When using `exclude_paths`, still include empty commits.

## Motivation and Context

I created an empty marker commit to evoke a change in version number, however, since I had `exclude_paths` set, this PR did not contribute to the new version number. 

I marked this as a bug fix because this change still satisfies the existing documentation:

https://git-cliff.org/docs/configuration/git/#:~:text=exclude%5Fpaths%20is%20an%20optional%20array%20of%20glob%20patterns%2E%20Commits%20that%20only%20modify%20files%20matching%20these%20patterns%20will%20be%20excluded%20from%20the%20changelog

> `exclude_paths` is an _optional_ array of glob patterns. Commits that **only** modify files matching these patterns will be excluded from the changelog.

Since an empty commit does NOT modify ANY files, it does not modify ANY files in the `exclude_paths`, and thus should be included. 

## How Has This Been Tested?

* Added tests
* Tested build locally to verify

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
  - [x] `cargo +nightly fmt --all`
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
  - [x] `cargo clippy --tests --verbose -- -D warnings`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
  - [x] `cargo test`

<!--- Thank you for contributing to git-cliff! ⛰️ -->
